### PR TITLE
Add application restart lifecycle support

### DIFF
--- a/src/core/eventflux_app_runtime.rs
+++ b/src/core/eventflux_app_runtime.rs
@@ -675,10 +675,12 @@ impl EventFluxAppRuntime {
         use crate::core::exception::EventFluxError;
 
         // 1. State validation - idempotent start
+        let restarting;
         {
             let mut state = self.state.write().unwrap();
             match *state {
                 RuntimeState::Created | RuntimeState::Failed => {
+                    restarting = false;
                     *state = RuntimeState::Starting;
                 }
                 RuntimeState::Running => {
@@ -692,15 +694,40 @@ impl EventFluxAppRuntime {
                     return Ok(());
                 }
                 RuntimeState::Stopped => {
-                    return Err(EventFluxError::app_runtime(
-                        "Cannot restart a stopped runtime".to_string(),
-                    ));
+                    restarting = true;
+                    *state = RuntimeState::Starting;
                 }
                 _ => {
                     return Err(EventFluxError::app_runtime(format!(
                         "Cannot start runtime in state: {:?}",
                         *state
                     )));
+                }
+            }
+        }
+
+        // Auto-restore on restart only — on first start (Created), the user may have
+        // already called restore_revision() manually before start()
+        if restarting {
+            if let Some(service) = self.eventflux_app_context.get_snapshot_service() {
+                if let Some(store) = &service.persistence_store {
+                    if let Some(revision) = store.get_last_revision(&self.name) {
+                        match self.restore_revision(&revision) {
+                            Ok(()) => {
+                                log::info!("Auto-restored state (revision: {})", revision)
+                            }
+                            Err(e) => {
+                                log::warn!(
+                                    "Auto-restore failed, clearing partial state and starting fresh: {}",
+                                    e
+                                );
+                                // Clear in-memory state only — preserve persisted revisions
+                                // so they remain available for debugging or manual recovery
+                                service.clear_state_holders();
+                                self.clear_select_processor_group_states();
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -861,23 +888,53 @@ impl EventFluxAppRuntime {
     }
 
     pub fn shutdown(&self) {
-        // Stop all source and sink handlers first
+        // Guard: only shutdown if Running, Starting, or Failed
+        {
+            let mut state = self.state.write().unwrap();
+            match *state {
+                RuntimeState::Running | RuntimeState::Starting | RuntimeState::Failed => {
+                    *state = RuntimeState::Stopping;
+                }
+                _ => return, // Already stopped or not started
+            }
+        }
+
+        // Deactivate triggers and stop sources to fully quiesce the pipeline
+        for tr in &self.trigger_runtimes {
+            tr.shutdown();
+        }
         self.stop_all_sources();
+
+        // Flush remaining events through the pipeline so state is stable
+        for qr in &self.query_runtimes {
+            qr.flush();
+        }
+
+        // Auto-persist after pipeline is quiesced
+        if let Some(service) = self.eventflux_app_context.get_snapshot_service() {
+            if service.persistence_store.is_some() {
+                match self.persist() {
+                    Ok(report) => {
+                        log::info!(
+                            "Auto-persisted on shutdown (revision: {})",
+                            report.revision
+                        )
+                    }
+                    Err(e) => log::warn!("Auto-persist on shutdown failed: {}", e),
+                }
+            }
+        }
+
         self.stop_all_sinks();
 
         if let Some(scheduler) = &self.scheduler {
             scheduler.shutdown();
         }
-        for tr in &self.trigger_runtimes {
-            tr.shutdown();
-        }
         for pr in &self.partition_runtimes {
             pr.shutdown();
         }
-        for qr in &self.query_runtimes {
-            qr.flush();
-        }
-        // Persisted revisions are retained after shutdown for potential restoration
+
+        *self.state.write().unwrap() = RuntimeState::Stopped;
         log::info!("EventFluxAppRuntime '{}' shutdown", self.name);
     }
 
@@ -950,6 +1007,36 @@ impl EventFluxAppRuntime {
             // No barrier configured, proceed with restoration (may have timing issues)
             service.restore_revision(revision)
         }
+    }
+
+    /// Clear all persisted and in-memory state.
+    ///
+    /// Call this between `shutdown()` and `start()` to ensure a clean restart
+    /// with no residual state from previous runs. Only works when the runtime
+    /// is in `Stopped` state.
+    pub fn clear_state(&self) {
+        {
+            let state = self.state.read().unwrap();
+            if !matches!(*state, RuntimeState::Stopped) {
+                log::warn!(
+                    "Cannot clear state while runtime '{}' is in {:?} state",
+                    self.name,
+                    *state
+                );
+                return;
+            }
+        }
+        if let Some(service) = self.eventflux_app_context.get_snapshot_service() {
+            // Clear persisted revisions
+            if let Some(store) = &service.persistence_store {
+                store.clear_all_revisions(&self.name);
+            }
+            // Reset all registered state holders (window buffers, aggregator accumulators)
+            service.clear_state_holders();
+        }
+        // Clear in-memory group states (aggregator/window per-partition state)
+        self.clear_select_processor_group_states();
+        log::info!("Cleared all state for '{}'", self.name);
     }
 
     /// Clear group states in all SelectProcessors to ensure fresh state after restoration

--- a/src/core/persistence/snapshot_service.rs
+++ b/src/core/persistence/snapshot_service.rs
@@ -158,6 +158,17 @@ impl SnapshotService {
         Ok(report)
     }
 
+    /// Reset all registered state holders to their initial (empty) values.
+    pub fn clear_state_holders(&self) {
+        let holders: Vec<_> = self.state_holders.lock().unwrap()
+            .iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+        for (id, holder) in holders {
+            holder.lock().unwrap().reset_state();
+            log::debug!("Reset state for component: {}", id);
+        }
+        *self.state.lock().unwrap() = Vec::new();
+    }
+
     /// Load the given revision from the store and set as current state.
     pub fn restore_revision(&self, revision: &str) -> Result<(), String> {
         let store = self

--- a/src/core/persistence/state_holder.rs
+++ b/src/core/persistence/state_holder.rs
@@ -272,6 +272,15 @@ pub trait StateHolder: Send + Sync {
 
         self.deserialize_state(&snapshot)
     }
+
+    /// Reset all mutable state to initial (empty) values.
+    ///
+    /// Called during `clear_state()` to discard accumulated in-memory state
+    /// (window buffers, aggregator accumulators, etc.) so the runtime can
+    /// restart fresh.
+    fn reset_state(&self) {
+        // Default: no-op. Concrete state holders should override.
+    }
 }
 
 /// State management errors

--- a/src/core/query/processor/stream/window/external_time_window_state_holder.rs
+++ b/src/core/query/processor/stream/window/external_time_window_state_holder.rs
@@ -320,6 +320,13 @@ impl StateHolder for ExternalTimeWindowStateHolder {
 
         metadata
     }
+
+    fn reset_state(&self) {
+        self.buffer.lock().unwrap().clear();
+        *self.last_checkpoint_id.lock().unwrap() = None;
+        self.change_log.lock().unwrap().clear();
+        *self.total_events_processed.lock().unwrap() = 0;
+    }
 }
 
 impl CompressibleStateHolder for ExternalTimeWindowStateHolder {

--- a/src/core/query/processor/stream/window/length_batch_window_state_holder.rs
+++ b/src/core/query/processor/stream/window/length_batch_window_state_holder.rs
@@ -565,6 +565,15 @@ impl StateHolder for LengthBatchWindowStateHolder {
 
         metadata
     }
+
+    fn reset_state(&self) {
+        self.buffer.lock().unwrap().clear();
+        self.expired.lock().unwrap().clear();
+        *self.reset_event.lock().unwrap() = None;
+        *self.last_checkpoint_id.lock().unwrap() = None;
+        self.change_log.lock().unwrap().clear();
+        *self.total_events_processed.lock().unwrap() = 0;
+    }
 }
 
 impl CompressibleStateHolder for LengthBatchWindowStateHolder {

--- a/src/core/query/processor/stream/window/length_window_state_holder.rs
+++ b/src/core/query/processor/stream/window/length_window_state_holder.rs
@@ -344,6 +344,13 @@ impl StateHolder for LengthWindowStateHolder {
 
         metadata
     }
+
+    fn reset_state(&self) {
+        self.buffer.lock().unwrap().clear();
+        *self.last_checkpoint_id.lock().unwrap() = None;
+        self.change_log.lock().unwrap().clear();
+        *self.total_events_processed.lock().unwrap() = 0;
+    }
 }
 
 impl CompressibleStateHolder for LengthWindowStateHolder {

--- a/src/core/query/processor/stream/window/mod.rs
+++ b/src/core/query/processor/stream/window/mod.rs
@@ -1794,7 +1794,7 @@ impl CronWindowProcessor {
                     expired: Arc::clone(&self.expired),
                     next: self.meta.next_processor.as_ref().map(Arc::clone),
                 };
-                let _ = sched.schedule_cron(&self.cron, Arc::new(task), None);
+                let _ = sched.schedule_cron(&self.cron, Arc::new(task), None, None);
                 *self.scheduled.lock().unwrap() = true;
             }
         }

--- a/src/core/query/processor/stream/window/session_window_state_holder.rs
+++ b/src/core/query/processor/stream/window/session_window_state_holder.rs
@@ -604,6 +604,16 @@ impl StateHolder for SessionWindowStateHolder {
 
         metadata
     }
+
+    fn reset_state(&self) {
+        let mut state = self.state.lock().unwrap();
+        state.session_map.clear();
+        state.expired_event_chunk.clear();
+        *self.last_checkpoint_id.lock().unwrap() = None;
+        self.change_log.lock().unwrap().clear();
+        *self.total_sessions_processed.lock().unwrap() = 0;
+        *self.total_events_processed.lock().unwrap() = 0;
+    }
 }
 
 impl CompressibleStateHolder for SessionWindowStateHolder {

--- a/src/core/query/processor/stream/window/time_batch_window_state_holder.rs
+++ b/src/core/query/processor/stream/window/time_batch_window_state_holder.rs
@@ -616,6 +616,16 @@ impl StateHolder for TimeBatchWindowStateHolder {
 
         metadata
     }
+
+    fn reset_state(&self) {
+        self.buffer.lock().unwrap().clear();
+        self.expired.lock().unwrap().clear();
+        *self.start_time.lock().unwrap() = None;
+        *self.reset_event.lock().unwrap() = None;
+        *self.last_checkpoint_id.lock().unwrap() = None;
+        self.change_log.lock().unwrap().clear();
+        *self.total_events_processed.lock().unwrap() = 0;
+    }
 }
 
 impl CompressibleStateHolder for TimeBatchWindowStateHolder {

--- a/src/core/query/processor/stream/window/time_window_state_holder.rs
+++ b/src/core/query/processor/stream/window/time_window_state_holder.rs
@@ -361,6 +361,14 @@ impl StateHolder for TimeWindowStateHolder {
 
         metadata
     }
+
+    fn reset_state(&self) {
+        self.buffer.lock().unwrap().clear();
+        *self.last_checkpoint_id.lock().unwrap() = None;
+        self.change_log.lock().unwrap().clear();
+        *self.total_events_processed.lock().unwrap() = 0;
+        *self.window_start_time.lock().unwrap() = None;
+    }
 }
 
 impl CompressibleStateHolder for TimeWindowStateHolder {

--- a/src/core/query/selector/attribute/aggregator/and_aggregator_state_holder.rs
+++ b/src/core/query/selector/attribute/aggregator/and_aggregator_state_holder.rs
@@ -177,6 +177,12 @@ impl StateHolder for AndAggregatorStateHolder {
         );
         metadata
     }
+
+    fn reset_state(&self) {
+        *self.true_count.lock().unwrap() = 0;
+        *self.false_count.lock().unwrap() = 0;
+        self.base.restored.store(true, std::sync::atomic::Ordering::Release);
+    }
 }
 
 impl CompressibleStateHolder for AndAggregatorStateHolder {

--- a/src/core/query/selector/attribute/aggregator/avg_aggregator_state_holder.rs
+++ b/src/core/query/selector/attribute/aggregator/avg_aggregator_state_holder.rs
@@ -203,6 +203,12 @@ impl StateHolder for AvgAggregatorStateHolder {
         }
         metadata
     }
+
+    fn reset_state(&self) {
+        *self.sum.lock().unwrap() = 0.0;
+        *self.count.lock().unwrap() = 0;
+        self.base.restored.store(true, std::sync::atomic::Ordering::Release);
+    }
 }
 
 impl CompressibleStateHolder for AvgAggregatorStateHolder {

--- a/src/core/query/selector/attribute/aggregator/count_aggregator_state_holder.rs
+++ b/src/core/query/selector/attribute/aggregator/count_aggregator_state_holder.rs
@@ -156,6 +156,11 @@ impl StateHolder for CountAggregatorStateHolder {
             .insert("current_count".to_string(), self.get_count().to_string());
         metadata
     }
+
+    fn reset_state(&self) {
+        *self.count.lock().unwrap() = 0;
+        self.base.restored.store(true, std::sync::atomic::Ordering::Release);
+    }
 }
 
 impl CompressibleStateHolder for CountAggregatorStateHolder {

--- a/src/core/query/selector/attribute/aggregator/distinctcount_aggregator_state_holder.rs
+++ b/src/core/query/selector/attribute/aggregator/distinctcount_aggregator_state_holder.rs
@@ -230,6 +230,11 @@ impl StateHolder for DistinctCountAggregatorStateHolder {
 
         metadata
     }
+
+    fn reset_state(&self) {
+        self.map.lock().unwrap().clear();
+        self.base.restored.store(true, std::sync::atomic::Ordering::Release);
+    }
 }
 
 impl CompressibleStateHolder for DistinctCountAggregatorStateHolder {

--- a/src/core/query/selector/attribute/aggregator/first_aggregator_state_holder.rs
+++ b/src/core/query/selector/attribute/aggregator/first_aggregator_state_holder.rs
@@ -160,6 +160,11 @@ impl StateHolder for FirstAggregatorStateHolder {
             .insert("value_count".to_string(), values.len().to_string());
         metadata
     }
+
+    fn reset_state(&self) {
+        self.values.lock().unwrap().clear();
+        self.base.restored.store(true, std::sync::atomic::Ordering::Release);
+    }
 }
 
 impl CompressibleStateHolder for FirstAggregatorStateHolder {

--- a/src/core/query/selector/attribute/aggregator/last_aggregator_state_holder.rs
+++ b/src/core/query/selector/attribute/aggregator/last_aggregator_state_holder.rs
@@ -137,6 +137,11 @@ impl StateHolder for LastAggregatorStateHolder {
             .insert("aggregator_type".to_string(), "last".to_string());
         metadata
     }
+
+    fn reset_state(&self) {
+        *self.last_value.lock().unwrap() = None;
+        self.base.restored.store(true, std::sync::atomic::Ordering::Release);
+    }
 }
 
 impl CompressibleStateHolder for LastAggregatorStateHolder {

--- a/src/core/query/selector/attribute/aggregator/max_aggregator_state_holder.rs
+++ b/src/core/query/selector/attribute/aggregator/max_aggregator_state_holder.rs
@@ -186,6 +186,11 @@ impl StateHolder for MaxAggregatorStateHolder {
         }
         metadata
     }
+
+    fn reset_state(&self) {
+        *self.value.lock().unwrap() = None;
+        self.base.restored.store(true, std::sync::atomic::Ordering::Release);
+    }
 }
 
 impl CompressibleStateHolder for MaxAggregatorStateHolder {

--- a/src/core/query/selector/attribute/aggregator/min_aggregator_state_holder.rs
+++ b/src/core/query/selector/attribute/aggregator/min_aggregator_state_holder.rs
@@ -186,6 +186,11 @@ impl StateHolder for MinAggregatorStateHolder {
         }
         metadata
     }
+
+    fn reset_state(&self) {
+        *self.value.lock().unwrap() = None;
+        self.base.restored.store(true, std::sync::atomic::Ordering::Release);
+    }
 }
 
 impl CompressibleStateHolder for MinAggregatorStateHolder {

--- a/src/core/query/selector/attribute/aggregator/or_aggregator_state_holder.rs
+++ b/src/core/query/selector/attribute/aggregator/or_aggregator_state_holder.rs
@@ -151,6 +151,11 @@ impl StateHolder for OrAggregatorStateHolder {
         );
         metadata
     }
+
+    fn reset_state(&self) {
+        *self.true_count.lock().unwrap() = 0;
+        self.base.restored.store(true, std::sync::atomic::Ordering::Release);
+    }
 }
 
 impl CompressibleStateHolder for OrAggregatorStateHolder {

--- a/src/core/query/selector/attribute/aggregator/stddev_aggregator_state_holder.rs
+++ b/src/core/query/selector/attribute/aggregator/stddev_aggregator_state_holder.rs
@@ -210,6 +210,14 @@ impl StateHolder for StdDevAggregatorStateHolder {
             .insert("aggregator_type".to_string(), "stddev".to_string());
         metadata
     }
+
+    fn reset_state(&self) {
+        *self.mean.lock().unwrap() = 0.0;
+        *self.m2.lock().unwrap() = 0.0;
+        *self.sum.lock().unwrap() = 0.0;
+        *self.count.lock().unwrap() = 0;
+        self.base.restored.store(true, std::sync::atomic::Ordering::Release);
+    }
 }
 
 impl CompressibleStateHolder for StdDevAggregatorStateHolder {

--- a/src/core/query/selector/attribute/aggregator/sum_aggregator_state_holder.rs
+++ b/src/core/query/selector/attribute/aggregator/sum_aggregator_state_holder.rs
@@ -204,6 +204,12 @@ impl StateHolder for SumAggregatorStateHolder {
             .insert("current_count".to_string(), self.get_count().to_string());
         metadata
     }
+
+    fn reset_state(&self) {
+        *self.sum.lock().unwrap() = 0.0;
+        *self.count.lock().unwrap() = 0;
+        self.base.restored.store(true, std::sync::atomic::Ordering::Release);
+    }
 }
 
 impl CompressibleStateHolder for SumAggregatorStateHolder {

--- a/src/core/query/selector/select_processor.rs
+++ b/src/core/query/selector/select_processor.rs
@@ -165,6 +165,11 @@ impl StateHolder for OutputRateLimiterStateHolder {
             "OutputRateLimiter".to_string(),
         )
     }
+
+    fn reset_state(&self) {
+        self.buffer.lock().unwrap().clear();
+        *self.counter.lock().unwrap() = 0;
+    }
 }
 
 impl OutputRateLimiter {

--- a/src/core/trigger/trigger_runtime.rs
+++ b/src/core/trigger/trigger_runtime.rs
@@ -7,6 +7,7 @@ use crate::core::event::value::AttributeValue;
 use crate::core::stream::stream_junction::StreamJunction;
 use crate::core::util::scheduler::{Schedulable, Scheduler};
 use crate::query_api::definition::TriggerDefinition;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
 #[derive(Debug)]
@@ -14,6 +15,10 @@ pub struct TriggerRuntime {
     pub definition: Arc<TriggerDefinition>,
     pub stream_junction: Arc<Mutex<StreamJunction>>,
     scheduler: Arc<Scheduler>,
+    started: AtomicBool,
+    /// Flag shared with the current generation's TriggerTask.
+    /// Set to false on shutdown so old periodic tasks become no-ops.
+    active_flag: Mutex<Arc<AtomicBool>>,
 }
 
 impl TriggerRuntime {
@@ -26,39 +31,63 @@ impl TriggerRuntime {
             definition,
             stream_junction,
             scheduler,
+            started: AtomicBool::new(false),
+            active_flag: Mutex::new(Arc::new(AtomicBool::new(false))),
         }
     }
 
     pub fn start(&self) {
+        // Idempotent: skip if already started
+        if self.started.swap(true, Ordering::AcqRel) {
+            return;
+        }
+
+        // Create a new active flag for this generation; old tasks see their flag as false
+        let active = Arc::new(AtomicBool::new(true));
+        *self.active_flag.lock().unwrap() = Arc::clone(&active);
+
         let task = Arc::new(TriggerTask {
             junction: Arc::clone(&self.stream_junction),
+            active: Arc::clone(&active),
         });
         if let Some(period) = self.definition.at_every {
-            self.scheduler.schedule_periodic(period, task, None);
+            self.scheduler
+                .schedule_periodic(period, task, None, Some(Arc::clone(&active)));
         } else if let Some(at) = &self.definition.at {
             if at.trim().eq_ignore_ascii_case("start") {
                 // Emit immediately
                 let now = chrono::Utc::now().timestamp_millis();
                 TriggerTask {
                     junction: Arc::clone(&self.stream_junction),
+                    active: Arc::new(AtomicBool::new(true)),
                 }
                 .on_time(now);
             } else {
-                let _ = self.scheduler.schedule_cron(at, task, None);
+                let _ =
+                    self.scheduler
+                        .schedule_cron(at, task, None, Some(Arc::clone(&active)));
             }
         }
     }
 
-    pub fn shutdown(&self) {}
+    pub fn shutdown(&self) {
+        self.started.store(false, Ordering::Release);
+        // Deactivate current generation's tasks so old periodic loops become no-ops
+        self.active_flag.lock().unwrap().store(false, Ordering::Release);
+    }
 }
 
 #[derive(Debug)]
 struct TriggerTask {
     junction: Arc<Mutex<StreamJunction>>,
+    active: Arc<AtomicBool>,
 }
 
 impl Schedulable for TriggerTask {
     fn on_time(&self, timestamp: i64) {
+        if !self.active.load(Ordering::Acquire) {
+            return;
+        }
         let ev = Event::new_with_data(timestamp, vec![AttributeValue::Long(timestamp)]);
         self.junction.lock().unwrap().send_event(ev);
     }

--- a/src/core/util/scheduler.rs
+++ b/src/core/util/scheduler.rs
@@ -24,6 +24,7 @@ use crate::core::util::executor_service::ExecutorService;
 use chrono::Utc;
 use cron::Schedule;
 use std::str::FromStr;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -62,6 +63,7 @@ impl Scheduler {
         period_ms: i64,
         target: Arc<dyn Schedulable>,
         limit: Option<usize>,
+        running: Option<Arc<AtomicBool>>,
     ) {
         self.executor.execute(move || {
             let mut next = SystemTime::now()
@@ -71,6 +73,11 @@ impl Scheduler {
                 + period_ms;
             let mut count = 0usize;
             loop {
+                if let Some(ref flag) = running {
+                    if !flag.load(Ordering::Acquire) {
+                        break;
+                    }
+                }
                 if let Some(lim) = limit {
                     if count >= lim {
                         break;
@@ -95,6 +102,7 @@ impl Scheduler {
         cron_expr: &str,
         target: Arc<dyn Schedulable>,
         limit: Option<usize>,
+        running: Option<Arc<AtomicBool>>,
     ) -> Result<(), String> {
         let schedule = Schedule::from_str(cron_expr).map_err(|e| e.to_string())?;
         self.executor.execute(move || {
@@ -104,6 +112,11 @@ impl Scheduler {
                 None => Box::new(iter),
             };
             for datetime in it {
+                if let Some(ref flag) = running {
+                    if !flag.load(Ordering::Acquire) {
+                        break;
+                    }
+                }
                 let ts = datetime.timestamp_millis();
                 let now = SystemTime::now()
                     .duration_since(UNIX_EPOCH)

--- a/tests/app_runner_start_stop.rs
+++ b/tests/app_runner_start_stop.rs
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+#[path = "common/mod.rs"]
+mod common;
+use common::AppRunner;
+use eventflux::core::event::value::AttributeValue;
+use eventflux::core::persistence::{InMemoryPersistenceStore, PersistenceStore};
+use std::sync::Arc;
+
+/// Basic start → shutdown → start → send → shutdown cycle.
+#[tokio::test]
+async fn test_start_stop_restart() {
+    let app = "\
+        CREATE STREAM In (v INT);\n\
+        CREATE STREAM Out (v INT);\n\
+        INSERT INTO Out SELECT v FROM In;\n";
+    let runner = AppRunner::new(app, "Out").await;
+    let rt = runner.runtime();
+
+    // Send an event before first shutdown
+    runner.send("In", vec![AttributeValue::Int(1)]);
+
+    // Shutdown and restart
+    rt.shutdown();
+    rt.start().expect("restart should succeed");
+
+    // Send after restart
+    runner.send("In", vec![AttributeValue::Int(2)]);
+
+    rt.shutdown();
+    let out = runner.collected.lock().unwrap().clone();
+    // Both events should have been received
+    assert!(out.contains(&vec![AttributeValue::Int(1)]));
+    assert!(out.contains(&vec![AttributeValue::Int(2)]));
+}
+
+/// Callbacks registered before first start still fire after restart.
+#[tokio::test]
+async fn test_restart_callback_preserved() {
+    let app = "\
+        CREATE STREAM In (v INT);\n\
+        CREATE STREAM Out (v INT);\n\
+        INSERT INTO Out SELECT v FROM In;\n";
+    let runner = AppRunner::new(app, "Out").await;
+    let rt = runner.runtime();
+
+    rt.shutdown();
+    rt.start().expect("restart");
+
+    runner.send("In", vec![AttributeValue::Int(42)]);
+    rt.shutdown();
+
+    let out = runner.collected.lock().unwrap().clone();
+    assert!(out.contains(&vec![AttributeValue::Int(42)]));
+}
+
+/// Multiple streams and queries work correctly after restart.
+#[tokio::test]
+async fn test_restart_with_multiple_streams() {
+    let app = "\
+        CREATE STREAM A (x INT);\n\
+        CREATE STREAM B (y INT);\n\
+        CREATE STREAM Out (z INT);\n\
+        INSERT INTO Out SELECT x as z FROM A;\n\
+        INSERT INTO Out SELECT y as z FROM B;\n";
+    let runner = AppRunner::new(app, "Out").await;
+    let rt = runner.runtime();
+
+    runner.send("A", vec![AttributeValue::Int(1)]);
+    rt.shutdown();
+    rt.start().expect("restart");
+
+    runner.send("A", vec![AttributeValue::Int(2)]);
+    runner.send("B", vec![AttributeValue::Int(3)]);
+    rt.shutdown();
+
+    let out = runner.collected.lock().unwrap().clone();
+    assert!(out.contains(&vec![AttributeValue::Int(1)]));
+    assert!(out.contains(&vec![AttributeValue::Int(2)]));
+    assert!(out.contains(&vec![AttributeValue::Int(3)]));
+}
+
+/// Calling shutdown() twice is a safe no-op, and the runtime remains restartable.
+#[tokio::test]
+async fn test_double_shutdown_is_safe() {
+    let app = "\
+        CREATE STREAM In (v INT);\n\
+        CREATE STREAM Out (v INT);\n\
+        INSERT INTO Out SELECT v FROM In;\n";
+    let runner = AppRunner::new(app, "Out").await;
+    let rt = runner.runtime();
+
+    rt.shutdown();
+    rt.shutdown(); // second call should be a no-op
+
+    // Runtime should still be usable after double shutdown
+    rt.start().expect("restart after double shutdown");
+    runner.send("In", vec![AttributeValue::Int(99)]);
+    rt.shutdown();
+
+    let out = runner.collected.lock().unwrap().clone();
+    assert!(out.contains(&vec![AttributeValue::Int(99)]));
+}
+
+/// Calling start() on a running runtime is a no-op.
+#[tokio::test]
+async fn test_start_idempotent() {
+    let app = "\
+        CREATE STREAM In (v INT);\n\
+        CREATE STREAM Out (v INT);\n\
+        INSERT INTO Out SELECT v FROM In;\n";
+    let runner = AppRunner::new(app, "Out").await;
+    let rt = runner.runtime();
+
+    // Already running — second start should be fine
+    rt.start().expect("idempotent start");
+
+    runner.send("In", vec![AttributeValue::Int(7)]);
+    rt.shutdown();
+
+    let out = runner.collected.lock().unwrap().clone();
+    assert!(out.contains(&vec![AttributeValue::Int(7)]));
+}
+
+/// With a persistence store: shutdown auto-persists, start auto-restores.
+#[tokio::test]
+async fn test_restart_with_auto_persist_restore() {
+    let store: Arc<dyn PersistenceStore> = Arc::new(InMemoryPersistenceStore::new());
+    let app = "\
+        CREATE STREAM In (v INT);\n\
+        CREATE STREAM Out (total LONG);\n\
+        INSERT INTO Out\n\
+        SELECT sum(v) as total FROM In WINDOW('length', 3);\n";
+    let runner = AppRunner::new_with_store(app, "Out", Arc::clone(&store)).await;
+    let rt = runner.runtime();
+
+    // Build up state: sum=10, window=[10]
+    runner.send("In", vec![AttributeValue::Int(10)]);
+    // sum=30, window=[10,20]
+    runner.send("In", vec![AttributeValue::Int(20)]);
+
+    // Shutdown triggers auto-persist
+    rt.shutdown();
+
+    // Verify a revision was saved
+    let rev = store.get_last_revision(&rt.name);
+    assert!(rev.is_some(), "auto-persist should have saved a revision");
+
+    // Restart triggers auto-restore
+    rt.start().expect("restart with auto-restore");
+
+    // After restore: state should be sum=30, window=[10,20]
+    // Sending 5 → sum=35, window=[10,20,5]
+    runner.send("In", vec![AttributeValue::Int(5)]);
+    rt.shutdown();
+
+    let out = runner.collected.lock().unwrap().clone();
+    let last = out.last().expect("should have output");
+    assert_eq!(last, &vec![AttributeValue::Long(35)]);
+}
+
+/// clear_state() removes persisted state so restart starts fresh.
+#[tokio::test]
+async fn test_clear_state_then_start() {
+    let store: Arc<dyn PersistenceStore> = Arc::new(InMemoryPersistenceStore::new());
+    let app = "\
+        CREATE STREAM In (v INT);\n\
+        CREATE STREAM Out (total LONG);\n\
+        INSERT INTO Out\n\
+        SELECT sum(v) as total FROM In WINDOW('length', 3);\n";
+    let runner = AppRunner::new_with_store(app, "Out", Arc::clone(&store)).await;
+    let rt = runner.runtime();
+
+    // Build up state: sum=10
+    runner.send("In", vec![AttributeValue::Int(10)]);
+
+    // Shutdown (auto-persist)
+    rt.shutdown();
+    assert!(store.get_last_revision(&rt.name).is_some());
+
+    // Clear all state, then restart
+    rt.clear_state();
+    assert!(
+        store.get_last_revision(&rt.name).is_none(),
+        "revisions should be cleared"
+    );
+
+    rt.start().expect("fresh restart");
+
+    // After clear + restart: no old aggregation state
+    // sum should start from 0: sending 5 → sum=5
+    runner.send("In", vec![AttributeValue::Int(5)]);
+    rt.shutdown();
+
+    let out = runner.collected.lock().unwrap().clone();
+    let last = out.last().expect("should have output");
+    assert_eq!(last, &vec![AttributeValue::Long(5)]);
+}

--- a/tests/scheduler.rs
+++ b/tests/scheduler.rs
@@ -23,7 +23,7 @@ fn test_periodic_scheduler() {
         count: Arc::new(Mutex::new(0)),
     };
     let count_arc = Arc::clone(&counter.count);
-    scheduler.schedule_periodic(50, Arc::new(counter), Some(3));
+    scheduler.schedule_periodic(50, Arc::new(counter), Some(3), None);
     std::thread::sleep(Duration::from_millis(200));
     assert_eq!(*count_arc.lock().unwrap(), 3);
 }
@@ -37,7 +37,7 @@ fn test_cron_scheduler() {
     };
     let count_arc = Arc::clone(&counter.count);
     scheduler
-        .schedule_cron("*/1 * * * * *", Arc::new(counter), Some(2))
+        .schedule_cron("*/1 * * * * *", Arc::new(counter), Some(2), None)
         .unwrap();
     std::thread::sleep(Duration::from_millis(2500));
     assert_eq!(*count_arc.lock().unwrap(), 2);

--- a/website/docs/architecture/state-management.md
+++ b/website/docs/architecture/state-management.md
@@ -334,6 +334,69 @@ pub fn decompress(data: &[u8]) -> Result<Vec<u8>, Error> {
 }
 ```
 
+## Automatic Persistence on Shutdown and Restart
+
+When a persistence store is configured, EventFlux automatically manages state across runtime lifecycle transitions:
+
+```mermaid
+sequenceDiagram
+    participant App
+    participant Runtime
+    participant Store as Persistence Store
+
+    App->>Runtime: start()
+    Runtime->>Store: get_last_revision()
+    Store-->>Runtime: revision (if exists)
+    Runtime->>Runtime: auto-restore state
+    Note over Runtime: Windows, aggregators restored
+
+    App->>Runtime: send events...
+    Note over Runtime: State accumulates
+
+    App->>Runtime: shutdown()
+    Runtime->>Runtime: quiesce pipeline
+    Runtime->>Store: auto-persist state
+    Note over Runtime: State = Stopped
+
+    App->>Runtime: start()
+    Runtime->>Store: get_last_revision()
+    Store-->>Runtime: latest revision
+    Runtime->>Runtime: auto-restore state
+    Note over Runtime: Continues from where it left off
+```
+
+### Shutdown Sequence
+
+On `shutdown()`, the runtime follows a carefully ordered sequence to ensure a consistent snapshot:
+
+1. **Deactivate triggers** — Prevents new timer-based events from entering the pipeline
+2. **Stop sources** — Prevents new external events from entering
+3. **Flush queries** — Drains any in-flight events through the processing pipeline
+4. **Auto-persist** — Saves a snapshot of all state holders (windows, aggregators) to the persistence store
+5. **Stop sinks and scheduler** — Cleans up remaining resources
+6. **Transition to Stopped** — Runtime is now restartable
+
+### Start Sequence (Restart)
+
+On `start()` from a `Stopped` state, the runtime:
+
+1. **Check for persisted revision** — Looks up the last saved revision from the persistence store
+2. **Auto-restore** — Deserializes all state holders back to their saved state
+3. **Start components** — Sources, sinks, triggers, and partitions are reactivated
+4. **Transition to Running** — Runtime is processing events again
+
+If auto-restore fails (e.g., corrupted data), the runtime clears in-memory state and starts fresh rather than failing to start. Persisted revisions are preserved for debugging.
+
+### Clean Restart
+
+To discard all state and start fresh, call `clear_state()` between shutdown and start:
+
+```rust
+runtime.shutdown();
+runtime.clear_state();  // Removes persisted + in-memory state
+runtime.start()?;       // Starts with zero state
+```
+
 ## Best Practices
 
 :::tip State Management

--- a/website/docs/getting-started/running.md
+++ b/website/docs/getting-started/running.md
@@ -161,7 +161,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Keep running until interrupted
     tokio::signal::ctrl_c().await?;
+
+    // Shutdown (auto-persists state if persistence is configured)
     runtime.shutdown();
+
+    // The runtime can be restarted after shutdown:
+    // runtime.start()?;        // auto-restores state
+    //
+    // Or for a clean restart with no old state:
+    // runtime.clear_state();   // clears persisted + in-memory state
+    // runtime.start()?;
 
     Ok(())
 }

--- a/website/docs/rust-api/getting-started.md
+++ b/website/docs/rust-api/getting-started.md
@@ -262,6 +262,95 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
+## Lifecycle Management
+
+EventFlux runtimes support full lifecycle control: start, shutdown, restart, and state management.
+
+### Shutdown and Restart
+
+A runtime can be restarted after shutdown. The same runtime instance transitions through `Created → Running → Stopped → Running` states:
+
+```rust
+let runtime = manager
+    .create_eventflux_app_runtime_from_string(query)
+    .await?;
+
+runtime.start()?;
+
+// Process events...
+runtime.send_event("Input", vec!["sensor-1".into(), 105.0.into()])?;
+
+// Shutdown (auto-persists state if persistence store is configured)
+runtime.shutdown();
+
+// Restart (auto-restores state if a persisted revision exists)
+runtime.start()?;
+
+// Continue processing — state (windows, aggregators) is preserved
+runtime.send_event("Input", vec!["sensor-2".into(), 110.0.into()])?;
+
+runtime.shutdown();
+```
+
+Key behaviors:
+- **`shutdown()`** is idempotent — calling it twice is safe (second call is a no-op)
+- **`start()`** is idempotent — calling it on a running runtime is a no-op
+- Callbacks registered before the first start are preserved across restarts
+
+### Auto-Persist and Auto-Restore
+
+When a persistence store is configured, the runtime automatically:
+- **Persists** all state (window buffers, aggregator accumulators) on `shutdown()`
+- **Restores** state from the last saved revision on `start()`
+
+```rust
+use eventflux::core::persistence::{InMemoryPersistenceStore, PersistenceStore};
+
+// Configure persistence store on the manager
+let store: Arc<dyn PersistenceStore> = Arc::new(InMemoryPersistenceStore::new());
+manager.set_persistence_store(Arc::clone(&store));
+
+let runtime = manager
+    .create_eventflux_app_runtime_from_string(query)
+    .await?;
+
+runtime.start()?;
+
+// Send events — aggregation state accumulates
+runtime.send_event("Input", vec![10.into()])?;
+runtime.send_event("Input", vec![20.into()])?;
+
+// Shutdown auto-persists: sum=30, window=[10, 20]
+runtime.shutdown();
+
+// Restart auto-restores: state is back to sum=30, window=[10, 20]
+runtime.start()?;
+
+// Next event builds on restored state
+runtime.send_event("Input", vec![5.into()])?;
+// Output: sum=35, window=[10, 20, 5]
+
+runtime.shutdown();
+```
+
+### Clear State
+
+Use `clear_state()` between `shutdown()` and `start()` to discard all accumulated state and start fresh:
+
+```rust
+runtime.shutdown();
+
+// Clear all persisted revisions and in-memory state
+runtime.clear_state();
+
+// Restart with clean state — no old aggregation values
+runtime.start()?;
+```
+
+:::note
+`clear_state()` only works when the runtime is in the `Stopped` state. It removes both persisted revisions from the store and in-memory state (window buffers, aggregator accumulators, per-partition group states).
+:::
+
 ## Next Steps
 
 - [Configuration](/docs/rust-api/configuration) - Customize runtime behavior


### PR DESCRIPTION
## Summary

- Enable `start() → shutdown() → start()` runtime lifecycle cycles (Siddhi `StartStopTestCase` parity)
- Auto-persist state on shutdown and auto-restore on start when a persistence store is configured
- Add `clear_state()` for discarding all state before a clean restart
- Add `reset_state()` to StateHolder trait with implementations across all 18 state holders
- Add generational cancellation flags to TriggerRuntime for idempotent start/shutdown
- Add `running` flag parameter to Scheduler for graceful thread termination
- Update website documentation (lifecycle management, state management architecture)

## Test plan

- [x] `cargo test --test app_runner_start_stop` — 7 new tests covering restart, callbacks, multi-stream, double-shutdown, idempotent start, auto-persist/restore, and clear_state
- [x] `cargo test --test scheduler` — Updated scheduler tests pass
- [x] `cargo test` — Full test suite passes (0 failures)
- [x] `cargo clippy` — No warnings