### PR TITLE
Integrate code quality tooling and fix warnings

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,6 +21,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   # Disable incremental compilation to save disk space
@@ -29,8 +32,8 @@ env:
   RUSTFLAGS: "-C debuginfo=0"
 
 jobs:
-  build:
-
+  ci:
+    name: Quality, Build & Test
     runs-on: ubuntu-latest
 
     services:
@@ -45,7 +48,7 @@ jobs:
           - 6379:6379
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       with:
         submodules: recursive
 
@@ -57,20 +60,44 @@ jobs:
         df -h
 
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7  # stable
       with:
         toolchain: 1.85
+        components: rustfmt, clippy
 
     - name: Cache cargo registry and target
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
       with:
         path: |
           ~/.cargo/registry
           ~/.cargo/git
           target
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('src/**') }}
         restore-keys: |
+          ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-
           ${{ runner.os }}-cargo-
+
+    - name: Check formatting
+      run: cargo fmt --all -- --check
+
+    - name: Run clippy
+      # Note: Not using --all-features because cloud-native features (kubernetes, consul,
+      # etcd, vault) require external system dependencies not available in CI.
+      run: cargo clippy --all-targets -- -D warnings
+
+    - name: Check typos
+      uses: crate-ci/typos@631208b7aac2daa8b707f55e7331f9112b0e062d  # v1.44.0
+
+    - name: Install cargo-machete and cargo-sort
+      uses: taiki-e/install-action@cbb1dcaa26e1459e2876c39f61c1e22a1258aac5  # v2
+      with:
+        tool: cargo-machete,cargo-sort
+
+    - name: Check unused dependencies
+      run: cargo machete
+
+    - name: Check dependency sorting
+      run: cargo sort --workspace --check
 
     - name: Run tests
       run: cargo test --verbose

--- a/.gitignore
+++ b/.gitignore
@@ -147,6 +147,9 @@ website/.cache-loader/
 website/.npm/
 research/
 
+# Feature development scratchpads (may contain proprietary references)
+feat/
+
 # LLM instruction files
 GEMINI.md
 CLAUDE.md

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,41 @@
+# Pre-commit hooks for EventFlux Engine
+# Install: cargo install prek && prek install
+# Run all: prek run --all-files
+
+repos:
+  - repo: local
+    hooks:
+      - id: cargo-fmt
+        name: cargo fmt
+        entry: cargo fmt --all -- --check
+        language: system
+        types: [rust]
+        pass_filenames: false
+
+      - id: cargo-clippy
+        name: cargo clippy
+        entry: cargo clippy --all-targets -- -D warnings
+        language: system
+        types: [rust]
+        pass_filenames: false
+
+      - id: typos
+        name: typos
+        entry: typos
+        language: system
+        types: [file]
+        pass_filenames: false
+
+      - id: cargo-machete
+        name: cargo machete
+        entry: cargo machete
+        language: system
+        types: [rust]
+        pass_filenames: false
+
+      - id: cargo-sort
+        name: cargo sort
+        entry: cargo sort --workspace --check
+        language: system
+        types: [toml]
+        pass_filenames: false

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,27 @@
+[files]
+extend-exclude = [
+    "vendor/",
+    "references/",
+    "target/",
+    "studio/webview/dist/",
+    "*.lock",
+]
+
+[default.extend-identifiers]
+# SQL keyword plurals used in comments (WHENs, WINDOWs)
+WHENs = "WHENs"
+WINDOWs = "WINDOWs"
+
+[default.extend-words]
+# HashiCorp proper noun (substring match)
+Hashi = "Hashi"
+
+# Substring in test assertions (e.g., SUBSTRING('hello', 1, 3) = 'Hel')
+Hel = "Hel"
+hel = "hel"
+
+# Part of filename app_runner_event_ser.rs
+ser = "ser"
+
+# IIF is a valid SQL function name
+IIF = "IIF"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,127 @@
+# Contributing to EventFlux Engine
+
+## Issue First
+
+Every new PR that introduces new functionality must link to an approved issue.
+PRs without one may be closed at the maintainer's discretion.
+
+1. Create an issue or comment under an existing one
+2. Wait for maintainer approval (`good-first-issue` label or comment)
+3. Then code
+
+## Size Limits
+
+For new contributors, keep PRs under 500 lines of code unless explicitly approved by a maintainer under the linked issue.
+
+## High-Risk Areas
+
+These require design discussion in the issue before coding:
+
+- **SQL Parser** — streaming extensions, EventFluxQL grammar
+- **Window Processors** — event buffering, expiry, state
+- **State Management** — checkpointing, recovery, WAL
+- **Distributed Processing** — cluster coordination, transport
+- **Event Pipeline** — crossbeam queues, backpressure, object pools
+- **Expression Executors** — type coercion, evaluation logic
+
+## PR Requirements
+
+### Run It Locally
+
+**If you can't run it, you can't submit it.**
+
+Authors of PRs must run the code locally. "Relying on CI" is not acceptable.
+
+### Single Purpose
+
+One PR = one thing. Bug fix, refactor, feature — separate PRs. Mixed PRs will be closed.
+
+### Quality Checks
+
+All checks must pass before submitting:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets -- -D warnings
+typos
+cargo machete
+cargo sort --workspace --check
+cargo test
+```
+
+To auto-fix formatting: `cargo fmt --all`
+
+To auto-fix typos: `typos --write-changes`
+
+### Typos
+
+We use [typos](https://github.com/crate-ci/typos) for spell checking:
+
+```bash
+cargo install typos-cli --locked
+typos
+```
+
+If a word is a valid domain term (e.g., SQL keywords, proper nouns), add an exception in `.typos.toml`.
+
+### Pre-commit Hooks
+
+We use [prek](https://github.com/j178/prek) to run quality checks before each commit:
+
+```bash
+cargo install prek
+prek install
+```
+
+This installs git hooks that automatically run fmt, clippy, typos, machete, and sort checks on every commit. To run all hooks manually:
+
+```bash
+prek run --all-files
+```
+
+> **Note**: `prek` is optional for local development. CI runs the same checks independently. The `.pre-commit-config.yaml` is also compatible with standard [pre-commit](https://pre-commit.com/) if you prefer that tool.
+
+## Code Style
+
+### Comments: WHY, Not WHAT
+
+```rust
+// Bad: Increment counter
+counter += 1;
+
+// Good: Offset by 1 because stream event indices are 0-based but IDs are 1-based
+counter += 1;
+```
+
+Don't comment obvious code. Do explain non-obvious decisions, invariants, and constraints.
+
+### Commit Messages
+
+- Start with a capital letter
+- Use imperative mood ("Add feature" not "Added feature")
+- Keep under 60 characters
+- Do not mention AI assistance
+
+**Good examples:**
+
+```
+Add length batch window processor
+Fix float literal parsing in WINDOW clause
+Optimize event pipeline with lock-free queues
+Update Redis state backend configuration
+```
+
+## Close Policy
+
+PRs may be closed if:
+
+- No approved issue or no approval from a maintainer
+- Code not run and tested locally
+- Mixed purposes or purposes not clear
+- Can't answer questions about the change
+- Inactivity for longer than 7 days
+
+## Questions?
+
+- [GitHub Issues](https://github.com/eventflux-io/eventflux/issues)
+- [GitHub Discussions](https://github.com/eventflux-io/eventflux/discussions)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,6 +455,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "backon"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
+dependencies = [
+ "fastrand 2.3.0",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -973,9 +982,9 @@ dependencies = [
 
 [[package]]
 name = "deadpool-redis"
-version = "0.15.1"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff315fab2a7a42132352909afc81140d06b8bbfd1414b098ce278e3f95dd1b9"
+checksum = "bfae6799b68a735270e4344ee3e834365f707c72da09c9a8bb89b45cc3351395"
 dependencies = [
  "deadpool",
  "redis",
@@ -1984,6 +1993,15 @@ name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -3169,24 +3187,26 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "0.25.4"
+version = "0.27.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0d7a6955c7511f60f3ba9e86c6d02b3c3f144f8c24b288d1f4e18074ab8bbec"
+checksum = "09d8f99a4090c89cc489a94833c901ead69bfbf3877b4867d5482e321ee875bc"
 dependencies = [
  "arc-swap",
  "async-trait",
+ "backon",
  "bytes",
  "combine",
  "futures",
  "futures-util",
+ "itertools 0.13.0",
  "itoa",
+ "num-bigint",
  "percent-encoding",
  "pin-project-lite",
  "ryu",
  "sha1_smol",
  "socket2 0.5.10",
  "tokio",
- "tokio-retry",
  "tokio-util",
  "url",
 ]
@@ -4143,17 +4163,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
- "tokio",
-]
-
-[[package]]
-name = "tokio-retry"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
-dependencies = [
- "pin-project",
- "rand 0.8.5",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,75 +9,11 @@ homepage = "https://eventflux.io"
 documentation = "https://eventflux.io/docs"
 build = "build.rs"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]
-regex = "1"
-uuid = { version = "1", features = ["v4"] }
-rand = "0.8"
-crossbeam-channel = "0.5"
-crossbeam = "0.8"
-crossbeam-queue = "0.3"
-crossbeam-utils = "0.8"
-chrono = { version = "0.4", features = ["serde"] }
-cron = "0.11"
-bincode = "1.3"
-serde = { version = "1", features = ["derive"] }
-serde_json = { version = "1", features = ["preserve_order"] }
-rayon = "1"
-num_cpus = "1"
-once_cell = "1"
-# Using EventFlux fork with streaming SQL extensions
-sqlparser = { path = "vendor/datafusion-sqlparser-rs" }
-rusqlite = { version = "0.29", features = ["bundled"] }
-libloading = "0.8"
-clap = { version = "4", features = ["derive"] }
-thiserror = "1.0"
-lz4 = "1.24"
-snap = "1.1"
-zstd = "0.13"
-thread_local = "1.1"
-tokio = { version = "1", features = ["full"] }
-async-trait = "0.1"
-tonic = { version = "0.11", features = ["tls"] }
-prost = "0.12"
-tower = "0.4"
-futures = "0.3"
-tokio-stream = "0.1"
-redis = { version = "0.25", features = ["aio", "tokio-comp", "connection-manager"] }
-deadpool-redis = "0.15"
-lapin = "2.3"
-log = "0.4"
-env_logger = "0.11"
-tokio-tungstenite = { version = "0.24", features = ["native-tls"] }
-tungstenite = "0.24"
-dashmap = "6.0"
-urlencoding = "2.1"
-
-# Configuration management dependencies
-serde_yaml = "0.9"
-toml = "0.8"
-dirs = "5.0"
-etcd-rs = { version = "1.0", optional = true }
-consul = { version = "0.4", optional = true }
-kube = { version = "0.87", features = ["runtime", "derive"], optional = true }
-k8s-openapi = { version = "0.20", features = ["v1_28"], optional = true }
-vault = { version = "10.1", optional = true }
-base64 = { version = "0.22", optional = true }
-
-[build-dependencies]
-tonic-build = "0.11"
-
-[dev-dependencies]
-tempfile = "3"
-custom_dyn_ext = { path = "tests/custom_dyn_ext" }
-serial_test = "3.0"
-tokio = { version = "1", features = ["full", "test-util"] }
-criterion = { version = "0.5", features = ["html_reports"] }
-
-[[bench]]
-name = "lock_contention_bench"
-harness = false
+[package.metadata.cargo-machete]
+# consul, etcd-rs, vault: feature-gated optional deps
+# tokio-stream: used by tonic-generated gRPC code (codegen import)
+# tower: transitive dep required by tonic runtime
+ignored = ["consul", "etcd-rs", "tokio-stream", "tower", "vault"]
 
 [features]
 default = []
@@ -87,4 +23,74 @@ consul = ["dep:consul"]
 etcd = ["etcd-rs"]
 vault = ["dep:vault"]
 cloud-native = ["kubernetes", "consul", "etcd", "vault"]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+async-trait = "0.1"
+base64 = { version = "0.22", optional = true }
+bincode = "1.3"
+chrono = { version = "0.4", features = ["serde"] }
+clap = { version = "4", features = ["derive"] }
+consul = { version = "0.4", optional = true }
+cron = "0.11"
+crossbeam = "0.8"
+crossbeam-channel = "0.5"
+crossbeam-queue = "0.3"
+crossbeam-utils = "0.8"
+dashmap = "6.0"
+deadpool-redis = "0.18"
+dirs = "5.0"
+env_logger = "0.11"
+etcd-rs = { version = "1.0", optional = true }
+futures = "0.3"
+k8s-openapi = { version = "0.20", features = ["v1_28"], optional = true }
+kube = { version = "0.87", features = ["runtime", "derive"], optional = true }
+lapin = "2.3"
+libloading = "0.8"
+log = "0.4"
+lz4 = "1.24"
+num_cpus = "1"
+once_cell = "1"
+prost = "0.12"
+rand = "0.8"
+rayon = "1"
+redis = { version = "0.27", features = ["aio", "tokio-comp", "connection-manager"] }
+regex = "1"
+rusqlite = { version = "0.29", features = ["bundled"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = { version = "1", features = ["preserve_order"] }
+
+# Configuration management dependencies
+serde_yaml = "0.9"
+snap = "1.1"
+# Using EventFlux fork with streaming SQL extensions
+sqlparser = { path = "vendor/datafusion-sqlparser-rs" }
+thiserror = "1.0"
+thread_local = "1.1"
+tokio = { version = "1", features = ["full"] }
+tokio-stream = "0.1"
+tokio-tungstenite = { version = "0.24", features = ["native-tls"] }
+toml = "0.8"
+tonic = { version = "0.11", features = ["tls"] }
+tower = "0.4"
+tungstenite = "0.24"
+urlencoding = "2.1"
+uuid = { version = "1", features = ["v4"] }
+vault = { version = "10.1", optional = true }
+zstd = "0.13"
+
+[build-dependencies]
+tonic-build = "0.11"
+
+[dev-dependencies]
+criterion = { version = "0.5", features = ["html_reports"] }
+custom_dyn_ext = { path = "tests/custom_dyn_ext" }
+serial_test = "3.0"
+tempfile = "3"
+tokio = { version = "1", features = ["full", "test-util"] }
+
+[[bench]]
+name = "lock_contention_bench"
+harness = false
 

--- a/DEV_GUIDE.md
+++ b/DEV_GUIDE.md
@@ -400,16 +400,29 @@ See [docs/writing_extensions.md](docs/writing_extensions.md) for complete guide.
 
 ## Contributing
 
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full contribution guide.
+
 ### Development Setup
 
 1. Fork the repository
 2. Clone your fork
-3. Create a feature branch
-4. Make changes
-5. Run tests: `cargo test`
-6. Format code: `cargo fmt`
-7. Run linter: `cargo clippy`
-8. Submit pull request
+3. Install pre-commit hooks:
+   ```bash
+   cargo install prek
+   prek install
+   ```
+4. Create a feature branch
+5. Make changes
+6. Run quality checks:
+   ```bash
+   cargo fmt --all -- --check
+   cargo clippy --all-targets -- -D warnings
+   typos
+   cargo machete
+   cargo sort --workspace --check
+   cargo test
+   ```
+7. Submit pull request
 
 ### Code Style
 

--- a/benches/lock_contention_bench.rs
+++ b/benches/lock_contention_bench.rs
@@ -156,7 +156,7 @@ fn bench_subscriber_lock_contention(c: &mut Criterion) {
                             for i in 0..2500 {
                                 let event = Event::new_with_data(
                                     i as i64,
-                                    vec![AttributeValue::Int((thread_id * 1000 + i) as i32)],
+                                    vec![AttributeValue::Int(thread_id * 1000 + i)],
                                 );
                                 // Use send_event and handle backpressure gracefully
                                 let _ = junction_clone.lock().unwrap().send_event(event);
@@ -199,8 +199,7 @@ fn bench_single_threaded_baseline(c: &mut Criterion) {
                 b.iter(|| {
                     // Send 10K events from single thread
                     for i in 0..10000 {
-                        let event =
-                            Event::new_with_data(i as i64, vec![AttributeValue::Int(i as i32)]);
+                        let event = Event::new_with_data(i as i64, vec![AttributeValue::Int(i)]);
                         let _ = black_box(junction.lock().unwrap().send_event(event));
                     }
                 });

--- a/src/bin/run_eventflux.rs
+++ b/src/bin/run_eventflux.rs
@@ -66,11 +66,7 @@ fn init_persistence_store(
 
     match persistence_config.backend_type {
         PersistenceBackendType::File => {
-            let path = persistence_config
-                .path
-                .as_ref()
-                .map(|s| s.as_str())
-                .unwrap_or("./snapshots");
+            let path = persistence_config.path.as_deref().unwrap_or("./snapshots");
 
             match FilePersistenceStore::new(path) {
                 Ok(s) => {
@@ -86,8 +82,7 @@ fn init_persistence_store(
         PersistenceBackendType::Sqlite => {
             let path = persistence_config
                 .path
-                .as_ref()
-                .map(|s| s.as_str())
+                .as_deref()
                 .unwrap_or("./eventflux.db");
 
             match SqlitePersistenceStore::new(path) {
@@ -104,8 +99,7 @@ fn init_persistence_store(
         PersistenceBackendType::Redis => {
             let url = persistence_config
                 .url
-                .as_ref()
-                .map(|s| s.as_str())
+                .as_deref()
                 .unwrap_or("redis://localhost:6379");
 
             eprintln!(

--- a/src/core/aggregation/incremental_executor.rs
+++ b/src/core/aggregation/incremental_executor.rs
@@ -78,7 +78,12 @@ impl IncrementalExecutor {
                     out[i] = v.clone();
                 }
             }
-            self.table.insert(&values);
+            if let Err(e) = self.table.insert(&values) {
+                log::error!("Failed to insert aggregation into table: {}", e);
+                // Best-effort persistence: downstream processing continues so the
+                // event pipeline is not blocked by a table write failure.
+                // TODO: Route to error handler / DLQ when error infrastructure is wired.
+            }
             if let Some(ref next) = self.next {
                 next.execute(&ev);
             }

--- a/src/core/config/eventflux_context.rs
+++ b/src/core/config/eventflux_context.rs
@@ -97,7 +97,7 @@ pub struct EventFluxContext {
     default_junction_async: bool,
 
     // Actual fields for extensions and data sources
-    /// Stores factories for User-Defined Scalar Functions. Key: "namespace:name" or "name", Value: clonable factory instance.
+    /// Stores factories for User-Defined Scalar Functions. Key: "namespace:name" or "name", Value: cloneable factory instance.
     scalar_function_factories: Arc<RwLock<HashMap<String, Box<dyn ScalarFunctionExecutor>>>>,
     /// Window processor factories
     window_factories:
@@ -455,11 +455,17 @@ impl EventFluxContext {
         self.add_window_factory("session".to_string(), Box::new(SessionWindowFactory));
         self.add_window_factory("sort".to_string(), Box::new(SortWindowFactory));
         self.add_window_factory("unique".to_string(), Box::new(UniqueWindowFactory));
-        self.add_window_factory("firstUnique".to_string(), Box::new(FirstUniqueWindowFactory));
+        self.add_window_factory(
+            "firstUnique".to_string(),
+            Box::new(FirstUniqueWindowFactory),
+        );
         self.add_window_factory("delay".to_string(), Box::new(DelayWindowFactory));
         self.add_window_factory("expression".to_string(), Box::new(ExpressionWindowFactory));
         self.add_window_factory("frequent".to_string(), Box::new(FrequentWindowFactory));
-        self.add_window_factory("lossyFrequent".to_string(), Box::new(LossyFrequentWindowFactory));
+        self.add_window_factory(
+            "lossyFrequent".to_string(),
+            Box::new(LossyFrequentWindowFactory),
+        );
 
         self.add_attribute_aggregator_factory(
             "sum".to_string(),

--- a/src/core/config/loader.rs
+++ b/src/core/config/loader.rs
@@ -132,7 +132,7 @@ impl YamlConfigLoader {
     /// Load configuration from a specific file
     pub async fn load_file<P: AsRef<Path>>(&self, path: P) -> ConfigResult<EventFluxConfig> {
         let path = path.as_ref();
-        let content = fs::read_to_string(path).map_err(|e| ConfigError::IoError(e))?;
+        let content = fs::read_to_string(path).map_err(ConfigError::IoError)?;
 
         self.parse_yaml_content(&content, path.to_string_lossy().as_ref())
     }

--- a/src/core/config/manager.rs
+++ b/src/core/config/manager.rs
@@ -134,6 +134,7 @@ impl ConfigManager {
     }
 
     /// Check if running in Kubernetes environment
+    #[allow(dead_code)]
     fn is_kubernetes_environment(&self) -> bool {
         std::env::var("KUBERNETES_SERVICE_HOST").is_ok()
     }
@@ -598,6 +599,6 @@ eventflux:
 
         // Should be able to load even with invalid config (when validation is off)
         let config = manager.load_unified_config().await.unwrap();
-        assert!(config.api_version.len() > 0);
+        assert!(!config.api_version.is_empty());
     }
 }

--- a/src/core/config/monitoring.rs
+++ b/src/core/config/monitoring.rs
@@ -1149,6 +1149,7 @@ impl EndpointConfig {
     }
 
     /// Kubernetes configuration
+    #[allow(clippy::needless_update)]
     pub fn kubernetes() -> Self {
         Self {
             health_endpoint: "/healthz".to_string(), // K8s standard

--- a/src/core/config/override_utils.rs
+++ b/src/core/config/override_utils.rs
@@ -257,6 +257,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::approx_constant)]
     fn test_parse_override_float() {
         let (_, value) = parse_override("ratio=3.14").unwrap();
         if let Value::Number(n) = value {

--- a/src/core/config/processor_config_reader.rs
+++ b/src/core/config/processor_config_reader.rs
@@ -158,12 +158,10 @@ impl ProcessorConfigReader {
     fn lookup_window_config(&self, window_type: &str, key: &str) -> Option<ConfigValue> {
         // First check application-specific window configuration
         if let Some(ref app_config) = self.app_config {
-            if let Some(definition_config) = app_config.definitions.get(window_type) {
-                if let crate::core::config::DefinitionConfig::Window(window_config) =
-                    definition_config
-                {
-                    return self.extract_config_value_from_yaml(&window_config.parameters, key);
-                }
+            if let Some(crate::core::config::DefinitionConfig::Window(window_config)) =
+                app_config.definitions.get(window_type)
+            {
+                return self.extract_config_value_from_yaml(&window_config.parameters, key);
             }
         }
 
@@ -205,13 +203,12 @@ impl ProcessorConfigReader {
     fn lookup_stream_config(&self, processor_type: &str, key: &str) -> Option<ConfigValue> {
         // First check application-specific stream configuration
         if let Some(ref app_config) = self.app_config {
-            if let Some(definition_config) = app_config.definitions.get(processor_type) {
-                if let crate::core::config::DefinitionConfig::Stream(_stream_config) =
-                    definition_config
-                {
-                    // For now, we'll implement simple stream config extraction later
-                    // TODO: Implement stream-specific configuration extraction
-                }
+            if let Some(crate::core::config::DefinitionConfig::Stream(_stream_config)) =
+                app_config.definitions.get(processor_type)
+            {
+                // TODO: Extract @source/@sink properties from the unified
+                // ApplicationConfig and map them to processor properties.
+                // Without this, YAML-based stream configuration is ignored at runtime.
             }
         }
 
@@ -259,6 +256,7 @@ impl ProcessorConfigReader {
     }
 
     /// Extract configuration value from parameter map
+    #[allow(dead_code)]
     fn extract_config_value(
         &self,
         parameters: &Option<std::collections::HashMap<String, String>>,
@@ -290,7 +288,7 @@ impl ProcessorConfigReader {
         key: &str,
     ) -> Option<ConfigValue> {
         if let serde_yaml::Value::Mapping(map) = yaml_value {
-            if let Some(value) = map.get(&serde_yaml::Value::String(key.to_string())) {
+            if let Some(value) = map.get(serde_yaml::Value::String(key.to_string())) {
                 match value {
                     serde_yaml::Value::Number(num) => {
                         if let Some(int_val) = num.as_i64() {
@@ -421,6 +419,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::approx_constant)]
     fn test_config_value_conversions() {
         let int_val = ConfigValue::Integer(42);
         assert_eq!(int_val.as_integer(), Some(42));

--- a/src/core/config/resolver.rs
+++ b/src/core/config/resolver.rs
@@ -367,7 +367,7 @@ mod tests {
 
         env::set_var("EVENTFLUX_RUNTIME_MODE", "distributed");
 
-        let mut config = EventFluxConfig::default();
+        let config = EventFluxConfig::default();
         // This is a mock test - in real usage, the config would have variable placeholders
         // For now, just verify the function runs without error
         let resolved = resolver.resolve_all(config).unwrap();

--- a/src/core/config/security.rs
+++ b/src/core/config/security.rs
@@ -347,6 +347,7 @@ impl SecretProvider for KubernetesSecretProvider {
 
 /// External secret provider interface for HashiCorp Vault, AWS Secrets Manager, etc.
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 pub struct ExternalSecretProvider {
     /// Provider name
     name: String,

--- a/src/core/config/stream_config.rs
+++ b/src/core/config/stream_config.rs
@@ -47,6 +47,7 @@
 //! ```
 
 use std::collections::HashMap;
+use std::str::FromStr;
 
 /// Property source identifier with priority ordering
 ///
@@ -229,9 +230,11 @@ pub enum StreamType {
     Internal,
 }
 
-impl StreamType {
+impl std::str::FromStr for StreamType {
+    type Err = String;
+
     /// Parse stream type from string (case-insensitive)
-    pub fn from_str(s: &str) -> Result<Self, String> {
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
             "source" => Ok(StreamType::Source),
             "sink" => Ok(StreamType::Sink),
@@ -242,7 +245,9 @@ impl StreamType {
             )),
         }
     }
+}
 
+impl StreamType {
     /// Convert stream type to string representation
     #[inline]
     pub const fn as_str(&self) -> &'static str {

--- a/src/core/config/types/application_config.rs
+++ b/src/core/config/types/application_config.rs
@@ -25,7 +25,7 @@ use std::collections::HashMap;
 use std::time::Duration;
 
 /// Application-specific configuration
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
 pub struct ApplicationConfig {
     /// Per-stream configuration (input/output streams with sources/sinks)
     #[serde(default)]
@@ -52,22 +52,10 @@ pub struct ApplicationConfig {
     pub error_handling: Option<ErrorHandlingConfig>,
 }
 
-impl Default for ApplicationConfig {
-    fn default() -> Self {
-        Self {
-            streams: HashMap::new(),
-            definitions: HashMap::new(),
-            queries: HashMap::new(),
-            persistence: None,
-            monitoring: None,
-            error_handling: None,
-        }
-    }
-}
-
 /// Configuration for individual definitions (streams, tables, windows, etc.)
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type", rename_all = "lowercase")]
+#[allow(clippy::large_enum_variant)]
 pub enum DefinitionConfig {
     /// Stream definition configuration
     Stream(StreamConfig),

--- a/src/core/config/types/distributed_config.rs
+++ b/src/core/config/types/distributed_config.rs
@@ -25,7 +25,7 @@ use std::collections::HashMap;
 use std::time::Duration;
 
 /// Distributed processing configuration
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
 pub struct DistributedConfig {
     /// Node configuration
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -47,19 +47,6 @@ pub struct DistributedConfig {
     /// Message broker configuration
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message_broker: Option<MessageBrokerConfig>,
-}
-
-impl Default for DistributedConfig {
-    fn default() -> Self {
-        Self {
-            node: None,
-            cluster: None,
-            transport: TransportConfig::default(),
-            state_backend: StateBackendConfig::default(),
-            coordination: CoordinationConfig::default(),
-            message_broker: None,
-        }
-    }
 }
 
 impl DistributedConfig {

--- a/src/core/config/types/eventflux_config.rs
+++ b/src/core/config/types/eventflux_config.rs
@@ -124,19 +124,19 @@ impl EventFluxConfig {
 
     /// Check if configuration is valid for single-node mode
     pub fn is_single_node_mode(&self) -> bool {
-        match self.eventflux.runtime.mode {
-            super::global_config::RuntimeMode::SingleNode => true,
-            _ => false,
-        }
+        matches!(
+            self.eventflux.runtime.mode,
+            super::global_config::RuntimeMode::SingleNode
+        )
     }
 
     /// Check if configuration is for distributed mode
     pub fn is_distributed_mode(&self) -> bool {
-        match self.eventflux.runtime.mode {
+        matches!(
+            self.eventflux.runtime.mode,
             super::global_config::RuntimeMode::Distributed
-            | super::global_config::RuntimeMode::Hybrid => true,
-            _ => false,
-        }
+                | super::global_config::RuntimeMode::Hybrid
+        )
     }
 
     /// Get the effective environment name
@@ -221,7 +221,7 @@ impl EventFluxConfig {
         }
 
         // Validate application names are not empty
-        for (name, _) in &self.applications {
+        for name in self.applications.keys() {
             if name.is_empty() {
                 errors.push("Application name cannot be empty".to_string());
             }

--- a/src/core/config/types/global_config.rs
+++ b/src/core/config/types/global_config.rs
@@ -24,7 +24,7 @@ use serde::{Deserialize, Serialize};
 use std::time::Duration;
 
 /// Global EventFlux runtime configuration
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
 pub struct EventFluxGlobalConfig {
     /// Application configuration (name, async mode, etc.)
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -56,21 +56,6 @@ pub struct EventFluxGlobalConfig {
     /// Extensions configuration
     #[serde(skip_serializing_if = "Option::is_none")]
     pub extensions: Option<ExtensionsConfig>,
-}
-
-impl Default for EventFluxGlobalConfig {
-    fn default() -> Self {
-        Self {
-            application: None,
-            runtime: RuntimeConfig::default(),
-            persistence: None,
-            distributed: None,
-            security: None,
-            observability: None,
-            monitoring: None,
-            extensions: None,
-        }
-    }
 }
 
 impl EventFluxGlobalConfig {
@@ -174,7 +159,7 @@ impl EventFluxGlobalConfig {
 ///
 /// Configures application-wide settings like application name and default async mode.
 /// Used to replace `@app` annotations in the old EventFluxQL syntax.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
 pub struct ApplicationGlobalConfig {
     /// Application name used for runtime identification and persistence
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -183,15 +168,6 @@ pub struct ApplicationGlobalConfig {
     /// Default async mode for all streams (unless overridden by stream-level config)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub async_default: Option<bool>,
-}
-
-impl Default for ApplicationGlobalConfig {
-    fn default() -> Self {
-        Self {
-            name: None,
-            async_default: None,
-        }
-    }
 }
 
 impl ApplicationGlobalConfig {

--- a/src/core/config/types/metadata.rs
+++ b/src/core/config/types/metadata.rs
@@ -24,7 +24,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 /// Configuration metadata following Kubernetes API conventions
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
 pub struct ConfigMetadata {
     /// Name of the configuration
     pub name: Option<String>,
@@ -53,21 +53,6 @@ pub struct ConfigMetadata {
     /// Last update timestamp (ISO 8601)
     #[serde(rename = "updatedAt", skip_serializing_if = "Option::is_none")]
     pub updated_at: Option<String>,
-}
-
-impl Default for ConfigMetadata {
-    fn default() -> Self {
-        Self {
-            name: None,
-            namespace: None,
-            version: None,
-            environment: None,
-            labels: HashMap::new(),
-            annotations: HashMap::new(),
-            created_at: None,
-            updated_at: None,
-        }
-    }
 }
 
 impl ConfigMetadata {
@@ -129,7 +114,7 @@ impl ConfigMetadata {
     pub fn matches_labels(&self, selectors: &HashMap<String, String>) -> bool {
         selectors
             .iter()
-            .all(|(key, value)| self.labels.get(key).map_or(false, |v| v == value))
+            .all(|(key, value)| self.labels.get(key) == Some(value))
     }
 
     /// Generate a unique identifier for this configuration

--- a/src/core/config/types/mod.rs
+++ b/src/core/config/types/mod.rs
@@ -176,7 +176,7 @@ mod tests {
         use serde_json;
 
         let duration = Duration::from_secs(3600);
-        let serialized = serde_json::to_string(&duration).unwrap();
+        let _serialized = serde_json::to_string(&duration).unwrap();
         // Note: This test would work with a wrapper struct that uses the serde module
     }
 }

--- a/src/core/config/validation_api.rs
+++ b/src/core/config/validation_api.rs
@@ -561,7 +561,7 @@ impl ConfigurationValidator {
         self.rules.push(rule);
 
         // Sort rules by priority (highest first)
-        self.rules.sort_by(|a, b| b.priority().cmp(&a.priority()));
+        self.rules.sort_by_key(|b| std::cmp::Reverse(b.priority()));
     }
 
     /// Add multiple validation rules
@@ -917,14 +917,13 @@ impl ValidationRule for SecurityValidationRule {
         if matches!(
             config.eventflux.runtime.mode,
             crate::core::config::types::RuntimeMode::Distributed
-        ) {
-            if config.eventflux.security.is_none() {
-                report.add_error(ValidationError::new(
+        ) && config.eventflux.security.is_none()
+        {
+            report.add_error(ValidationError::new(
                     "MISSING_SECURITY_CONFIG".to_string(),
                     "Security configuration is required in distributed mode".to_string(),
                     "eventflux.security".to_string(),
                 ).with_suggestion("Add security configuration with appropriate authentication and authorization settings".to_string()));
-            }
         }
 
         // Check for monitoring configuration in production
@@ -1126,7 +1125,7 @@ mod tests {
         rule.validate(&config, &mut report).await.unwrap();
 
         assert!(report.is_valid); // Warnings don't invalidate
-        assert!(report.warnings.len() >= 1); // Should have warnings
+        assert!(!report.warnings.is_empty()); // Should have warnings
     }
 
     #[tokio::test]
@@ -1160,9 +1159,10 @@ mod tests {
         let report = validator.validate(&config).await.unwrap();
 
         assert!(!report.is_valid);
-        assert!(report.errors.len() > 0);
+        assert!(!report.errors.is_empty());
         // Validation duration should be set (could be 0 for very fast validation)
-        assert!(report.validation_duration.as_nanos() >= 0);
+        // validation_duration is always >= 0 for Duration
+        let _ = report.validation_duration;
         assert!(!report.summary().contains("✅"));
     }
 

--- a/src/core/config/validator.rs
+++ b/src/core/config/validator.rs
@@ -121,7 +121,7 @@ impl ConfigValidator {
         }
 
         // Validate application names
-        for (name, _) in &config.applications {
+        for name in config.applications.keys() {
             if name.is_empty() {
                 result.add_error(ValidationError::invalid_field_value(
                     "applications.<name>",
@@ -223,13 +223,11 @@ impl ConfigValidator {
 
     /// Validate connectivity to external services
     async fn validate_connectivity(&self, _config: &EventFluxConfig) -> ValidationResult {
-        let result = ValidationResult::new();
-
         // Implementation pending: External service connectivity validation
         // Future implementation will test database connections, validate Kafka brokers,
         // check Redis connectivity, and verify external service endpoints
 
-        result
+        ValidationResult::new()
     }
 
     /// Validate resource requirements and limits
@@ -314,7 +312,7 @@ impl ValidationRule for ApplicationValidationRule {
             // Validate that each application has at least one definition
             if app_config.definitions.is_empty() {
                 result.add_warning(ValidationError::custom_validation(
-                    &format!("applications.{}.definitions", app_name),
+                    format!("applications.{}.definitions", app_name),
                     "Application has no definitions configured",
                 ));
             }
@@ -350,7 +348,7 @@ impl ApplicationValidationRule {
         // Validate definition name
         if def_name.is_empty() {
             result.add_error(ValidationError::invalid_field_value(
-                &format!("applications.{}.definitions.<name>", app_name),
+                format!("applications.{}.definitions.<name>", app_name),
                 "Definition name cannot be empty",
             ));
         }
@@ -404,7 +402,7 @@ impl ValidationRule for SecurityValidationRule {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::config::{PerformanceConfig, RuntimeMode};
+    use crate::core::config::RuntimeMode;
 
     #[tokio::test]
     async fn test_basic_validation() {

--- a/src/core/distributed/distributed_runtime.rs
+++ b/src/core/distributed/distributed_runtime.rs
@@ -448,8 +448,10 @@ mod tests {
         let api_app = Arc::new(EventFluxApp::default());
         let context = Arc::new(EventFluxContext::default());
 
-        let mut config = DistributedConfig::default();
-        config.mode = mode;
+        let mut config = DistributedConfig {
+            mode,
+            ..Default::default()
+        };
 
         if mode == RuntimeMode::Distributed {
             config.node = Some(super::super::NodeConfig {

--- a/src/core/distributed/grpc/simple_transport.rs
+++ b/src/core/distributed/grpc/simple_transport.rs
@@ -62,6 +62,12 @@ pub struct SimpleGrpcTransport {
     clients: Arc<RwLock<HashMap<String, super::transport_client::TransportClient<Channel>>>>,
 }
 
+impl Default for SimpleGrpcTransport {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl SimpleGrpcTransport {
     /// Create a new simple gRPC transport
     pub fn new() -> Self {
@@ -122,7 +128,7 @@ impl SimpleGrpcTransport {
             }
         })?;
 
-        let response_message = self.from_proto_message(&response.into_inner());
+        let response_message = self.decode_proto_message(&response.into_inner());
         Ok(response_message)
     }
 
@@ -188,12 +194,12 @@ impl SimpleGrpcTransport {
     }
 
     /// Convert protobuf message to local message
-    pub fn from_proto_message(&self, proto_msg: &TransportMessage) -> Message {
+    pub fn decode_proto_message(&self, proto_msg: &TransportMessage) -> Message {
         Message {
             id: proto_msg.id.clone(),
             payload: proto_msg.payload.clone(),
             headers: proto_msg.headers.clone(),
-            message_type: self.from_proto_message_type(proto_msg.message_type),
+            message_type: self.decode_proto_message_type(proto_msg.message_type),
         }
     }
 
@@ -213,7 +219,7 @@ impl SimpleGrpcTransport {
     }
 
     /// Convert protobuf message type to local message type
-    fn from_proto_message_type(
+    fn decode_proto_message_type(
         &self,
         proto_type: i32,
     ) -> crate::core::distributed::transport::MessageType {
@@ -232,13 +238,12 @@ impl SimpleGrpcTransport {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::distributed::transport::MessageType;
 
     #[test]
     fn test_simple_grpc_transport_creation() {
         let transport = SimpleGrpcTransport::new();
         assert_eq!(transport.config.connection_timeout_ms, 10000);
-        assert_eq!(transport.config.enable_compression, true);
+        assert!(transport.config.enable_compression);
     }
 
     #[test]
@@ -249,7 +254,7 @@ mod tests {
             .with_header("source_node".to_string(), "node1".to_string());
 
         let proto_message = transport.to_proto_message(&original_message);
-        let converted_message = transport.from_proto_message(&proto_message);
+        let converted_message = transport.decode_proto_message(&proto_message);
 
         assert_eq!(original_message.id, converted_message.id);
         assert_eq!(original_message.payload, converted_message.payload);
@@ -263,7 +268,7 @@ mod tests {
     fn test_config_default() {
         let config = SimpleGrpcConfig::default();
         assert_eq!(config.connection_timeout_ms, 10000);
-        assert_eq!(config.enable_compression, true);
+        assert!(config.enable_compression);
         assert_eq!(config.server_address, "127.0.0.1:50051");
     }
 }

--- a/src/core/distributed/grpc/transport.rs
+++ b/src/core/distributed/grpc/transport.rs
@@ -23,7 +23,6 @@
 //! using Tonic. It supports streaming, compression, load balancing, and health checks.
 
 use super::transport_client::TransportClient;
-use super::transport_server::Transport as TransportService;
 use super::{
     ClusterInfo, CompressionType, HeartbeatRequest, HeartbeatResponse, MessageType, NodeHealth,
     NodeStatus, TransportMessage,
@@ -45,6 +44,7 @@ use tonic::transport::{Certificate, Channel, ClientTlsConfig};
 use tonic::{Request, Response, Status};
 
 /// gRPC transport implementation using Tonic
+#[allow(dead_code)]
 pub struct GrpcTransport {
     /// Client connections pool
     clients: Arc<RwLock<HashMap<String, TransportClient<Channel>>>>,
@@ -117,6 +117,7 @@ impl Default for GrpcTransportConfig {
 }
 
 /// Handle for gRPC server
+#[allow(dead_code)]
 struct GrpcServerHandle {
     /// Shutdown signal
     shutdown_tx: oneshot::Sender<()>,
@@ -125,6 +126,7 @@ struct GrpcServerHandle {
 }
 
 /// gRPC connection wrapper
+#[allow(dead_code)]
 pub struct GrpcConnection {
     /// Connection identifier
     pub id: String,
@@ -141,6 +143,7 @@ pub struct GrpcConnection {
 }
 
 /// gRPC listener wrapper
+#[allow(dead_code)]
 pub struct GrpcListener {
     /// Listen endpoint
     pub endpoint: String,
@@ -148,6 +151,12 @@ pub struct GrpcListener {
     server_handle: Option<GrpcServerHandle>,
     /// Connection acceptor
     connection_rx: Arc<RwLock<Option<mpsc::UnboundedReceiver<GrpcConnection>>>>,
+}
+
+impl Default for GrpcTransport {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl GrpcTransport {
@@ -206,12 +215,13 @@ impl GrpcTransport {
     }
 
     /// Convert protobuf message to local message
-    fn from_proto_message(&self, proto_msg: &TransportMessage) -> Message {
+    #[allow(dead_code)]
+    fn decode_proto_message(&self, proto_msg: &TransportMessage) -> Message {
         Message {
             id: proto_msg.id.clone(),
             payload: proto_msg.payload.clone(),
             headers: proto_msg.headers.clone(),
-            message_type: self.from_proto_message_type(proto_msg.message_type),
+            message_type: self.decode_proto_message_type(proto_msg.message_type),
         }
     }
 
@@ -228,7 +238,8 @@ impl GrpcTransport {
     }
 
     /// Convert protobuf message type to local message type
-    fn from_proto_message_type(&self, proto_type: i32) -> LocalMessageType {
+    #[allow(dead_code)]
+    fn decode_proto_message_type(&self, proto_type: i32) -> LocalMessageType {
         match MessageType::try_from(proto_type).unwrap_or(MessageType::Unspecified) {
             MessageType::Event => LocalMessageType::Event,
             MessageType::Query => LocalMessageType::Query,
@@ -366,7 +377,7 @@ impl Transport for GrpcTransport {
         Ok(())
     }
 
-    async fn receive(&self, connection: &Connection) -> DistributedResult<Message> {
+    async fn receive(&self, _connection: &Connection) -> DistributedResult<Message> {
         // For gRPC, receiving is typically handled through streaming
         // This is a simplified implementation that would need to be extended
         // based on the specific use case (request/response vs streaming)
@@ -395,6 +406,7 @@ impl Transport for GrpcTransport {
 }
 
 /// gRPC service implementation
+#[allow(dead_code)]
 pub struct GrpcTransportService {
     /// Connection notifier
     connection_tx: mpsc::UnboundedSender<GrpcConnection>,
@@ -491,7 +503,7 @@ mod tests {
     async fn test_grpc_transport_creation() {
         let transport = GrpcTransport::new();
         assert_eq!(transport.config.connection_timeout_ms, 10000);
-        assert_eq!(transport.config.enable_compression, true);
+        assert!(transport.config.enable_compression);
     }
 
     #[tokio::test]
@@ -502,7 +514,7 @@ mod tests {
             .with_header("source_node".to_string(), "node1".to_string());
 
         let proto_message = transport.to_proto_message(&original_message);
-        let converted_message = transport.from_proto_message(&proto_message);
+        let converted_message = transport.decode_proto_message(&proto_message);
 
         assert_eq!(original_message.id, converted_message.id);
         assert_eq!(original_message.payload, converted_message.payload);
@@ -516,7 +528,7 @@ mod tests {
     fn test_grpc_config_default() {
         let config = GrpcTransportConfig::default();
         assert_eq!(config.connection_timeout_ms, 10000);
-        assert_eq!(config.enable_compression, true);
+        assert!(config.enable_compression);
         assert_eq!(config.preferred_compression, CompressionType::Zstd);
         assert_eq!(config.max_concurrent_requests, 1000);
     }

--- a/src/core/distributed/processing_engine.rs
+++ b/src/core/distributed/processing_engine.rs
@@ -254,8 +254,12 @@ impl ProcessingEngineImpl for SingleNodeEngine {
         let streams = self.streams.read().await;
 
         if let Some(junction) = streams.get(stream_id) {
-            let mut junction = junction.lock().await;
-            junction.send_event(event);
+            let junction = junction.lock().await;
+            junction
+                .send_event(event)
+                .map_err(|e| DistributedError::StateError {
+                    message: format!("Failed to send event to stream {}: {}", stream_id, e),
+                })?;
             Ok(())
         } else {
             Err(DistributedError::NetworkError {
@@ -341,14 +345,18 @@ impl DistributedEngine {
 
 #[async_trait]
 impl ProcessingEngineImpl for DistributedEngine {
-    async fn process_event(&self, stream_id: &str, event: Event) -> DistributedResult<()> {
+    async fn process_event(&self, stream_id: &str, _event: Event) -> DistributedResult<()> {
         // In distributed mode, route event to appropriate node
         let target_node = self.load_balancer.select_node(stream_id).await?;
 
-        // Send event to target node (simplified)
-        println!(
-            "Routing event for stream {} to node {}",
-            stream_id, target_node
+        // FIXME: Event is selected for routing but not forwarded to the target node.
+        // Must send `_event` to `target_node` via the transport layer once the
+        // distributed message protocol is implemented.
+        log::warn!(
+            "Distributed routing not yet implemented: event for stream '{}' \
+             selected node '{}' but was not forwarded",
+            stream_id,
+            target_node
         );
 
         Ok(())
@@ -419,7 +427,7 @@ impl ProcessingEngineImpl for DistributedEngine {
         for (query_id, node_id) in assignments.iter() {
             node_queries
                 .entry(node_id.clone())
-                .or_insert_with(Vec::new)
+                .or_default()
                 .push(query_id.clone());
         }
 
@@ -435,6 +443,7 @@ impl ProcessingEngineImpl for DistributedEngine {
 }
 
 /// Hybrid processing engine
+#[allow(dead_code)]
 struct HybridEngine {
     /// Local engine for processing
     local_engine: SingleNodeEngine,

--- a/src/core/distributed/runtime_mode.rs
+++ b/src/core/distributed/runtime_mode.rs
@@ -27,6 +27,7 @@ use super::{DistributedConfig, DistributedError, DistributedResult, RuntimeMode}
 use std::sync::Arc;
 
 /// Runtime mode manager that handles mode-specific initialization
+#[allow(dead_code)]
 pub struct RuntimeModeManager {
     /// Current runtime mode
     mode: RuntimeMode,
@@ -202,6 +203,7 @@ pub struct ComponentHealth {
 }
 
 /// Single-node mode implementation
+#[allow(dead_code)]
 struct SingleNodeMode {
     config: Arc<DistributedConfig>,
     start_time: std::time::Instant,
@@ -276,6 +278,7 @@ impl RuntimeModeImpl for SingleNodeMode {
 }
 
 /// Distributed mode implementation
+#[allow(dead_code)]
 struct DistributedMode {
     config: Arc<DistributedConfig>,
     coordinator: Option<Arc<dyn super::coordinator::DistributedCoordinator>>,
@@ -385,6 +388,7 @@ impl RuntimeModeImpl for DistributedMode {
 }
 
 /// Hybrid mode implementation (local processing with distributed state)
+#[allow(dead_code)]
 struct HybridMode {
     config: Arc<DistributedConfig>,
     single_node: SingleNodeMode,
@@ -490,8 +494,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_distributed_mode_validation() {
-        let mut config = DistributedConfig::default();
-        config.mode = RuntimeMode::Distributed;
+        let mut config = DistributedConfig {
+            mode: RuntimeMode::Distributed,
+            ..Default::default()
+        };
 
         // Should fail without cluster config
         let result = RuntimeModeManager::new(config.clone());
@@ -518,8 +524,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_hybrid_mode() {
-        let mut config = DistributedConfig::default();
-        config.mode = RuntimeMode::Hybrid;
+        let config = DistributedConfig {
+            mode: RuntimeMode::Hybrid,
+            ..Default::default()
+        };
 
         let mut manager = RuntimeModeManager::new(config).unwrap();
 

--- a/src/core/distributed/state_backend.rs
+++ b/src/core/distributed/state_backend.rs
@@ -64,6 +64,12 @@ pub struct InMemoryBackend {
     state: Arc<RwLock<std::collections::HashMap<String, Vec<u8>>>>,
 }
 
+impl Default for InMemoryBackend {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl InMemoryBackend {
     pub fn new() -> Self {
         Self {
@@ -146,6 +152,7 @@ impl Default for RedisConfig {
 }
 
 /// Redis state backend for distributed state management
+#[allow(clippy::type_complexity)]
 pub struct RedisBackend {
     pool: Option<Pool>,
     config: RedisConfig,
@@ -165,6 +172,12 @@ impl std::fmt::Debug for RedisBackend {
                 ),
             )
             .finish()
+    }
+}
+
+impl Default for RedisBackend {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -257,7 +270,7 @@ impl StateBackend for RedisBackend {
         // Test with a simple ping
         let mut conn = conn;
         redis::cmd("PING")
-            .query_async::<_, String>(&mut conn)
+            .query_async::<String>(&mut conn)
             .await
             .map_err(|e| DistributedError::StateError {
                 message: format!("Redis ping failed: {}", e),
@@ -315,7 +328,7 @@ impl StateBackend for RedisBackend {
         }
 
         // Execute pipeline atomically
-        pipe.query_async::<_, ()>(&mut conn)
+        pipe.query_async::<()>(&mut conn)
             .await
             .map_err(|e| DistributedError::StateError {
                 message: format!("Redis atomic set_multi failed: {}", e),

--- a/src/core/distributed/transport.rs
+++ b/src/core/distributed/transport.rs
@@ -67,6 +67,7 @@ pub struct Connection {
 
 /// Internal connection handle
 #[derive(Debug)]
+#[allow(dead_code)]
 pub(crate) enum ConnectionHandle {
     Tcp(TcpStream),
     // Placeholder for gRPC - actual implementation in grpc module
@@ -206,6 +207,12 @@ impl Default for TcpTransportConfig {
             recv_buffer_size: Some(65536),
             max_message_size: 10 * 1024 * 1024, // 10MB
         }
+    }
+}
+
+impl Default for TcpTransport {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -657,8 +664,8 @@ mod tests {
     fn test_tcp_config_default() {
         let config = TcpTransportConfig::default();
         assert_eq!(config.connection_timeout_ms, 5000);
-        assert_eq!(config.keepalive_enabled, true);
-        assert_eq!(config.nodelay, true);
+        assert!(config.keepalive_enabled);
+        assert!(config.nodelay);
         assert_eq!(config.max_message_size, 10 * 1024 * 1024);
     }
 

--- a/src/core/error/config.rs
+++ b/src/core/error/config.rs
@@ -21,6 +21,8 @@
 //! retry configuration, DLQ configuration, and logging settings into a unified
 //! configuration system.
 
+use std::str::FromStr;
+
 use crate::core::config::FlatConfig;
 
 use super::dlq::DlqConfig;
@@ -42,9 +44,11 @@ pub enum LogLevel {
     Error,
 }
 
-impl LogLevel {
+impl std::str::FromStr for LogLevel {
+    type Err = String;
+
     /// Parse log level from string (case-insensitive)
-    pub fn from_str(s: &str) -> Result<Self, String> {
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
             "debug" => Ok(LogLevel::Debug),
             "info" => Ok(LogLevel::Info),
@@ -56,7 +60,9 @@ impl LogLevel {
             )),
         }
     }
+}
 
+impl LogLevel {
     /// Convert log level to string representation
     #[inline]
     pub const fn as_str(&self) -> &'static str {

--- a/src/core/error/dlq.rs
+++ b/src/core/error/dlq.rs
@@ -20,10 +20,12 @@
 //! This module provides DLQ configuration with fallback strategies for scenarios
 //! where the DLQ stream itself is unavailable or delivery fails.
 
+use std::str::FromStr;
+use std::time::{SystemTime, UNIX_EPOCH};
+
 use crate::core::config::{FlatConfig, PropertySource};
 use crate::core::event::{AttributeValue, Event};
 use crate::core::exception::EventFluxError;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use super::retry::RetryConfig;
 
@@ -51,9 +53,11 @@ pub enum DlqFallbackStrategy {
     Retry,
 }
 
-impl DlqFallbackStrategy {
+impl std::str::FromStr for DlqFallbackStrategy {
+    type Err = String;
+
     /// Parse fallback strategy from string (case-insensitive)
-    pub fn from_str(s: &str) -> Result<Self, String> {
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
             "log" => Ok(DlqFallbackStrategy::Log),
             "fail" => Ok(DlqFallbackStrategy::Fail),
@@ -64,7 +68,9 @@ impl DlqFallbackStrategy {
             )),
         }
     }
+}
 
+impl DlqFallbackStrategy {
     /// Convert fallback strategy to string representation
     #[inline]
     pub const fn as_str(&self) -> &'static str {

--- a/src/core/error/handler.rs
+++ b/src/core/error/handler.rs
@@ -395,7 +395,7 @@ impl std::fmt::Debug for ErrorHandler {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::config::FlatConfig;
+
     use crate::core::error::{BackoffStrategy, RetryConfig};
     use crate::core::event::AttributeValue;
 

--- a/src/core/error/integration.rs
+++ b/src/core/error/integration.rs
@@ -53,6 +53,7 @@ use std::sync::{Arc, Mutex};
 ///
 /// This provides utilities for M7 to extract error configuration from stream
 /// properties and lookup DLQ stream junctions.
+#[allow(clippy::type_complexity)]
 pub struct ErrorIntegrationHelper {
     /// Lookup function for DLQ stream junctions
     dlq_lookup: Box<dyn Fn(&str) -> Option<Arc<Mutex<InputHandler>>> + Send + Sync>,
@@ -117,10 +118,15 @@ impl ErrorIntegrationHelper {
             return Ok(None);
         }
 
-        // Extract error configuration
-        let error_config = error_config_builder.build()?.ok_or_else(|| {
+        // TODO: Wire error_config into SourceErrorContext for runtime error handling
+        let _error_config = error_config_builder.build()?.ok_or_else(|| {
             "Error handling configured but failed to build ErrorConfig".to_string()
         })?;
+        log::error!(
+            "[{}] Error handling configuration parsed but not yet wired into runtime. \
+             Configured error strategy will NOT be applied — defaults will be used.",
+            stream_name
+        );
 
         // Lookup DLQ junction if needed
         let dlq_junction = if let Some(dlq_stream) = properties.get("error.dlq.stream") {

--- a/src/core/error/retry.rs
+++ b/src/core/error/retry.rs
@@ -20,8 +20,10 @@
 //! This module provides configurable retry logic with multiple backoff strategies
 //! including exponential, linear, and fixed delay patterns.
 
-use crate::core::config::FlatConfig;
+use std::str::FromStr;
 use std::time::Duration;
+
+use crate::core::config::FlatConfig;
 
 /// Backoff strategy for retry delays
 ///
@@ -47,9 +49,11 @@ pub enum BackoffStrategy {
     Fixed,
 }
 
-impl BackoffStrategy {
+impl std::str::FromStr for BackoffStrategy {
+    type Err = String;
+
     /// Parse backoff strategy from string (case-insensitive)
-    pub fn from_str(s: &str) -> Result<Self, String> {
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
             "exponential" => Ok(BackoffStrategy::Exponential),
             "linear" => Ok(BackoffStrategy::Linear),
@@ -60,7 +64,9 @@ impl BackoffStrategy {
             )),
         }
     }
+}
 
+impl BackoffStrategy {
     /// Convert backoff strategy to string representation
     #[inline]
     pub const fn as_str(&self) -> &'static str {

--- a/src/core/error/source_support.rs
+++ b/src/core/error/source_support.rs
@@ -148,12 +148,10 @@ impl SourceErrorContext {
     ) -> ErrorAction {
         let action = self.handler.handle_error(event, error);
 
-        match &action {
-            ErrorAction::Retry { delay } => {
-                // Sleep for retry delay
-                thread::sleep(*delay);
-            }
-            _ => {}
+        if let ErrorAction::Retry { delay } = &action {
+            // Note: This runs on blocking source threads (spawn_blocking), not the async executor.
+            // thread::sleep is intentional here — sources are synchronous.
+            thread::sleep(*delay);
         }
 
         action

--- a/src/core/error/strategy.rs
+++ b/src/core/error/strategy.rs
@@ -52,36 +52,6 @@ pub enum ErrorStrategy {
 }
 
 impl ErrorStrategy {
-    /// Parse error strategy from string (case-insensitive)
-    ///
-    /// # Arguments
-    /// * `s` - String representation of error strategy
-    ///
-    /// # Returns
-    /// * `Ok(ErrorStrategy)` - Successfully parsed strategy
-    /// * `Err(String)` - Parse error with message
-    ///
-    /// # Examples
-    /// ```
-    /// use eventflux::core::error::ErrorStrategy;
-    ///
-    /// assert_eq!(ErrorStrategy::from_str("drop").unwrap(), ErrorStrategy::Drop);
-    /// assert_eq!(ErrorStrategy::from_str("RETRY").unwrap(), ErrorStrategy::Retry);
-    /// assert!(ErrorStrategy::from_str("invalid").is_err());
-    /// ```
-    pub fn from_str(s: &str) -> Result<Self, String> {
-        match s.to_lowercase().as_str() {
-            "drop" => Ok(ErrorStrategy::Drop),
-            "retry" => Ok(ErrorStrategy::Retry),
-            "dlq" => Ok(ErrorStrategy::Dlq),
-            "fail" => Ok(ErrorStrategy::Fail),
-            _ => Err(format!(
-                "Invalid error strategy '{}'. Valid values: 'drop', 'retry', 'dlq', 'fail'",
-                s
-            )),
-        }
-    }
-
     /// Convert error strategy to string representation
     ///
     /// Returns the canonical lowercase string representation of the strategy.
@@ -116,6 +86,41 @@ impl Default for ErrorStrategy {
     }
 }
 
+impl std::str::FromStr for ErrorStrategy {
+    type Err = String;
+
+    /// Parse error strategy from string (case-insensitive)
+    ///
+    /// # Arguments
+    /// * `s` - String representation of error strategy
+    ///
+    /// # Returns
+    /// * `Ok(ErrorStrategy)` - Successfully parsed strategy
+    /// * `Err(String)` - Parse error with message
+    ///
+    /// # Examples
+    /// ```
+    /// use eventflux::core::error::ErrorStrategy;
+    /// use std::str::FromStr;
+    ///
+    /// assert_eq!(ErrorStrategy::from_str("drop").unwrap(), ErrorStrategy::Drop);
+    /// assert_eq!(ErrorStrategy::from_str("RETRY").unwrap(), ErrorStrategy::Retry);
+    /// assert!(ErrorStrategy::from_str("invalid").is_err());
+    /// ```
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "drop" => Ok(ErrorStrategy::Drop),
+            "retry" => Ok(ErrorStrategy::Retry),
+            "dlq" => Ok(ErrorStrategy::Dlq),
+            "fail" => Ok(ErrorStrategy::Fail),
+            _ => Err(format!(
+                "Invalid error strategy '{}'. Valid values: 'drop', 'retry', 'dlq', 'fail'",
+                s
+            )),
+        }
+    }
+}
+
 impl std::fmt::Display for ErrorStrategy {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.as_str())
@@ -125,6 +130,7 @@ impl std::fmt::Display for ErrorStrategy {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::str::FromStr;
 
     #[test]
     fn test_error_strategy_from_str() {

--- a/src/core/event/complex_event.rs
+++ b/src/core/event/complex_event.rs
@@ -73,7 +73,7 @@ pub trait ComplexEvent: Debug + Send + Sync + 'static {
     fn as_any(&self) -> &dyn Any;
     fn as_any_mut(&mut self) -> &mut dyn Any;
 
-    // Helper for cloning, if ComplexEvent needs to be clonable for some strategies
+    // Helper for cloning, if ComplexEvent needs to be cloneable for some strategies
     // Each implementor would need to implement this.
     // fn clone_complex_event(&self) -> Box<dyn ComplexEvent>;
 }

--- a/src/core/event/mod.rs
+++ b/src/core/event/mod.rs
@@ -16,6 +16,7 @@
  */
 
 pub mod complex_event;
+#[allow(clippy::module_inception)]
 pub mod event;
 pub mod state;
 pub mod stream;

--- a/src/core/event/state/state_event_cloner.rs
+++ b/src/core/event/state/state_event_cloner.rs
@@ -58,9 +58,7 @@ impl StateEventCloner {
         if self.output_data_size > 0 {
             if let (Some(src), Some(dest)) = (&state_event.output_data, &mut new_event.output_data)
             {
-                for i in 0..self.output_data_size {
-                    dest[i] = src[i].clone();
-                }
+                dest[..self.output_data_size].clone_from_slice(&src[..self.output_data_size]);
             }
         }
         if self.stream_event_size > 0 {
@@ -228,6 +226,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::approx_constant)]
     fn test_clone_output_data() {
         let mut state = StateEvent::new(1, 3);
 

--- a/src/core/event/stream/stream_event_cloner.rs
+++ b/src/core/event/stream/stream_event_cloner.rs
@@ -101,6 +101,7 @@ impl StreamEventCloner {
                 stream_event.output_data.as_ref(),
                 new_event.output_data.as_mut(),
             ) {
+                #[allow(clippy::needless_range_loop)]
                 for i in 0..self.output_data_size {
                     if let Some(v) = src.get(i) {
                         dest[i] = v.clone();

--- a/src/core/eventflux_app_runtime.rs
+++ b/src/core/eventflux_app_runtime.rs
@@ -245,7 +245,7 @@ impl EventFluxAppRuntime {
     fn new_with_applied_config(
         api_eventflux_app: Arc<ApiEventFluxApp>,
         eventflux_context: Arc<crate::core::config::eventflux_context::EventFluxContext>,
-        eventflux_app_string: Option<String>,
+        _eventflux_app_string: Option<String>,
         app_config: &ApplicationConfig,
     ) -> Result<Self, String> {
         // 1. Create EventFluxAppContext using YAML/TOML configuration (ApplicationConfig)
@@ -930,10 +930,7 @@ impl EventFluxAppRuntime {
             if service.persistence_store.is_some() {
                 match self.persist() {
                     Ok(report) => {
-                        log::info!(
-                            "Auto-persisted on shutdown (revision: {})",
-                            report.revision
-                        )
+                        log::info!("Auto-persisted on shutdown (revision: {})", report.revision)
                     }
                     Err(e) => log::warn!("Auto-persist on shutdown failed: {}", e),
                 }
@@ -1059,14 +1056,13 @@ impl EventFluxAppRuntime {
         for query_runtime in &self.query_runtimes {
             // Try to access the processor chain and find SelectProcessors
             if let Some(ref processor) = query_runtime.processor_chain_head {
-                self.clear_processor_chain_group_states(processor);
+                Self::clear_processor_chain_group_states(processor);
             }
         }
     }
 
     /// Recursively clear group states in processor chains
     fn clear_processor_chain_group_states(
-        &self,
         processor: &Arc<Mutex<dyn crate::core::query::processor::Processor>>,
     ) {
         if let Ok(proc) = processor.lock() {
@@ -1075,7 +1071,7 @@ impl EventFluxAppRuntime {
 
             // Recursively check next processors in the chain
             if let Some(ref next) = proc.next_processor() {
-                self.clear_processor_chain_group_states(next);
+                Self::clear_processor_chain_group_states(next);
             }
         }
     }
@@ -2004,9 +2000,9 @@ impl EventFluxAppRuntime {
         };
 
         // Remove fields already extracted elsewhere (to avoid duplication)
-        mapping.remove(&serde_yaml::Value::String("type".to_string()));
-        mapping.remove(&serde_yaml::Value::String("format".to_string()));
-        mapping.remove(&serde_yaml::Value::String("connection".to_string()));
+        mapping.remove(serde_yaml::Value::String("type".to_string()));
+        mapping.remove(serde_yaml::Value::String("format".to_string()));
+        mapping.remove(serde_yaml::Value::String("connection".to_string()));
 
         // Flatten remaining fields (security, delivery_guarantee, retry, batching)
         Self::flatten_yaml_value(&serde_yaml::Value::Mapping(mapping), "", properties)?;
@@ -2034,9 +2030,9 @@ impl EventFluxAppRuntime {
         };
 
         // Remove fields already extracted elsewhere (to avoid duplication)
-        mapping.remove(&serde_yaml::Value::String("type".to_string()));
-        mapping.remove(&serde_yaml::Value::String("format".to_string()));
-        mapping.remove(&serde_yaml::Value::String("connection".to_string()));
+        mapping.remove(serde_yaml::Value::String("type".to_string()));
+        mapping.remove(serde_yaml::Value::String("format".to_string()));
+        mapping.remove(serde_yaml::Value::String("connection".to_string()));
 
         // Flatten remaining fields (security, error_handling, rate_limit)
         Self::flatten_yaml_value(&serde_yaml::Value::Mapping(mapping), "", properties)?;

--- a/src/core/eventflux_manager.rs
+++ b/src/core/eventflux_manager.rs
@@ -661,6 +661,7 @@ impl std::fmt::Debug for EventFluxManager {
 // Helper on ApiEventFluxApp for getting name (if not already part of query_api)
 // This is more robust than assuming api_eventflux_app.name
 impl ApiEventFluxApp {
+    #[allow(dead_code)]
     fn get_name(&self) -> Option<String> {
         self.annotations
             .iter()

--- a/src/core/executor/cast_executor.rs
+++ b/src/core/executor/cast_executor.rs
@@ -261,6 +261,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::approx_constant)]
     fn test_double_to_string() {
         let inner = make_constant_executor(AttributeValue::Double(3.14));
         let cast = CastExecutor::new(inner, ApiAttributeType::STRING);
@@ -280,6 +281,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::approx_constant)]
     fn test_float_to_double() {
         let inner = make_constant_executor(AttributeValue::Float(3.14_f32));
         let cast = CastExecutor::new(inner, ApiAttributeType::DOUBLE);

--- a/src/core/executor/function/builtin_wrapper.rs
+++ b/src/core/executor/function/builtin_wrapper.rs
@@ -80,7 +80,7 @@ impl ExpressionExecutor for BuiltinScalarFunction {
 impl ScalarFunctionExecutor for BuiltinScalarFunction {
     fn init(
         &mut self,
-        args: &Vec<Box<dyn ExpressionExecutor>>,
+        args: &[Box<dyn ExpressionExecutor>],
         ctx: &Arc<EventFluxAppContext>,
     ) -> Result<(), String> {
         let cloned: Vec<Box<dyn ExpressionExecutor>> =

--- a/src/core/executor/function/default_function_executor.rs
+++ b/src/core/executor/function/default_function_executor.rs
@@ -224,6 +224,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::approx_constant)]
     fn test_default_allows_numeric_widening() {
         // INT + LONG should work
         let result = DefaultFunctionExecutor::new(vec![

--- a/src/core/executor/function/math_functions.rs
+++ b/src/core/executor/function/math_functions.rs
@@ -213,7 +213,7 @@ impl ExpressionExecutor for AsinFunctionExecutor {
             _ => {
                 let num = to_f64(&val)?;
                 // asin is only defined for values in [-1, 1]
-                if num < -1.0 || num > 1.0 {
+                if !(-1.0..=1.0).contains(&num) {
                     Some(AttributeValue::Double(f64::NAN))
                 } else {
                     Some(AttributeValue::Double(num.asin()))
@@ -252,7 +252,7 @@ impl ExpressionExecutor for AcosFunctionExecutor {
             _ => {
                 let num = to_f64(&val)?;
                 // acos is only defined for values in [-1, 1]
-                if num < -1.0 || num > 1.0 {
+                if !(-1.0..=1.0).contains(&num) {
                     Some(AttributeValue::Double(f64::NAN))
                 } else {
                     Some(AttributeValue::Double(num.acos()))

--- a/src/core/executor/function/scalar_function_executor.rs
+++ b/src/core/executor/function/scalar_function_executor.rs
@@ -38,7 +38,7 @@ pub trait ScalarFunctionExecutor: ExpressionExecutor {
     /// any internal state required for [`execute`](ExpressionExecutor::execute).
     fn init(
         &mut self,
-        argument_executors: &Vec<Box<dyn ExpressionExecutor>>,
+        argument_executors: &[Box<dyn ExpressionExecutor>],
         eventflux_app_context: &Arc<EventFluxAppContext>,
     ) -> Result<(), String>;
 

--- a/src/core/executor/function/script_function_executor.rs
+++ b/src/core/executor/function/script_function_executor.rs
@@ -53,7 +53,7 @@ impl ExpressionExecutor for ScriptFunctionExecutor {
 impl ScalarFunctionExecutor for ScriptFunctionExecutor {
     fn init(
         &mut self,
-        _args: &Vec<Box<dyn ExpressionExecutor>>,
+        _args: &[Box<dyn ExpressionExecutor>],
         _ctx: &Arc<EventFluxAppContext>,
     ) -> Result<(), String> {
         Ok(())

--- a/src/core/executor/incremental/should_update.rs
+++ b/src/core/executor/incremental/should_update.rs
@@ -73,11 +73,9 @@ impl ExpressionExecutor for IncrementalShouldUpdateFunctionExecutor {
 mod tests {
     use super::*;
     use crate::core::event::stream::stream_event::StreamEvent;
-    use crate::core::executor::constant_expression_executor::ConstantExpressionExecutor;
+
     use crate::core::executor::variable_expression_executor::VariableExpressionExecutor;
-    use crate::core::util::eventflux_constants::{
-        BEFORE_WINDOW_DATA_INDEX, STREAM_ATTRIBUTE_INDEX_IN_TYPE, STREAM_ATTRIBUTE_TYPE_INDEX,
-    };
+    use crate::core::util::eventflux_constants::BEFORE_WINDOW_DATA_INDEX;
 
     #[test]
     fn test_should_update() {

--- a/src/core/extension/example_factories.rs
+++ b/src/core/extension/example_factories.rs
@@ -46,6 +46,7 @@ use std::collections::HashMap;
 
 /// Kafka-specific validated configuration (INTERNAL to KafkaSourceFactory)
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 struct KafkaSourceConfig {
     bootstrap_servers: Vec<String>,
     topic: String,
@@ -194,6 +195,7 @@ impl SourceFactory for KafkaSourceFactory {
 
 /// HTTP-specific validated configuration
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 struct HttpSinkConfig {
     url: String,
     method: String,

--- a/src/core/persistence/incremental/checkpoint_merger.rs
+++ b/src/core/persistence/incremental/checkpoint_merger.rs
@@ -121,6 +121,7 @@ pub enum ConflictResolution {
 }
 
 /// Compression engine for state data
+#[allow(dead_code)]
 pub struct CompressionEngine {
     /// Compression type
     compression_type: CompressionType,
@@ -153,6 +154,7 @@ pub struct MergeStatistics {
 
 /// Intermediate merge result
 #[derive(Debug)]
+#[allow(dead_code)]
 struct MergeResult {
     /// Merged component state
     component_states: HashMap<ComponentId, MergedComponentState>,
@@ -169,6 +171,7 @@ struct MergeResult {
 
 /// Merged state for a single component
 #[derive(Debug)]
+#[allow(dead_code)]
 struct MergedComponentState {
     /// Final state snapshot
     snapshot: StateSnapshot,
@@ -185,6 +188,7 @@ struct MergedComponentState {
 
 /// Metadata about the merge operation
 #[derive(Debug)]
+#[allow(dead_code)]
 struct MergeMetadata {
     /// Merge start time
     start_time: Instant,
@@ -497,9 +501,6 @@ impl CheckpointMerger for AdvancedCheckpointMerger {
             return Ok(base.clone());
         }
 
-        // Analyze chain for optimization opportunities
-        let analysis = self.analyze_chain(incrementals);
-
         // Collect all operations in chronological order
         let mut all_operations = Vec::new();
         for checkpoint in incrementals {
@@ -553,7 +554,7 @@ impl CheckpointMerger for AdvancedCheckpointMerger {
         changes: HashMap<ComponentId, ChangeLog>,
         wal_range: (u64, u64),
     ) -> Result<IncrementalCheckpoint, StateError> {
-        let start_time = Instant::now();
+        let _start_time = Instant::now();
 
         // Calculate total size
         let mut total_size = 0;
@@ -736,6 +737,7 @@ impl CompressionEngine {
 
 /// Analysis of checkpoint chain
 #[derive(Debug)]
+#[allow(dead_code)]
 struct ChainAnalysis {
     total_checkpoints: usize,
     total_size: usize,
@@ -746,6 +748,7 @@ struct ChainAnalysis {
 
 /// Identified merge opportunity
 #[derive(Debug)]
+#[allow(dead_code)]
 struct MergeOpportunity {
     checkpoint_range: (CheckpointId, CheckpointId),
     overlapping_components: usize,
@@ -755,6 +758,7 @@ struct MergeOpportunity {
 
 /// Type of merge opportunity
 #[derive(Debug)]
+#[allow(dead_code)]
 enum MergeOpportunityType {
     ComponentOverlap,
     SmallCheckpoint,
@@ -911,7 +915,9 @@ mod tests {
             wal_offset_range: (0, 10),
         };
 
-        let result = merger.optimize_chain(&[incremental.clone()]).unwrap();
+        let result = merger
+            .optimize_chain(std::slice::from_ref(&incremental))
+            .unwrap();
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].checkpoint_id, incremental.checkpoint_id);

--- a/src/core/persistence/incremental/distributed_coordinator.rs
+++ b/src/core/persistence/incremental/distributed_coordinator.rs
@@ -69,6 +69,7 @@ pub struct InMemoryDistributedCoordinator {
 
 /// State of the current node
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 struct NodeState {
     /// Node identifier
     node_id: String,
@@ -99,6 +100,7 @@ enum NodeRole {
 
 /// Health status of a node
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 enum NodeHealth {
     Healthy,
     Degraded { reason: String },
@@ -107,6 +109,7 @@ enum NodeHealth {
 
 /// Information about a cluster member
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 struct NodeInfo {
     /// Node identifier
     node_id: String,
@@ -126,6 +129,7 @@ struct NodeInfo {
 
 /// Capabilities of a cluster node
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 struct NodeCapabilities {
     /// Can participate in leader election
     can_be_leader: bool,
@@ -142,6 +146,7 @@ struct NodeCapabilities {
 
 /// Progress tracking for distributed checkpoints
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 struct CheckpointProgress {
     /// Checkpoint identifier
     checkpoint_id: CheckpointId,
@@ -167,6 +172,7 @@ struct CheckpointProgress {
 
 /// Metadata for a distributed checkpoint
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 struct CheckpointMetadata {
     /// Checkpoint type
     checkpoint_type: String,
@@ -199,6 +205,7 @@ struct ElectionState {
 
 /// Consensus log entry
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 struct ConsensusEntry {
     /// Entry term
     term: u64,
@@ -218,6 +225,7 @@ struct ConsensusEntry {
 
 /// Type of consensus entry
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 enum ConsensusEntryType {
     CheckpointInitiation,
     CheckpointCompletion,
@@ -228,6 +236,7 @@ enum ConsensusEntryType {
 
 /// Coordinator performance statistics
 #[derive(Debug, Default)]
+#[allow(dead_code)]
 struct CoordinatorStatistics {
     /// Total checkpoints coordinated
     pub total_checkpoints: u64,
@@ -253,6 +262,7 @@ struct CoordinatorStatistics {
 
 /// Simulated cluster state for testing
 #[derive(Debug, Default)]
+#[allow(dead_code)]
 struct SimulatedClusterState {
     /// Nodes in the cluster
     nodes: HashMap<String, NodeInfo>,

--- a/src/core/persistence/incremental/mod.rs
+++ b/src/core/persistence/incremental/mod.rs
@@ -224,6 +224,7 @@ pub struct CheckpointResult {
 }
 
 /// Incremental checkpointing system coordinator
+#[allow(dead_code)]
 pub struct IncrementalCheckpointSystem {
     /// System configuration
     config: IncrementalCheckpointConfig,

--- a/src/core/persistence/incremental/persistence_backend.rs
+++ b/src/core/persistence/incremental/persistence_backend.rs
@@ -65,6 +65,7 @@ pub struct MemoryPersistenceBackend {
 }
 
 /// Distributed persistence backend (placeholder for etcd/Consul integration)
+#[allow(dead_code)]
 pub struct DistributedPersistenceBackend {
     /// Cluster endpoints
     endpoints: Vec<String>,
@@ -116,6 +117,7 @@ enum CheckpointType {
 
 /// Backend performance statistics
 #[derive(Debug, Default)]
+#[allow(dead_code)]
 struct BackendStatistics {
     /// Total checkpoints stored
     pub total_stored: u64,
@@ -346,6 +348,7 @@ impl FilePersistenceBackend {
     }
 
     /// Calculate file checksum
+    #[allow(dead_code)]
     fn calculate_file_checksum(&self, data: &[u8]) -> u64 {
         use std::collections::hash_map::DefaultHasher;
         use std::hash::{Hash, Hasher};
@@ -561,13 +564,17 @@ impl PersistenceBackend for FilePersistenceBackend {
     }
 
     fn cleanup_checkpoints(&self, before: Instant) -> Result<usize, StateError> {
-        // For testing purposes, clean up all checkpoints
-        // In production, this would use the proper time comparison
-        let before_timestamp = SystemTime::now()
+        // Convert Instant → epoch seconds so we can compare with metadata.created_at (u64).
+        let now = Instant::now();
+        let now_epoch = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap()
-            .as_secs()
-            + 1;
+            .as_secs();
+        let before_timestamp = if now >= before {
+            now_epoch.saturating_sub((now - before).as_secs())
+        } else {
+            now_epoch + (before - now).as_secs()
+        };
         let mut removed_count = 0;
 
         let mut to_remove = Vec::new();
@@ -576,7 +583,9 @@ impl PersistenceBackend for FilePersistenceBackend {
         {
             let cache = self.metadata_cache.read().unwrap();
             for (checkpoint_id, metadata) in cache.iter() {
-                if metadata.created_at < before_timestamp {
+                // Use <= because created_at has second granularity; a sub-second
+                // delta between creation and the cutoff would otherwise be missed.
+                if metadata.created_at <= before_timestamp {
                     to_remove.push(*checkpoint_id);
                 }
             }

--- a/src/core/persistence/incremental/recovery_engine.rs
+++ b/src/core/persistence/incremental/recovery_engine.rs
@@ -34,6 +34,7 @@ use crate::core::persistence::state_holder::{
 };
 
 /// Advanced recovery engine with parallel processing
+#[allow(dead_code)]
 pub struct AdvancedRecoveryEngine {
     /// Persistence backend for loading checkpoints
     backend: Arc<dyn PersistenceBackend>,
@@ -113,6 +114,7 @@ pub enum VerificationLevel {
 
 /// Information about a checkpoint for recovery planning
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 struct CheckpointInfo {
     /// Checkpoint identifier
     pub checkpoint_id: CheckpointId,
@@ -135,6 +137,7 @@ struct CheckpointInfo {
 
 /// Type of checkpoint
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 enum CheckpointType {
     Full,
     Incremental { base: CheckpointId },
@@ -164,6 +167,7 @@ pub struct RecoveryStatistics {
 
 /// Recovery plan for a set of components
 #[derive(Debug)]
+#[allow(dead_code)]
 struct RecoveryPlan {
     /// Recovery stages (can be executed in parallel)
     pub stages: Vec<RecoveryStage>,
@@ -180,6 +184,7 @@ struct RecoveryPlan {
 
 /// Single recovery stage
 #[derive(Debug)]
+#[allow(dead_code)]
 struct RecoveryStage {
     /// Components to recover in this stage
     pub components: Vec<ComponentId>,
@@ -196,6 +201,7 @@ struct RecoveryStage {
 
 /// Recovery context for tracking progress
 #[derive(Debug)]
+#[allow(dead_code)]
 struct RecoveryContext {
     /// Target components
     pub target_components: HashSet<ComponentId>,
@@ -237,6 +243,7 @@ impl AdvancedRecoveryEngine {
     }
 
     /// Build checkpoint information cache
+    #[allow(dead_code)]
     fn build_checkpoint_cache(&mut self) -> Result<(), StateError> {
         let checkpoint_ids = self.backend.list_checkpoints()?;
 
@@ -443,9 +450,10 @@ impl AdvancedRecoveryEngine {
                 // Apply changes to existing state
                 let mut updated_state = base_state.clone();
 
-                // Apply operations from changelog
-                for operation in &changes.operations {
-                    // Simplified - in practice would properly apply each operation
+                // FIXME: Placeholder — each operation in the changelog must be properly
+                // deserialized and applied to the state. Currently appends dummy bytes,
+                // which means incremental recovery produces incorrect state.
+                for _operation in &changes.operations {
                     updated_state.data.extend_from_slice(&[1, 2, 3]); // Placeholder
                 }
 
@@ -471,7 +479,7 @@ impl AdvancedRecoveryEngine {
         _verification_level: &VerificationLevel,
     ) -> Result<(), StateError> {
         // Verify checksums
-        for (component_id, snapshot) in results {
+        for snapshot in results.values() {
             let calculated_checksum =
                 crate::core::persistence::state_holder::StateSnapshot::calculate_checksum(
                     &snapshot.data,

--- a/src/core/persistence/incremental/write_ahead_log.rs
+++ b/src/core/persistence/incremental/write_ahead_log.rs
@@ -416,7 +416,7 @@ impl WriteAheadLog for SegmentedWAL {
         {
             let completed_segments = self.completed_segments.read().unwrap();
 
-            for (&segment_id, segment) in completed_segments.iter() {
+            for (_, segment) in completed_segments.iter() {
                 if current_offset >= segment.start_offset && current_offset < segment.end_offset {
                     let segment_entries =
                         segment.read_entries_from(current_offset, limit - results.len())?;
@@ -891,14 +891,16 @@ mod tests {
 
         // Should have rotated segments
         let completed_segments = wal.completed_segments.read().unwrap();
-        assert!(completed_segments.len() > 0);
+        assert!(!completed_segments.is_empty());
     }
 
     #[test]
     fn test_wal_cleanup() {
         let temp_dir = TempDir::new().unwrap();
-        let mut config = WALConfig::default();
-        config.retention_segments = 2;
+        let config = WALConfig {
+            retention_segments: 2,
+            ..Default::default()
+        };
 
         let wal = SegmentedWAL::new(temp_dir.path(), 50, config).unwrap();
 

--- a/src/core/persistence/persistence_store.rs
+++ b/src/core/persistence/persistence_store.rs
@@ -328,7 +328,7 @@ impl PersistenceStore for RedisPersistenceStore {
                 ];
 
                 // Try atomic multi-set, initialize if needed
-                if let Err(_) = backend.set_multi(kvs.clone()).await {
+                if backend.set_multi(kvs.clone()).await.is_err() {
                     // Initialize and retry
                     if let Err(e) = backend.initialize().await {
                         error!("Failed to initialize Redis backend: {}", e);
@@ -336,7 +336,6 @@ impl PersistenceStore for RedisPersistenceStore {
                     }
                     if let Err(e) = backend.set_multi(kvs).await {
                         error!("Failed to atomically save snapshot to Redis: {}", e);
-                        return;
                     }
                 }
             });
@@ -354,7 +353,7 @@ impl PersistenceStore for RedisPersistenceStore {
                     ];
 
                     // Try atomic multi-set, initialize if needed
-                    if let Err(_) = backend.set_multi(kvs.clone()).await {
+                    if backend.set_multi(kvs.clone()).await.is_err() {
                         // Initialize and retry
                         if let Err(e) = backend.initialize().await {
                             error!("Failed to initialize Redis backend: {}", e);
@@ -362,7 +361,6 @@ impl PersistenceStore for RedisPersistenceStore {
                         }
                         if let Err(e) = backend.set_multi(kvs).await {
                             error!("Failed to atomically save snapshot to Redis: {}", e);
-                            return;
                         }
                     }
                 })
@@ -504,7 +502,7 @@ impl PersistenceStore for RedisPersistenceStore {
 
                 // Try to delete, initialize if needed
                 let last_rev_key = Self::last_revision_key(eventflux_app_id);
-                if let Err(_) = backend.delete(&last_rev_key).await {
+                if backend.delete(&last_rev_key).await.is_err() {
                     // Initialize and retry
                     if let Err(e) = backend.initialize().await {
                         error!("Failed to initialize Redis backend: {}", e);
@@ -528,7 +526,7 @@ impl PersistenceStore for RedisPersistenceStore {
 
                     // Try to delete, initialize if needed
                     let last_rev_key = Self::last_revision_key(&eventflux_app_id);
-                    if let Err(_) = backend.delete(&last_rev_key).await {
+                    if backend.delete(&last_rev_key).await.is_err() {
                         // Initialize and retry
                         if let Err(e) = backend.initialize().await {
                             error!("Failed to initialize Redis backend: {}", e);

--- a/src/core/persistence/snapshot_service.rs
+++ b/src/core/persistence/snapshot_service.rs
@@ -175,8 +175,13 @@ impl SnapshotService {
 
     /// Reset all registered state holders to their initial (empty) values.
     pub fn clear_state_holders(&self) {
-        let holders: Vec<_> = self.state_holders.lock().unwrap()
-            .iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+        let holders: Vec<_> = self
+            .state_holders
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
         for (id, holder) in holders {
             holder.lock().unwrap().reset_state();
             log::debug!("Reset state for component: {}", id);

--- a/src/core/persistence/state_manager.rs
+++ b/src/core/persistence/state_manager.rs
@@ -458,7 +458,7 @@ impl UnifiedStateManager {
 
     /// Perform live state schema migration
     pub fn migrate_schema(&self, migration: SchemaMigration) -> Result<(), StateError> {
-        let component = self
+        let _component = self
             .registry
             .get_component(&migration.component_id)
             .ok_or_else(|| StateError::InvalidStateData {

--- a/src/core/persistence/state_registry.rs
+++ b/src/core/persistence/state_registry.rs
@@ -454,7 +454,7 @@ impl StateRegistry {
         for component_id in topology.components.keys() {
             if !visited.contains(component_id) {
                 let mut current_path = Vec::new();
-                self.dfs_longest_path(
+                Self::dfs_longest_path(
                     component_id,
                     &topology.dependency_graph,
                     &mut visited,
@@ -471,7 +471,6 @@ impl StateRegistry {
     }
 
     fn dfs_longest_path(
-        &self,
         node: &ComponentId,
         graph: &DependencyGraph,
         visited: &mut HashSet<ComponentId>,
@@ -483,7 +482,7 @@ impl StateRegistry {
         if let Some(neighbors) = graph.edges.get(node) {
             for neighbor in neighbors {
                 if !visited.contains(neighbor) {
-                    self.dfs_longest_path(neighbor, graph, visited, current_path);
+                    Self::dfs_longest_path(neighbor, graph, visited, current_path);
                 }
             }
         }

--- a/src/core/query/input/stream/join/table_join_processor.rs
+++ b/src/core/query/input/stream/join/table_join_processor.rs
@@ -41,6 +41,7 @@ pub struct TableJoinProcessor {
 }
 
 impl TableJoinProcessor {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         join_type: JoinType,
         compiled_condition: Option<Arc<dyn CompiledCondition>>,

--- a/src/core/query/input/stream/state/count_post_state_processor.rs
+++ b/src/core/query/input/stream/state/count_post_state_processor.rs
@@ -77,6 +77,7 @@ impl CountPostStateProcessor {
     /// stream_events[0] = e1 -> e2 -> e3
     /// count_events_in_chain() = 3
     /// ```
+    #[allow(dead_code)]
     fn count_events_in_chain(&self, state_event: &StateEvent) -> usize {
         use crate::core::event::stream::stream_event::StreamEvent;
 

--- a/src/core/query/input/stream/state/count_pre_state_processor.rs
+++ b/src/core/query/input/stream/state/count_pre_state_processor.rs
@@ -151,13 +151,9 @@ impl PreStateProcessor for CountPreStateProcessor {
     ) -> Option<Box<dyn ComplexEvent>> {
         // Get incoming StreamEvent from chunk
         let stream_event = match chunk.as_ref() {
-            Some(c) => match c
+            Some(c) => c
                 .as_any()
-                .downcast_ref::<crate::core::event::stream::stream_event::StreamEvent>()
-            {
-                Some(se) => se,
-                None => return None,
-            },
+                .downcast_ref::<crate::core::event::stream::stream_event::StreamEvent>()?,
             None => return None,
         };
 
@@ -220,10 +216,7 @@ impl PreStateProcessor for CountPreStateProcessor {
         let stream_cloner = self.stream_processor.get_stream_event_cloner().clone();
 
         // Get post processor for validation
-        let post_processor = match self.stream_processor.get_this_state_post_processor() {
-            Some(p) => p,
-            None => return None, // No post processor, can't validate count
-        };
+        let post_processor = self.stream_processor.get_this_state_post_processor()?;
 
         let mut any_state_completed = false;
 
@@ -1135,6 +1128,7 @@ mod tests {
         outputs: Arc<Mutex<Vec<StateEvent>>>,
     }
 
+    #[allow(dead_code)]
     impl OutputTracker {
         fn new() -> Self {
             Self {
@@ -1192,7 +1186,7 @@ mod tests {
         let state_factory = StateEventFactory::new(1, 0);
         let state_cloner = StateEventCloner::new(&meta_state, state_factory);
 
-        let stream_pre_state = StreamPreState::new();
+        let _stream_pre_state = StreamPreState::new();
 
         let eventflux_context = Arc::new(EventFluxContext::new());
         let app = Arc::new(EventFluxApp::new("TestApp".to_string()));
@@ -1524,7 +1518,7 @@ mod tests {
         pre_proc.update_state();
 
         // Send events with specific timestamps
-        let timestamps = vec![1000i64, 2000i64, 3000i64];
+        let timestamps = [1000i64, 2000i64, 3000i64];
         for (i, &ts) in timestamps.iter().enumerate() {
             let mut event = StreamEvent::new(((i + 1) * 100) as i64, 0, 0, 0);
             event.timestamp = ts;
@@ -1719,7 +1713,7 @@ mod tests {
         let state_factory = StateEventFactory::new(1, 0);
         let state_cloner = StateEventCloner::new(&meta_state, state_factory);
 
-        let stream_pre_state = StreamPreState::new();
+        let _stream_pre_state = StreamPreState::new();
 
         let eventflux_context = Arc::new(EventFluxContext::new());
         let app = Arc::new(EventFluxApp::new("TestApp".to_string()));

--- a/src/core/query/input/stream/state/logical_post_state_processor.rs
+++ b/src/core/query/input/stream/state/logical_post_state_processor.rs
@@ -157,7 +157,7 @@ impl LogicalPostStateProcessor {
                     // Partner not matched yet, just mark state changed
                     // Don't forward yet - waiting for both sides
                     if let Some(this_pre) = self.base_processor.this_state_pre_processor.as_ref() {
-                        if let Ok(mut guard) = this_pre.lock() {
+                        if let Ok(guard) = this_pre.lock() {
                             guard.state_changed();
                         }
                     }

--- a/src/core/query/input/stream/state/logical_pre_state_processor.rs
+++ b/src/core/query/input/stream/state/logical_pre_state_processor.rs
@@ -374,7 +374,7 @@ impl PreStateProcessor for LogicalPreStateProcessor {
         };
 
         let state_id = self.base_processor.state_id();
-        let mut state = self.base_processor.state.lock().unwrap();
+        let state = self.base_processor.state.lock().unwrap();
         let pending_states: Vec<StateEvent> = state.get_pending_list().iter().cloned().collect();
         drop(state); // Release lock before processing
 

--- a/src/core/query/input/stream/state/pattern_chain_builder.rs
+++ b/src/core/query/input/stream/state/pattern_chain_builder.rs
@@ -567,7 +567,6 @@ impl ProcessorChain {
         use crate::core::event::state::meta_state_event::MetaStateEvent;
         use crate::core::event::state::state_event_cloner::StateEventCloner;
         use crate::core::event::state::state_event_factory::StateEventFactory;
-        use crate::core::event::stream::meta_stream_event::MetaStreamEvent;
         use crate::core::event::stream::stream_event_cloner::StreamEventCloner;
         use crate::core::event::stream::stream_event_factory::StreamEventFactory;
 
@@ -581,7 +580,6 @@ impl ProcessorChain {
                 stream_defs[0].clone() // Fallback to first def
             };
 
-            let meta_stream = MetaStreamEvent::new_for_single_input(stream_def.clone());
             // Use attribute count from stream definition for before_window_data size
             // (new_for_single_input puts attrs in output_data but we need before_window_data)
             let attr_count = stream_def.abstract_definition.attribute_list.len();

--- a/src/core/query/input/stream/state/pre_state_processor.rs
+++ b/src/core/query/input/stream/state/pre_state_processor.rs
@@ -254,11 +254,12 @@ mod tests {
     use super::*;
     use crate::core::config::eventflux_app_context::EventFluxAppContext;
     use crate::core::config::eventflux_query_context::EventFluxQueryContext;
-    use crate::core::query::processor::{CommonProcessorMeta, ProcessingMode};
+
     use std::sync::{Arc, Mutex};
 
     // ===== Mock Implementation for Testing =====
 
+    #[allow(dead_code)]
     #[derive(Debug)]
     struct MockPreStateProcessor {
         app_context: Arc<EventFluxAppContext>,
@@ -511,7 +512,7 @@ mod tests {
 
     #[test]
     fn test_state_changed() {
-        let mut processor = MockPreStateProcessor::new(0, true);
+        let processor = MockPreStateProcessor::new(0, true);
         assert!(!processor.has_state_changed());
         processor.state_changed();
         assert!(processor.has_state_changed());

--- a/src/core/query/input/stream/state/stream_post_state_processor.rs
+++ b/src/core/query/input/stream/state/stream_post_state_processor.rs
@@ -157,6 +157,7 @@ impl StreamPostStateProcessor {
     /// 3. Notify thisStatePreProcessor that state changed
     /// 4. Forward StateEvent to next/every/callback processors
     /// 5. Mark event as returned if output processor exists
+    ///
     /// Made public for LogicalPostStateProcessor to call
     pub fn process_state_event(&mut self, state_event: &StateEvent) {
         // Get the StreamEvent at this state position

--- a/src/core/query/input/stream/state/stream_pre_state_processor.rs
+++ b/src/core/query/input/stream/state/stream_pre_state_processor.rs
@@ -127,6 +127,7 @@ pub struct StreamPreStateProcessor {
     // This enables cross-stream references like: e2[price > e1.price]
     // The current event being evaluated is already in StateEvent at position self.state_id
     // Uses Arc for shareability across clones (partitioned execution, state restoration)
+    #[allow(clippy::type_complexity)]
     condition_fn: Option<Arc<dyn Fn(&StateEvent) -> bool + Send + Sync>>,
 }
 
@@ -318,12 +319,10 @@ impl StreamPreStateProcessor {
             }
         } else {
             // Fallback: check first non-null event (legacy behavior)
-            for stream_opt in &state_event.stream_events {
-                if let Some(stream) = stream_opt {
-                    let age = (current_timestamp - stream.timestamp).abs();
-                    if age > within {
-                        return true;
-                    }
+            for stream in state_event.stream_events.iter().flatten() {
+                let age = (current_timestamp - stream.timestamp).abs();
+                if age > within {
+                    return true;
                 }
             }
         }
@@ -1046,10 +1045,9 @@ mod tests {
         // Condition: price > 100 (accessing from position 0 in StateEvent)
         processor.set_condition(|state_event| {
             if let Some(stream_event) = state_event.get_stream_event(0) {
-                if let Some(value) = stream_event.before_window_data.get(0) {
-                    if let AttributeValue::Float(price) = value {
-                        return *price > 100.0;
-                    }
+                if let Some(AttributeValue::Float(price)) = stream_event.before_window_data.first()
+                {
+                    return *price > 100.0;
                 }
             }
             false
@@ -1150,7 +1148,7 @@ mod tests {
 
     #[test]
     fn test_state_changed_flag() {
-        let mut processor = create_test_processor(0, true, StateType::Pattern);
+        let processor = create_test_processor(0, true, StateType::Pattern);
         assert!(!processor.has_state_changed());
 
         processor.state_changed();

--- a/src/core/query/input/stream/state/timers/timer_wheel.rs
+++ b/src/core/query/input/stream/state/timers/timer_wheel.rs
@@ -46,7 +46,7 @@
 /// # Example
 /// ```ignore
 /// use eventflux::core::query::input::stream::state::TimerWheel;
-/// let mut wheel = TimerWheel::new(3600_000, 1000); // 1 hour, 1-second ticks
+/// let mut wheel = TimerWheel::new(3_600_000, 1000); // 1 hour, 1-second ticks
 /// wheel.set_start_time(0);
 /// wheel.schedule(state_handle, trigger_at_ms);
 /// let expired = wheel.advance_to(current_time_ms);
@@ -69,12 +69,12 @@ impl<T> TimerWheel<T> {
     /// Create new timer wheel
     ///
     /// # Arguments
-    /// - `duration_ms`: Total time span covered (e.g., 3600_000 for 1 hour)
+    /// - `duration_ms`: Total time span covered (e.g., 3_600_000 for 1 hour)
     /// - `tick_ms`: Time per bucket (e.g., 1000 for 1 second)
     ///
     /// # Buckets
     /// - num_buckets = duration_ms / tick_ms
-    /// - Example: 3600_000 / 1000 = 3600 buckets (1 hour at 1-second resolution)
+    /// - Example: 3_600_000 / 1000 = 3600 buckets (1 hour at 1-second resolution)
     ///
     /// # Trade-offs
     /// - More buckets: Higher resolution, more memory
@@ -137,14 +137,14 @@ impl<T> TimerWheel<T> {
         // Edge case: if current_index == target_index, collect items at current bucket
         // This handles items scheduled at exactly current_time
         if self.current_index == target_index {
-            triggered.extend(self.buckets[self.current_index].drain(..));
+            triggered.append(&mut self.buckets[self.current_index]);
             return triggered;
         }
 
         // Advance wheel, collect expired items from each passed bucket
         while self.current_index != target_index {
             self.current_index = (self.current_index + 1) % self.buckets.len();
-            triggered.extend(self.buckets[self.current_index].drain(..));
+            triggered.append(&mut self.buckets[self.current_index]);
         }
 
         triggered
@@ -271,7 +271,7 @@ mod tests {
     fn test_timer_wheel_performance_10k_schedules() {
         use std::time::Instant;
 
-        let mut wheel = TimerWheel::new(3600_000, 1000); // 1 hour, 1-second ticks
+        let mut wheel = TimerWheel::new(3_600_000, 1000); // 1 hour, 1-second ticks
         wheel.set_start_time(0);
 
         // Schedule 10,000 items
@@ -290,7 +290,7 @@ mod tests {
 
     #[test]
     fn test_timer_wheel_o1_advance() {
-        let mut wheel = TimerWheel::new(3600_000, 1000);
+        let mut wheel = TimerWheel::new(3_600_000, 1000);
         wheel.set_start_time(0);
 
         // Schedule many items

--- a/src/core/query/input/stream/state/util/event_store.rs
+++ b/src/core/query/input/stream/state/util/event_store.rs
@@ -264,7 +264,7 @@ mod tests {
 
         let id = store.insert(event);
         let ref1 = store.get(id).unwrap();
-        let ref2 = store.get(id).unwrap();
+        let _ref2 = store.get(id).unwrap();
 
         // Both references point to same Arc
         assert_eq!(Arc::strong_count(&ref1), 3); // store + ref1 + ref2
@@ -342,7 +342,7 @@ mod tests {
         assert!(successful_inserts > 50);
         // Memory should be close to limit (within one event size)
         let memory_used = store.memory_usage_bytes();
-        assert!(memory_used >= 9_000 && memory_used <= 10_116); // Within limit + 1 event
+        assert!((9_000..=10_116).contains(&memory_used)); // Within limit + 1 event
 
         println!(
             "Inserted {} events using {} bytes before hitting 10KB limit",

--- a/src/core/query/output/insert_into_table_processor.rs
+++ b/src/core/query/output/insert_into_table_processor.rs
@@ -46,7 +46,11 @@ impl Processor for InsertIntoTableProcessor {
         while let Some(mut event) = chunk {
             let next = event.set_next(None);
             if let Some(data) = event.get_output_data() {
-                self.table.insert(data);
+                if let Err(e) = self.table.insert(data) {
+                    log::error!("Failed to insert into table: {}", e);
+                    // Best-effort: processor continues so the pipeline is not stalled.
+                    // TODO: Route to error handler / DLQ when error infrastructure is wired.
+                }
             }
             chunk = next;
         }

--- a/src/core/query/processor/stream/window/external_time_window_state_holder.rs
+++ b/src/core/query/processor/stream/window/external_time_window_state_holder.rs
@@ -36,6 +36,7 @@ use crate::core::util::compression::{
 
 /// Enhanced state holder for ExternalTimpleWindowProcessor with StateHolder capabilities
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 pub struct ExternalTimeWindowStateHolder {
     /// Window buffer containing events
     buffer: Arc<Mutex<VecDeque<Arc<StreamEvent>>>>,
@@ -56,6 +57,7 @@ pub struct ExternalTimeWindowStateHolder {
     total_events_processed: Arc<Mutex<u64>>,
 }
 
+#[allow(dead_code)]
 impl ExternalTimeWindowStateHolder {
     /// Create a new enhanced state holder
     pub fn new(
@@ -189,7 +191,7 @@ impl StateHolder for ExternalTimeWindowStateHolder {
         };
 
         // Serialize to bytes
-        let mut data = to_bytes(&state_data).map_err(|e| StateError::SerializationError {
+        let data = to_bytes(&state_data).map_err(|e| StateError::SerializationError {
             message: format!("Failed to serialize external time window state: {e}"),
         })?;
 

--- a/src/core/query/processor/stream/window/length_batch_window_state_holder.rs
+++ b/src/core/query/processor/stream/window/length_batch_window_state_holder.rs
@@ -204,6 +204,7 @@ impl LengthBatchWindowStateHolder {
     }
 
     /// Clear the change log (called after successful checkpoint)
+    #[allow(dead_code)]
     pub fn clear_change_log(&self, checkpoint_id: CheckpointId) {
         let mut change_log = self.change_log.lock().unwrap();
         change_log.clear();
@@ -268,13 +269,9 @@ impl StateHolder for LengthBatchWindowStateHolder {
         let reset_event = {
             let reset_guard = self.reset_event.lock().unwrap();
             if let Some(ref event) = *reset_guard {
-                match self
-                    .serialization_service
+                self.serialization_service
                     .serialize_event_with_strategy(event, storage_strategy.clone())
-                {
-                    Ok(data) => Some(data),
-                    Err(_e) => None, // Skip if serialization fails
-                }
+                    .ok()
             } else {
                 None
             }
@@ -289,7 +286,7 @@ impl StateHolder for LengthBatchWindowStateHolder {
         };
 
         // Serialize to bytes
-        let mut data = to_bytes(&state_data).map_err(|e| StateError::SerializationError {
+        let data = to_bytes(&state_data).map_err(|e| StateError::SerializationError {
             message: format!("Failed to serialize length batch window state: {e}"),
         })?;
 
@@ -378,10 +375,7 @@ impl StateHolder for LengthBatchWindowStateHolder {
         {
             let mut reset_guard = self.reset_event.lock().unwrap();
             *reset_guard = if let Some(serialized_event) = state_data.reset_event {
-                match self.deserialize_event(&serialized_event) {
-                    Ok(event) => Some(event),
-                    Err(_e) => None, // Skip if deserialization fails
-                }
+                self.deserialize_event(&serialized_event).ok()
             } else {
                 None
             };
@@ -674,7 +668,7 @@ mod tests {
         }
 
         let reset_event = Arc::new(Mutex::new(None));
-        let mut holder = LengthBatchWindowStateHolder::new(
+        let holder = LengthBatchWindowStateHolder::new(
             buffer,
             expired,
             reset_event,
@@ -699,12 +693,12 @@ mod tests {
         assert_eq!(expired.len(), 1); // Expired batch events should be restored
 
         // Verify event data integrity
-        if let Some(event) = buffer.get(0) {
+        if let Some(event) = buffer.first() {
             assert_eq!(event.timestamp, 1000);
             assert_eq!(event.before_window_data.len(), 2);
         }
 
-        if let Some(event) = expired.get(0) {
+        if let Some(event) = expired.first() {
             assert_eq!(event.timestamp, 3000);
             assert_eq!(event.before_window_data.len(), 1);
         }

--- a/src/core/query/processor/stream/window/length_window_state_holder.rs
+++ b/src/core/query/processor/stream/window/length_window_state_holder.rs
@@ -75,6 +75,7 @@ impl LengthWindowStateHolder {
     }
 
     /// Record an event addition for incremental checkpointing
+    #[allow(dead_code)]
     pub fn record_event_added(&self, event: &StreamEvent) {
         let mut change_log = self.change_log.lock().unwrap();
         let event_data = self.serialize_event(event);
@@ -89,6 +90,7 @@ impl LengthWindowStateHolder {
     }
 
     /// Record an event removal for incremental checkpointing
+    #[allow(dead_code)]
     pub fn record_event_removed(&self, event: &StreamEvent) {
         let mut change_log = self.change_log.lock().unwrap();
         let event_data = self.serialize_event(event);
@@ -100,6 +102,7 @@ impl LengthWindowStateHolder {
     }
 
     /// Generate a unique key for an event
+    #[allow(dead_code)]
     fn generate_event_key(&self, event: &StreamEvent) -> Vec<u8> {
         // Use timestamp and a hash of the event data as key
         let mut key = Vec::new();
@@ -113,6 +116,7 @@ impl LengthWindowStateHolder {
     }
 
     /// Simple hash function for event data
+    #[allow(dead_code)]
     fn hash_event_data(&self, data: &[crate::core::event::value::AttributeValue]) -> u64 {
         use std::collections::hash_map::DefaultHasher;
         use std::hash::{Hash, Hasher};
@@ -171,6 +175,7 @@ impl LengthWindowStateHolder {
     }
 
     /// Clear the change log (called after successful checkpoint)
+    #[allow(dead_code)]
     pub fn clear_change_log(&self, checkpoint_id: CheckpointId) {
         let mut change_log = self.change_log.lock().unwrap();
         change_log.clear();
@@ -420,7 +425,7 @@ mod tests {
             buf.push_back(Arc::new(event));
         }
 
-        let mut holder = LengthWindowStateHolder::new(buffer, "test_length_window".to_string(), 10);
+        let holder = LengthWindowStateHolder::new(buffer, "test_length_window".to_string(), 10);
 
         let hints = SerializationHints::default();
 

--- a/src/core/query/processor/stream/window/mod.rs
+++ b/src/core/query/processor/stream/window/mod.rs
@@ -693,7 +693,6 @@ impl LengthBatchWindowProcessor {
             Arc::new(Mutex::new(state_holder_clone));
         if let Some(snapshot_service) = app_ctx.get_snapshot_service() {
             snapshot_service.register_state_holder(component_id.clone(), state_holder_arc);
-        } else {
         }
 
         Self {
@@ -2023,12 +2022,15 @@ fn resolve_key_indices(
     if params.is_empty() {
         return Ok(Vec::new());
     }
-    let meta = parse_ctx.stream_meta_map.get(&parse_ctx.default_source)
+    let meta = parse_ctx
+        .stream_meta_map
+        .get(&parse_ctx.default_source)
         .ok_or_else(|| format!("No stream metadata for '{}'", parse_ctx.default_source))?;
     let mut indices = Vec::new();
     for param in params {
         if let Expression::Variable(var) = param {
-            let (idx, _) = meta.find_attribute_info(&var.attribute_name)
+            let (idx, _) = meta
+                .find_attribute_info(&var.attribute_name)
                 .ok_or_else(|| format!("Attribute '{}' not found in stream", var.attribute_name))?;
             indices.push(*idx);
         }
@@ -2044,14 +2046,18 @@ fn generate_composite_key(event: &StreamEvent, key_indices: &[usize]) -> String 
     let mut buf = String::new();
     if key_indices.is_empty() {
         for (i, v) in event.before_window_data.iter().enumerate() {
-            if i > 0 { buf.push('\0'); }
+            if i > 0 {
+                buf.push('\0');
+            }
             let _ = write!(buf, "{}", v);
         }
     } else {
         let mut first = true;
         for &idx in key_indices {
             if let Some(v) = event.before_window_data.get(idx) {
-                if !first { buf.push('\0'); }
+                if !first {
+                    buf.push('\0');
+                }
                 let _ = write!(buf, "{}", v);
                 first = false;
             }
@@ -2126,7 +2132,8 @@ impl Processor for UniqueWindowProcessor {
                     if let Some(se) = ev.as_any().downcast_ref::<StreamEvent>() {
                         let key = generate_composite_key(se, &self.key_attribute_indices);
 
-                        if let Some(old_event) = map.insert(key, Arc::new(se.clone_without_next())) {
+                        if let Some(old_event) = map.insert(key, Arc::new(se.clone_without_next()))
+                        {
                             // Expire the old event with the same key
                             let mut ex = old_event.as_ref().clone_without_next();
                             ex.set_event_type(ComplexEventType::Expired);
@@ -2345,9 +2352,9 @@ impl WindowProcessorFactory for FirstUniqueWindowFactory {
         query_ctx: Arc<EventFluxQueryContext>,
         parse_ctx: &crate::core::util::parser::expression_parser::ExpressionParserContext,
     ) -> Result<Arc<Mutex<dyn Processor>>, String> {
-        Ok(Arc::new(Mutex::new(FirstUniqueWindowProcessor::from_handler(
-            handler, app_ctx, query_ctx, parse_ctx,
-        )?)))
+        Ok(Arc::new(Mutex::new(
+            FirstUniqueWindowProcessor::from_handler(handler, app_ctx, query_ctx, parse_ctx)?,
+        )))
     }
 
     fn clone_box(&self) -> Box<dyn WindowProcessorFactory> {
@@ -2435,7 +2442,9 @@ impl DelayWindowProcessor {
             };
             let processor = Self::new(delay, app_ctx, query_ctx);
             if processor.scheduler.is_none() {
-                return Err("Delay window requires a scheduler (not available in this context)".to_string());
+                return Err(
+                    "Delay window requires a scheduler (not available in this context)".to_string(),
+                );
             }
             Ok(processor)
         } else {
@@ -2476,7 +2485,9 @@ impl Processor for DelayWindowProcessor {
     }
 
     fn clone_processor(&self, query_ctx: &Arc<EventFluxQueryContext>) -> Box<dyn Processor> {
-        let scheduler = self.scheduler.as_ref()
+        let scheduler = self
+            .scheduler
+            .as_ref()
             .expect("DelayWindowProcessor invariant violated: scheduler missing during clone")
             .clone();
         Box::new(Self::new_cloned(
@@ -2618,7 +2629,8 @@ impl Processor for FrequentWindowProcessor {
                         let key = generate_composite_key(se, &self.key_attribute_indices);
                         let cloned = Arc::new(se.clone_without_next());
 
-                        if let Some(old) = state.event_map.insert(key.clone(), Arc::clone(&cloned)) {
+                        if let Some(old) = state.event_map.insert(key.clone(), Arc::clone(&cloned))
+                        {
                             // Key exists — replacement policy: expire old, emit new
                             *state.count_map.entry(key).or_insert(0) += 1;
                             let mut ex = old.as_ref().clone_without_next();
@@ -2647,7 +2659,8 @@ impl Processor for FrequentWindowProcessor {
                                         ex.set_event_type(ComplexEventType::Expired);
                                         ex.set_timestamp(se.timestamp);
                                         *output_tail = Some(Box::new(ex));
-                                        output_tail = output_tail.as_mut().unwrap().mut_next_ref_option();
+                                        output_tail =
+                                            output_tail.as_mut().unwrap().mut_next_ref_option();
                                     }
                                 }
 
@@ -2657,7 +2670,8 @@ impl Processor for FrequentWindowProcessor {
                                 } else {
                                     state.count_map.insert(key, 1);
                                     *output_tail = Some(Box::new(se.clone_without_next()));
-                                    output_tail = output_tail.as_mut().unwrap().mut_next_ref_option();
+                                    output_tail =
+                                        output_tail.as_mut().unwrap().mut_next_ref_option();
                                 }
                             } else {
                                 state.count_map.insert(key, 1);
@@ -2840,7 +2854,13 @@ impl LossyFrequentWindowProcessor {
         // Resolve optional key attribute indices from remaining parameters
         let key_attribute_indices = resolve_key_indices(&params[key_params_start..], parse_ctx)?;
 
-        Ok(Self::new(support, error, key_attribute_indices, app_ctx, query_ctx))
+        Ok(Self::new(
+            support,
+            error,
+            key_attribute_indices,
+            app_ctx,
+            query_ctx,
+        ))
     }
 }
 
@@ -2868,16 +2888,21 @@ impl Processor for LossyFrequentWindowProcessor {
                             lc.count += 1;
                         } else {
                             let bucket_id = state.current_bucket_id.saturating_sub(1);
-                            state.count_map.insert(key.clone(), LossyCount {
-                                count: 1,
-                                bucket_id,
-                            });
+                            state.count_map.insert(
+                                key.clone(),
+                                LossyCount {
+                                    count: 1,
+                                    bucket_id,
+                                },
+                            );
                         }
 
                         // Check threshold to decide window membership
                         let threshold = (self.support - self.error) * (state.total_count as f64);
-                        let meets_threshold = state.count_map.get(&key)
-                            .map_or(false, |lc| lc.count as f64 >= threshold);
+                        let meets_threshold = state
+                            .count_map
+                            .get(&key)
+                            .is_some_and(|lc| lc.count as f64 >= threshold);
                         let was_in_window = state.event_map.contains_key(&key);
 
                         if meets_threshold {
@@ -2909,7 +2934,9 @@ impl Processor for LossyFrequentWindowProcessor {
                         // Prune if at window boundary
                         if state.total_count % self.window_width == 0 {
                             let bucket_id = state.current_bucket_id;
-                            let keys_to_remove: Vec<String> = state.count_map.iter()
+                            let keys_to_remove: Vec<String> = state
+                                .count_map
+                                .iter()
                                 .filter(|(_, lc)| lc.count + lc.bucket_id <= bucket_id)
                                 .map(|(k, _)| k.clone())
                                 .collect();
@@ -2920,7 +2947,8 @@ impl Processor for LossyFrequentWindowProcessor {
                                     ex.set_event_type(ComplexEventType::Expired);
                                     ex.set_timestamp(se.timestamp);
                                     *output_tail = Some(Box::new(ex));
-                                    output_tail = output_tail.as_mut().unwrap().mut_next_ref_option();
+                                    output_tail =
+                                        output_tail.as_mut().unwrap().mut_next_ref_option();
                                 }
                             }
                         }
@@ -2990,9 +3018,9 @@ impl WindowProcessorFactory for LossyFrequentWindowFactory {
         query_ctx: Arc<EventFluxQueryContext>,
         parse_ctx: &crate::core::util::parser::expression_parser::ExpressionParserContext,
     ) -> Result<Arc<Mutex<dyn Processor>>, String> {
-        Ok(Arc::new(Mutex::new(LossyFrequentWindowProcessor::from_handler(
-            handler, app_ctx, query_ctx, parse_ctx,
-        )?)))
+        Ok(Arc::new(Mutex::new(
+            LossyFrequentWindowProcessor::from_handler(handler, app_ctx, query_ctx, parse_ctx)?,
+        )))
     }
 
     fn clone_box(&self) -> Box<dyn WindowProcessorFactory> {
@@ -3047,7 +3075,10 @@ impl ExpressionWindowProcessor {
             if rest.starts_with("<=") {
                 rest.trim_start_matches("<=").trim().parse().ok()
             } else if rest.starts_with("<") {
-                rest.trim_start_matches("<").trim().parse::<usize>().ok()
+                rest.trim_start_matches("<")
+                    .trim()
+                    .parse::<usize>()
+                    .ok()
                     .map(|n| n.saturating_sub(1))
             } else {
                 None
@@ -3110,7 +3141,8 @@ impl Processor for ExpressionWindowProcessor {
                                         ex.set_event_type(ComplexEventType::Expired);
                                         ex.set_timestamp(se.timestamp);
                                         *output_tail = Some(Box::new(ex));
-                                        output_tail = output_tail.as_mut().unwrap().mut_next_ref_option();
+                                        output_tail =
+                                            output_tail.as_mut().unwrap().mut_next_ref_option();
                                     }
                                 }
                             }
@@ -3183,9 +3215,9 @@ impl WindowProcessorFactory for ExpressionWindowFactory {
         query_ctx: Arc<EventFluxQueryContext>,
         parse_ctx: &crate::core::util::parser::expression_parser::ExpressionParserContext,
     ) -> Result<Arc<Mutex<dyn Processor>>, String> {
-        Ok(Arc::new(Mutex::new(ExpressionWindowProcessor::from_handler(
-            handler, app_ctx, query_ctx, parse_ctx,
-        )?)))
+        Ok(Arc::new(Mutex::new(
+            ExpressionWindowProcessor::from_handler(handler, app_ctx, query_ctx, parse_ctx)?,
+        )))
     }
 
     fn clone_box(&self) -> Box<dyn WindowProcessorFactory> {

--- a/src/core/query/processor/stream/window/session_window_processor.rs
+++ b/src/core/query/processor/stream/window/session_window_processor.rs
@@ -598,7 +598,7 @@ impl SessionEventChunk {
 mod tests {
     use super::*;
     use crate::core::event::stream::StreamEvent;
-    use crate::core::event::value::AttributeValue;
+
     use std::sync::Arc;
 
     #[test]

--- a/src/core/query/processor/stream/window/session_window_state_holder.rs
+++ b/src/core/query/processor/stream/window/session_window_state_holder.rs
@@ -77,6 +77,7 @@ struct SerializableSessionState {
 
 /// Enhanced state holder for SessionWindowProcessor with StateHolder capabilities
 #[derive(Debug)]
+#[allow(dead_code)]
 pub struct SessionWindowStateHolder {
     /// Reference to the session window's state
     state: Arc<Mutex<SessionWindowState>>,
@@ -101,6 +102,7 @@ pub struct SessionWindowStateHolder {
     total_events_processed: Arc<Mutex<u64>>,
 }
 
+#[allow(dead_code)]
 impl SessionWindowStateHolder {
     /// Create a new enhanced state holder
     pub fn new(
@@ -667,7 +669,7 @@ mod tests {
     #[test]
     fn test_serialize_deserialize_empty_state() {
         let state = Arc::new(Mutex::new(SessionWindowState::new()));
-        let mut holder = SessionWindowStateHolder::new(
+        let holder = SessionWindowStateHolder::new(
             state.clone(),
             "test_session_window".to_string(),
             5000,
@@ -712,7 +714,7 @@ mod tests {
                 .insert("session1".to_string(), container);
         }
 
-        let mut holder = SessionWindowStateHolder::new(
+        let holder = SessionWindowStateHolder::new(
             state.clone(),
             "test_session_window".to_string(),
             5000,
@@ -936,8 +938,10 @@ mod tests {
         );
 
         // Serialize WITHOUT compression
-        let mut hints = SerializationHints::default();
-        hints.prefer_compression = Some(CompressionType::None); // Explicitly request no compression
+        let hints = SerializationHints {
+            prefer_compression: Some(CompressionType::None), // Explicitly request no compression
+            ..Default::default()
+        };
         let snapshot = holder.serialize_state(&hints).unwrap();
         assert_eq!(snapshot.compression, CompressionType::None);
     }
@@ -1001,7 +1005,7 @@ mod tests {
         }
 
         println!("Creating SessionWindowStateHolder");
-        let mut holder = SessionWindowStateHolder::new(
+        let holder = SessionWindowStateHolder::new(
             state.clone(),
             "test_session_window".to_string(),
             5000,
@@ -1010,8 +1014,10 @@ mod tests {
         println!("Created holder");
 
         // Test LZ4 compression
-        let mut hints = SerializationHints::default();
-        hints.prefer_compression = Some(CompressionType::LZ4);
+        let hints = SerializationHints {
+            prefer_compression: Some(CompressionType::LZ4),
+            ..Default::default()
+        };
         println!("Set compression hints");
 
         // Serialize with LZ4 compression
@@ -1072,7 +1078,7 @@ mod tests {
             }
         }
 
-        let mut holder = SessionWindowStateHolder::new(
+        let holder = SessionWindowStateHolder::new(
             state.clone(),
             "test_session_window".to_string(),
             5000,
@@ -1080,8 +1086,10 @@ mod tests {
         );
 
         // Test Snappy compression
-        let mut hints = SerializationHints::default();
-        hints.prefer_compression = Some(CompressionType::Snappy);
+        let hints = SerializationHints {
+            prefer_compression: Some(CompressionType::Snappy),
+            ..Default::default()
+        };
 
         // Serialize with Snappy compression
         let snapshot = holder.serialize_state(&hints).unwrap();
@@ -1143,7 +1151,7 @@ mod tests {
                 .insert("large_session".to_string(), container);
         }
 
-        let mut holder = SessionWindowStateHolder::new(
+        let holder = SessionWindowStateHolder::new(
             state.clone(),
             "test_session_window".to_string(),
             5000,
@@ -1151,8 +1159,10 @@ mod tests {
         );
 
         // Test Zstd compression
-        let mut hints = SerializationHints::default();
-        hints.prefer_compression = Some(CompressionType::Zstd);
+        let hints = SerializationHints {
+            prefer_compression: Some(CompressionType::Zstd),
+            ..Default::default()
+        };
 
         // Serialize with Zstd compression
         let snapshot = holder.serialize_state(&hints).unwrap();
@@ -1226,26 +1236,34 @@ mod tests {
         );
 
         // Test no compression (baseline)
-        let mut hints_none = SerializationHints::default();
-        hints_none.prefer_compression = Some(CompressionType::None);
+        let hints_none = SerializationHints {
+            prefer_compression: Some(CompressionType::None),
+            ..Default::default()
+        };
         let snapshot_none = holder.serialize_state(&hints_none).unwrap();
         let uncompressed_size = snapshot_none.data.len();
 
         // Test LZ4 compression
-        let mut hints_lz4 = SerializationHints::default();
-        hints_lz4.prefer_compression = Some(CompressionType::LZ4);
+        let hints_lz4 = SerializationHints {
+            prefer_compression: Some(CompressionType::LZ4),
+            ..Default::default()
+        };
         let snapshot_lz4 = holder.serialize_state(&hints_lz4).unwrap();
         let lz4_size = snapshot_lz4.data.len();
 
         // Test Snappy compression
-        let mut hints_snappy = SerializationHints::default();
-        hints_snappy.prefer_compression = Some(CompressionType::Snappy);
+        let hints_snappy = SerializationHints {
+            prefer_compression: Some(CompressionType::Snappy),
+            ..Default::default()
+        };
         let snapshot_snappy = holder.serialize_state(&hints_snappy).unwrap();
         let snappy_size = snapshot_snappy.data.len();
 
         // Test Zstd compression
-        let mut hints_zstd = SerializationHints::default();
-        hints_zstd.prefer_compression = Some(CompressionType::Zstd);
+        let hints_zstd = SerializationHints {
+            prefer_compression: Some(CompressionType::Zstd),
+            ..Default::default()
+        };
         let snapshot_zstd = holder.serialize_state(&hints_zstd).unwrap();
         let zstd_size = snapshot_zstd.data.len();
 

--- a/src/core/query/processor/stream/window/sort_window_processor.rs
+++ b/src/core/query/processor/stream/window/sort_window_processor.rs
@@ -146,6 +146,7 @@ impl SortWindowProcessor {
     }
 
     /// Check if memory-optimized processing should be used
+    #[allow(dead_code)]
     fn should_use_memory_optimization(&self) -> bool {
         // For now, return false since we don't have direct access to runtime config
         // TODO: Implement memory optimization detection through config reader

--- a/src/core/query/processor/stream/window/time_batch_window_state_holder.rs
+++ b/src/core/query/processor/stream/window/time_batch_window_state_holder.rs
@@ -240,6 +240,7 @@ impl TimeBatchWindowStateHolder {
     }
 
     /// Clear the change log (called after successful checkpoint)
+    #[allow(dead_code)]
     pub fn clear_change_log(&self, checkpoint_id: CheckpointId) {
         let mut change_log = self.change_log.lock().unwrap();
         change_log.clear();
@@ -306,13 +307,9 @@ impl StateHolder for TimeBatchWindowStateHolder {
         let reset_event = {
             let reset_guard = self.reset_event.lock().unwrap();
             if let Some(ref event) = *reset_guard {
-                match self
-                    .serialization_service
+                self.serialization_service
                     .serialize_event_with_strategy(event, storage_strategy.clone())
-                {
-                    Ok(data) => Some(data),
-                    Err(_e) => None, // Skip if serialization fails
-                }
+                    .ok()
             } else {
                 None
             }
@@ -328,7 +325,7 @@ impl StateHolder for TimeBatchWindowStateHolder {
         };
 
         // Serialize to bytes
-        let mut data = to_bytes(&state_data).map_err(|e| StateError::SerializationError {
+        let data = to_bytes(&state_data).map_err(|e| StateError::SerializationError {
             message: format!("Failed to serialize time batch window state: {e}"),
         })?;
 
@@ -421,10 +418,7 @@ impl StateHolder for TimeBatchWindowStateHolder {
         {
             let mut reset_guard = self.reset_event.lock().unwrap();
             *reset_guard = if let Some(serialized_event) = state_data.reset_event {
-                match self.deserialize_event(&serialized_event) {
-                    Ok(event) => Some(event),
-                    Err(_e) => None, // Skip if deserialization fails
-                }
+                self.deserialize_event(&serialized_event).ok()
             } else {
                 None
             };
@@ -730,7 +724,7 @@ mod tests {
         }
 
         let reset_event = Arc::new(Mutex::new(None));
-        let mut holder = TimeBatchWindowStateHolder::new(
+        let holder = TimeBatchWindowStateHolder::new(
             buffer,
             expired,
             start_time,
@@ -758,12 +752,12 @@ mod tests {
         assert_eq!(start_time, Some(1000));
 
         // Verify event data integrity
-        if let Some(event) = buffer.get(0) {
+        if let Some(event) = buffer.first() {
             assert_eq!(event.timestamp, 1000);
             assert_eq!(event.before_window_data.len(), 2);
         }
 
-        if let Some(event) = expired.get(0) {
+        if let Some(event) = expired.first() {
             assert_eq!(event.timestamp, 3000);
             assert_eq!(event.before_window_data.len(), 1);
         }

--- a/src/core/query/processor/stream/window/time_window_state_holder.rs
+++ b/src/core/query/processor/stream/window/time_window_state_holder.rs
@@ -108,6 +108,7 @@ impl TimeWindowStateHolder {
     }
 
     /// Update window start time
+    #[allow(dead_code)]
     pub fn update_window_start_time(&self, timestamp: i64) {
         *self.window_start_time.lock().unwrap() = Some(timestamp);
     }
@@ -158,6 +159,7 @@ impl TimeWindowStateHolder {
     }
 
     /// Clear the change log (called after successful checkpoint)
+    #[allow(dead_code)]
     pub fn clear_change_log(&self, checkpoint_id: CheckpointId) {
         let mut change_log = self.change_log.lock().unwrap();
         change_log.clear();
@@ -209,7 +211,7 @@ impl StateHolder for TimeWindowStateHolder {
         };
 
         // Serialize to bytes
-        let mut data = to_bytes(&state_data).map_err(|e| StateError::SerializationError {
+        let data = to_bytes(&state_data).map_err(|e| StateError::SerializationError {
             message: format!("Failed to serialize time window state: {e}"),
         })?;
 
@@ -443,7 +445,7 @@ mod tests {
             buf.push_back(Arc::new(event));
         }
 
-        let mut holder = TimeWindowStateHolder::new(buffer, "test_time_window".to_string(), 1000);
+        let holder = TimeWindowStateHolder::new(buffer, "test_time_window".to_string(), 1000);
 
         // Set window start time
         holder.update_window_start_time(900);
@@ -463,7 +465,7 @@ mod tests {
         assert_eq!(buffer.len(), 1); // Window events should be restored
 
         // Verify event data integrity
-        if let Some(event) = buffer.get(0) {
+        if let Some(event) = buffer.front() {
             assert_eq!(event.timestamp, 1000);
             assert_eq!(event.before_window_data.len(), 2);
         }

--- a/src/core/query/selector/attribute/aggregator/and_aggregator_state_holder.rs
+++ b/src/core/query/selector/attribute/aggregator/and_aggregator_state_holder.rs
@@ -196,7 +196,9 @@ impl StateHolder for AndAggregatorStateHolder {
     fn reset_state(&self) {
         *self.true_count.lock().unwrap() = 0;
         *self.false_count.lock().unwrap() = 0;
-        self.base.restored.store(true, std::sync::atomic::Ordering::Release);
+        self.base
+            .restored
+            .store(true, std::sync::atomic::Ordering::Release);
     }
 }
 

--- a/src/core/query/selector/attribute/aggregator/avg_aggregator_state_holder.rs
+++ b/src/core/query/selector/attribute/aggregator/avg_aggregator_state_holder.rs
@@ -222,7 +222,9 @@ impl StateHolder for AvgAggregatorStateHolder {
     fn reset_state(&self) {
         *self.sum.lock().unwrap() = 0.0;
         *self.count.lock().unwrap() = 0;
-        self.base.restored.store(true, std::sync::atomic::Ordering::Release);
+        self.base
+            .restored
+            .store(true, std::sync::atomic::Ordering::Release);
     }
 }
 

--- a/src/core/query/selector/attribute/aggregator/count_aggregator_state_holder.rs
+++ b/src/core/query/selector/attribute/aggregator/count_aggregator_state_holder.rs
@@ -174,7 +174,9 @@ impl StateHolder for CountAggregatorStateHolder {
 
     fn reset_state(&self) {
         *self.count.lock().unwrap() = 0;
-        self.base.restored.store(true, std::sync::atomic::Ordering::Release);
+        self.base
+            .restored
+            .store(true, std::sync::atomic::Ordering::Release);
     }
 }
 

--- a/src/core/query/selector/attribute/aggregator/distinctcount_aggregator_state_holder.rs
+++ b/src/core/query/selector/attribute/aggregator/distinctcount_aggregator_state_holder.rs
@@ -248,7 +248,9 @@ impl StateHolder for DistinctCountAggregatorStateHolder {
 
     fn reset_state(&self) {
         self.map.lock().unwrap().clear();
-        self.base.restored.store(true, std::sync::atomic::Ordering::Release);
+        self.base
+            .restored
+            .store(true, std::sync::atomic::Ordering::Release);
     }
 }
 

--- a/src/core/query/selector/attribute/aggregator/first_aggregator_state_holder.rs
+++ b/src/core/query/selector/attribute/aggregator/first_aggregator_state_holder.rs
@@ -178,7 +178,9 @@ impl StateHolder for FirstAggregatorStateHolder {
 
     fn reset_state(&self) {
         self.values.lock().unwrap().clear();
-        self.base.restored.store(true, std::sync::atomic::Ordering::Release);
+        self.base
+            .restored
+            .store(true, std::sync::atomic::Ordering::Release);
     }
 }
 

--- a/src/core/query/selector/attribute/aggregator/last_aggregator_state_holder.rs
+++ b/src/core/query/selector/attribute/aggregator/last_aggregator_state_holder.rs
@@ -155,7 +155,9 @@ impl StateHolder for LastAggregatorStateHolder {
 
     fn reset_state(&self) {
         *self.last_value.lock().unwrap() = None;
-        self.base.restored.store(true, std::sync::atomic::Ordering::Release);
+        self.base
+            .restored
+            .store(true, std::sync::atomic::Ordering::Release);
     }
 }
 

--- a/src/core/query/selector/attribute/aggregator/max_aggregator_state_holder.rs
+++ b/src/core/query/selector/attribute/aggregator/max_aggregator_state_holder.rs
@@ -204,7 +204,9 @@ impl StateHolder for MaxAggregatorStateHolder {
 
     fn reset_state(&self) {
         *self.value.lock().unwrap() = None;
-        self.base.restored.store(true, std::sync::atomic::Ordering::Release);
+        self.base
+            .restored
+            .store(true, std::sync::atomic::Ordering::Release);
     }
 }
 

--- a/src/core/query/selector/attribute/aggregator/min_aggregator_state_holder.rs
+++ b/src/core/query/selector/attribute/aggregator/min_aggregator_state_holder.rs
@@ -204,7 +204,9 @@ impl StateHolder for MinAggregatorStateHolder {
 
     fn reset_state(&self) {
         *self.value.lock().unwrap() = None;
-        self.base.restored.store(true, std::sync::atomic::Ordering::Release);
+        self.base
+            .restored
+            .store(true, std::sync::atomic::Ordering::Release);
     }
 }
 

--- a/src/core/query/selector/attribute/aggregator/or_aggregator_state_holder.rs
+++ b/src/core/query/selector/attribute/aggregator/or_aggregator_state_holder.rs
@@ -169,7 +169,9 @@ impl StateHolder for OrAggregatorStateHolder {
 
     fn reset_state(&self) {
         *self.true_count.lock().unwrap() = 0;
-        self.base.restored.store(true, std::sync::atomic::Ordering::Release);
+        self.base
+            .restored
+            .store(true, std::sync::atomic::Ordering::Release);
     }
 }
 

--- a/src/core/query/selector/attribute/aggregator/stddev_aggregator_state_holder.rs
+++ b/src/core/query/selector/attribute/aggregator/stddev_aggregator_state_holder.rs
@@ -231,7 +231,9 @@ impl StateHolder for StdDevAggregatorStateHolder {
         *self.m2.lock().unwrap() = 0.0;
         *self.sum.lock().unwrap() = 0.0;
         *self.count.lock().unwrap() = 0;
-        self.base.restored.store(true, std::sync::atomic::Ordering::Release);
+        self.base
+            .restored
+            .store(true, std::sync::atomic::Ordering::Release);
     }
 }
 

--- a/src/core/query/selector/attribute/aggregator/sum_aggregator_state_holder.rs
+++ b/src/core/query/selector/attribute/aggregator/sum_aggregator_state_holder.rs
@@ -223,7 +223,9 @@ impl StateHolder for SumAggregatorStateHolder {
     fn reset_state(&self) {
         *self.sum.lock().unwrap() = 0.0;
         *self.count.lock().unwrap() = 0;
-        self.base.restored.store(true, std::sync::atomic::Ordering::Release);
+        self.base
+            .restored
+            .store(true, std::sync::atomic::Ordering::Release);
     }
 }
 

--- a/src/core/query/selector/select_processor.rs
+++ b/src/core/query/selector/select_processor.rs
@@ -361,6 +361,7 @@ pub struct SelectProcessor {
 }
 
 impl SelectProcessor {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         api_selector: &crate::query_api::execution::query::selection::Selector,
         current_on: bool,

--- a/src/core/stream/input/source/rabbitmq_source.rs
+++ b/src/core/stream/input/source/rabbitmq_source.rs
@@ -111,6 +111,7 @@ impl RabbitMQSourceConfig {
     }
 
     /// Parse configuration from properties HashMap
+    #[allow(clippy::field_reassign_with_default)]
     pub fn from_properties(properties: &HashMap<String, String>) -> Result<Self, String> {
         let mut config = Self::default();
 
@@ -915,7 +916,7 @@ impl SourceFactory for RabbitMQSourceFactory {
             .unwrap_or_else(|| "rabbitmq-source".to_string());
 
         let source = RabbitMQSource::from_properties(config, None, &queue_name)
-            .map_err(|e| EventFluxError::configuration(e))?;
+            .map_err(EventFluxError::configuration)?;
 
         Ok(Box::new(source))
     }

--- a/src/core/stream/input/source/timer_source.rs
+++ b/src/core/stream/input/source/timer_source.rs
@@ -160,6 +160,7 @@ impl TimerSource {
 
     /// Simulate a failure for testing purposes
     #[cfg(test)]
+    #[allow(dead_code)]
     fn simulate_error(&self) -> Result<(), EventFluxError> {
         use rand::Rng;
         if self.simulate_failure_rate > 0.0 {
@@ -176,6 +177,7 @@ impl TimerSource {
 
     /// Check for simulated errors (no-op in non-test builds)
     #[cfg(not(test))]
+    #[allow(dead_code)]
     fn simulate_error(&self) -> Result<(), EventFluxError> {
         Ok(())
     }
@@ -235,7 +237,7 @@ impl Source for TimerSource {
                 match error_result {
                     Ok(_) => {
                         // Success case - serialize event to bytes and deliver via callback
-                        match PassthroughMapper::serialize(&[event.clone()]) {
+                        match PassthroughMapper::serialize(std::slice::from_ref(&event)) {
                             Ok(bytes) => {
                                 if let Err(e) = callback.on_data(&bytes) {
                                     // Handle send error with error context

--- a/src/core/stream/input/source/websocket_source.rs
+++ b/src/core/stream/input/source/websocket_source.rs
@@ -96,6 +96,7 @@ impl Default for WebSocketSourceConfig {
 
 impl WebSocketSourceConfig {
     /// Parse configuration from properties HashMap
+    #[allow(clippy::field_reassign_with_default)]
     pub fn from_properties(properties: &HashMap<String, String>) -> Result<Self, String> {
         let mut config = Self::default();
 
@@ -683,7 +684,7 @@ impl SourceFactory for WebSocketSourceFactory {
             .unwrap_or_else(|| "websocket-source".to_string());
 
         let source = WebSocketSource::from_properties(config, None, &stream_name)
-            .map_err(|e| EventFluxError::configuration(e))?;
+            .map_err(EventFluxError::configuration)?;
 
         Ok(Box::new(source))
     }

--- a/src/core/stream/mapper/bytes_mapper.rs
+++ b/src/core/stream/mapper/bytes_mapper.rs
@@ -242,7 +242,7 @@ mod tests {
         let input = vec![0x00, 0x01, 0xff, 0xfe, 0x80, 0x90, 0xa0, 0xb0];
 
         let events = mapper.map(&input).unwrap();
-        let cloned_events: Vec<Event> = events.iter().map(|e| e.clone()).collect();
+        let cloned_events: Vec<Event> = events.to_vec();
 
         // Verify cloned data is preserved exactly
         if let AttributeValue::Bytes(bytes) = &cloned_events[0].data[0] {

--- a/src/core/stream/mapper/factory.rs
+++ b/src/core/stream/mapper/factory.rs
@@ -149,7 +149,7 @@ pub trait SinkMapperFactory: Debug + Send + Sync {
     fn create_with_schema(
         &self,
         config: &HashMap<String, String>,
-        field_names: &[String],
+        _field_names: &[String],
     ) -> Result<Box<dyn SinkMapper>, EventFluxError> {
         // Default implementation ignores field names
         self.create_initialized(config)
@@ -554,7 +554,7 @@ impl SinkMapperFactory for BytesSinkMapperFactory {
         let field_index = match config.get("bytes.field-index") {
             Some(value) => value.parse::<usize>().map_err(|_| {
                 EventFluxError::invalid_parameter_with_details(
-                    &format!(
+                    format!(
                         "Invalid bytes.field-index value: '{}' is not a valid non-negative integer",
                         value
                     ),

--- a/src/core/stream/mapper/json_mapper.rs
+++ b/src/core/stream/mapper/json_mapper.rs
@@ -138,7 +138,7 @@ impl JsonSourceMapper {
         // Preserve JSON key order (serde_json maintains insertion order)
         // This allows the JSON input to match schema field order
         let mut event_data = Vec::new();
-        for (key, value) in obj.iter() {
+        for (_key, value) in obj.iter() {
             event_data.push(json_value_to_attribute(value, self.date_format.as_deref())?);
         }
 
@@ -425,8 +425,8 @@ pub fn convert_java_date_format(java_format: &str) -> String {
                     chars.next();
                     count += 1;
                 }
-                // HH → %H (24-hour, 00-23)
-                result.push_str("%H");
+                // HH → %H (24-hour with zero-pad), H → %-H (without)
+                result.push_str(if count >= 2 { "%H" } else { "%-H" });
             }
             'h' => {
                 // Count consecutive h's
@@ -435,8 +435,8 @@ pub fn convert_java_date_format(java_format: &str) -> String {
                     chars.next();
                     count += 1;
                 }
-                // hh → %I (12-hour, 01-12)
-                result.push_str("%I");
+                // hh → %I (12-hour with zero-pad), h → %-I (without)
+                result.push_str(if count >= 2 { "%I" } else { "%-I" });
             }
             'm' => {
                 // Count consecutive m's
@@ -445,8 +445,8 @@ pub fn convert_java_date_format(java_format: &str) -> String {
                     chars.next();
                     count += 1;
                 }
-                // mm → %M (minute, 00-59)
-                result.push_str("%M");
+                // mm → %M (minute with zero-pad), m → %-M (without)
+                result.push_str(if count >= 2 { "%M" } else { "%-M" });
             }
             's' => {
                 // Count consecutive s's
@@ -455,8 +455,8 @@ pub fn convert_java_date_format(java_format: &str) -> String {
                     chars.next();
                     count += 1;
                 }
-                // ss → %S (second, 00-59)
-                result.push_str("%S");
+                // ss → %S (second with zero-pad), s → %-S (without)
+                result.push_str(if count >= 2 { "%S" } else { "%-S" });
             }
             'S' => {
                 // Count consecutive S's for milliseconds
@@ -501,6 +501,7 @@ pub fn convert_java_date_format(java_format: &str) -> String {
 /// - `$.nested.field` - Nested field
 /// - `$.array[0]` - Array element
 /// - `$.nested.array[0].field` - Complex path
+///
 /// Extract value from JSON using JSONPath
 ///
 /// # Parameters
@@ -1007,6 +1008,16 @@ mod tests {
         // Java: M/d/yyyy
         // Chrono: %-m/%-d/%Y
         assert_eq!(convert_java_date_format("M/d/yyyy"), "%-m/%-d/%Y");
+    }
+
+    #[test]
+    fn test_convert_java_date_format_single_vs_double_time() {
+        // Single-char specifiers omit leading zero (Java SimpleDateFormat behavior)
+        assert_eq!(convert_java_date_format("H:m:s"), "%-H:%-M:%-S");
+        assert_eq!(convert_java_date_format("HH:mm:ss"), "%H:%M:%S");
+        // 12-hour format
+        assert_eq!(convert_java_date_format("h:m"), "%-I:%-M");
+        assert_eq!(convert_java_date_format("hh:mm"), "%I:%M");
     }
 
     #[test]

--- a/src/core/stream/output/sink/rabbitmq_sink.rs
+++ b/src/core/stream/output/sink/rabbitmq_sink.rs
@@ -108,6 +108,7 @@ impl RabbitMQSinkConfig {
     }
 
     /// Parse configuration from properties HashMap
+    #[allow(clippy::field_reassign_with_default)]
     pub fn from_properties(properties: &HashMap<String, String>) -> Result<Self, String> {
         let mut config = Self::default();
 
@@ -396,19 +397,22 @@ impl Sink for RabbitMQSink {
 
         // Define the async publish operation
         let publish_future = async move {
-            let state_guard = state
-                .lock()
-                .map_err(|_| EventFluxError::app_runtime("State lock poisoned".to_string()))?;
-            let conn_state =
-                state_guard
-                    .as_ref()
-                    .ok_or_else(|| EventFluxError::ConnectionUnavailable {
-                        message: "RabbitMQ sink not started - call start() first".to_string(),
-                        source: None,
-                    })?;
+            // Clone the channel (internally Arc-based) and drop the guard before .await
+            let channel = {
+                let state_guard = state
+                    .lock()
+                    .map_err(|_| EventFluxError::app_runtime("State lock poisoned".to_string()))?;
+                let conn_state =
+                    state_guard
+                        .as_ref()
+                        .ok_or_else(|| EventFluxError::ConnectionUnavailable {
+                            message: "RabbitMQ sink not started - call start() first".to_string(),
+                            source: None,
+                        })?;
+                conn_state.channel.clone()
+            };
 
-            conn_state
-                .channel
+            channel
                 .basic_publish(
                     &exchange,
                     &routing_key,
@@ -464,8 +468,12 @@ impl Sink for RabbitMQSink {
         // Create the shutdown future
         let state = Arc::clone(&self.state);
         let shutdown_future = async move {
-            let mut state_guard = state.lock().unwrap();
-            if let Some(conn_state) = state_guard.take() {
+            // Take the connection state and drop the guard before .await
+            let conn_state = {
+                let mut state_guard = state.lock().unwrap();
+                state_guard.take()
+            };
+            if let Some(conn_state) = conn_state {
                 if let Err(e) = conn_state.channel.close(200, "Normal shutdown").await {
                     log::warn!("[RabbitMQSink] Error closing channel: {}", e);
                 }
@@ -667,8 +675,8 @@ impl SinkFactory for RabbitMQSinkFactory {
         config: &HashMap<String, String>,
     ) -> Result<Box<dyn Sink>, EventFluxError> {
         // Parse and validate configuration
-        let parsed = RabbitMQSinkConfig::from_properties(config)
-            .map_err(|e| EventFluxError::configuration(e))?;
+        let parsed =
+            RabbitMQSinkConfig::from_properties(config).map_err(EventFluxError::configuration)?;
 
         // Create RabbitMQ sink
         let sink = RabbitMQSink::new(parsed);
@@ -789,6 +797,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::field_reassign_with_default)]
     fn test_exchange_kind_conversion() {
         // Test all supported exchange types
         let mut config = RabbitMQSinkConfig::default();

--- a/src/core/stream/output/sink/sink_factory.rs
+++ b/src/core/stream/output/sink/sink_factory.rs
@@ -31,6 +31,12 @@ pub struct SinkFactoryRegistry {
     factories: HashMap<String, Box<dyn SinkFactoryTrait>>,
 }
 
+impl Default for SinkFactoryRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl SinkFactoryRegistry {
     /// Create a new sink factory registry with default factories
     pub fn new() -> Self {

--- a/src/core/stream/output/sink/websocket_sink.rs
+++ b/src/core/stream/output/sink/websocket_sink.rs
@@ -45,32 +45,31 @@ use crate::core::extension::SinkFactory;
 use futures::{SinkExt, StreamExt};
 use std::collections::HashMap;
 use std::fmt::Debug;
+use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tokio::net::TcpStream;
+use tokio::sync::Mutex as TokioMutex;
 use tokio_tungstenite::{
     connect_async, tungstenite::http::Request, tungstenite::protocol::Message, MaybeTlsStream,
     WebSocketStream,
 };
 
 /// Message type for WebSocket sink
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum MessageType {
     /// Send messages as text (UTF-8)
+    #[default]
     Text,
     /// Send messages as binary
     Binary,
 }
 
-impl Default for MessageType {
-    fn default() -> Self {
-        MessageType::Text
-    }
-}
+impl std::str::FromStr for MessageType {
+    type Err = String;
 
-impl MessageType {
     /// Parse from string
-    pub fn from_str(s: &str) -> Result<Self, String> {
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
             "text" => Ok(MessageType::Text),
             "binary" => Ok(MessageType::Binary),
@@ -120,6 +119,7 @@ impl Default for WebSocketSinkConfig {
 
 impl WebSocketSinkConfig {
     /// Build configuration from properties HashMap
+    #[allow(clippy::field_reassign_with_default)]
     pub fn from_properties(properties: &HashMap<String, String>) -> Result<Self, String> {
         let mut config = Self::default();
 
@@ -210,7 +210,8 @@ pub struct WebSocketSink {
     /// Configuration
     config: WebSocketSinkConfig,
     /// Connection state (established in start())
-    state: Arc<Mutex<Option<WebSocketConnectionState>>>,
+    /// Uses tokio::sync::Mutex to safely hold across .await points in publish/stop
+    state: Arc<TokioMutex<Option<WebSocketConnectionState>>>,
     /// Tokio runtime for async operations (owned runtime when created by us)
     runtime: Arc<Mutex<Option<tokio::runtime::Runtime>>>,
     /// Runtime handle for async operations (stored when started inside existing runtime)
@@ -222,7 +223,7 @@ impl WebSocketSink {
     pub fn new(config: WebSocketSinkConfig) -> Self {
         Self {
             config,
-            state: Arc::new(Mutex::new(None)),
+            state: Arc::new(TokioMutex::new(None)),
             runtime: Arc::new(Mutex::new(None)),
             runtime_handle: Arc::new(Mutex::new(None)),
         }
@@ -348,7 +349,7 @@ impl Clone for WebSocketSink {
         // Connection will be established on start()
         Self {
             config: self.config.clone(),
-            state: Arc::new(Mutex::new(None)),
+            state: Arc::new(TokioMutex::new(None)),
             runtime: Arc::new(Mutex::new(None)),
             runtime_handle: Arc::new(Mutex::new(None)),
         }
@@ -365,7 +366,7 @@ impl Sink for WebSocketSink {
             let conn_state = Self::connect(&config).await?;
 
             // Store connection state
-            let mut state_guard = state.lock().unwrap();
+            let mut state_guard = state.lock().await;
             *state_guard = Some(conn_state);
 
             log::info!("[WebSocketSink] Ready to publish to {}", config.url);
@@ -428,13 +429,12 @@ impl Sink for WebSocketSink {
             async move {
                 // Try to send on existing connection
                 {
-                    let mut state_guard = state.lock().unwrap();
+                    let mut state_guard = state.lock().await;
                     if let Some(conn_state) = state_guard.as_mut() {
                         match conn_state.write.send(message.clone()).await {
                             Ok(()) => return Ok(()),
                             Err(e) => {
                                 log::warn!("[WebSocketSink] Send failed, will reconnect: {}", e);
-                                // Clear the state to trigger reconnection
                                 *state_guard = None;
                             }
                         }
@@ -452,7 +452,7 @@ impl Sink for WebSocketSink {
                     })?;
 
                     // Store the new connection
-                    let mut state_guard = state.lock().unwrap();
+                    let mut state_guard = state.lock().await;
                     *state_guard = Some(conn_state);
 
                     Ok(())
@@ -500,11 +500,13 @@ impl Sink for WebSocketSink {
 
         let state = Arc::clone(&self.state);
 
-        // Create the shutdown future
+        // Create the shutdown future — take state first so it's cleaned up even if close fails
         let shutdown_future = async move {
-            let mut state_guard = state.lock().unwrap();
-            if let Some(mut conn_state) = state_guard.take() {
-                // Send close frame
+            let conn_state = {
+                let mut state_guard = state.lock().await;
+                state_guard.take()
+            };
+            if let Some(mut conn_state) = conn_state {
                 if let Err(e) = conn_state.write.close().await {
                     log::warn!("[WebSocketSink] Error closing connection: {}", e);
                 }
@@ -633,8 +635,8 @@ impl SinkFactory for WebSocketSinkFactory {
         &self,
         config: &HashMap<String, String>,
     ) -> Result<Box<dyn Sink>, EventFluxError> {
-        let parsed = WebSocketSinkConfig::from_properties(config)
-            .map_err(|e| EventFluxError::configuration(e))?;
+        let parsed =
+            WebSocketSinkConfig::from_properties(config).map_err(EventFluxError::configuration)?;
 
         let sink = WebSocketSink::new(parsed);
 
@@ -830,7 +832,8 @@ mod tests {
         assert!(!cloned.config.reconnect);
         assert_eq!(cloned.config.message_type, MessageType::Binary);
         // Cloned sink should not have connection state
-        assert!(cloned.state.lock().unwrap().is_none());
+        // tokio::sync::Mutex::try_lock() for sync test context
+        assert!(cloned.state.try_lock().unwrap().is_none());
     }
 
     // =========================================================================

--- a/src/core/stream/stream_initializer.rs
+++ b/src/core/stream/stream_initializer.rs
@@ -499,10 +499,7 @@ fn build_dependency_graph(
         if let Some(target) = query.get_target_stream() {
             let sources = query.get_source_streams();
 
-            dependencies
-                .entry(target)
-                .or_insert_with(HashSet::new)
-                .extend(sources);
+            dependencies.entry(target).or_default().extend(sources);
         }
     }
 
@@ -512,7 +509,7 @@ fn build_dependency_graph(
         if let Some(dlq_stream) = config.get("error.dlq.stream") {
             dependencies
                 .entry(stream_name.clone())
-                .or_insert_with(HashSet::new)
+                .or_default()
                 .insert(dlq_stream.clone());
         }
     }
@@ -609,7 +606,7 @@ fn dfs_topo_sort(
 /// 4. DLQ junction wiring (if error.dlq.stream is configured)
 /// 5. SourceStreamHandler for lifecycle management
 fn initialize_source_stream_with_handler(
-    stream_def: &StreamDefinition,
+    _stream_def: &StreamDefinition,
     stream_config: &StreamTypeConfig,
     context: &EventFluxContext,
     input_manager: &crate::core::stream::input::InputManager,
@@ -952,7 +949,7 @@ fn validate_dlq_schema(
     }
 
     // 5. Check for extra fields not in required schema
-    for (actual_name, _) in &actual_fields {
+    for actual_name in actual_fields.keys() {
         if !REQUIRED_DLQ_FIELDS
             .iter()
             .any(|(req_name, _)| req_name == actual_name)
@@ -997,9 +994,7 @@ mod tests {
     use super::*;
     use crate::core::config::stream_config::{FlatConfig, PropertySource};
     use crate::core::extension::example_factories::{HttpSinkFactory, KafkaSourceFactory};
-    use crate::core::extension::{
-        CsvSinkMapperFactory, JsonSinkMapperFactory, JsonSourceMapperFactory,
-    };
+    use crate::core::extension::{CsvSinkMapperFactory, JsonSourceMapperFactory};
 
     #[test]
     fn test_initialize_source_stream_success() {

--- a/src/core/stream/stream_junction.rs
+++ b/src/core/stream/stream_junction.rs
@@ -52,6 +52,7 @@ pub enum OnErrorAction {
 }
 
 /// High-performance event router with crossbeam-based pipeline
+#[allow(clippy::type_complexity)]
 pub struct StreamJunction {
     // Core identification
     pub stream_id: String,
@@ -243,6 +244,7 @@ impl StreamJunction {
     ///
     /// This is a private implementation detail - use `new()` or `new_with_backpressure()`
     /// for production code.
+    #[allow(clippy::too_many_arguments)]
     fn new_with_backpressure_and_executor(
         stream_id: String,
         stream_definition: Arc<StreamDefinition>,
@@ -493,41 +495,38 @@ impl StreamJunction {
                     // CRITICAL: Each slot can contain a linked list of StreamEvents via `next` pointers
                     // (e.g., from count/sequence quantifiers like e1[2] or e1{2,5})
                     // We must traverse the entire chain, not just the head
-                    for stream_event_opt in &state_event.stream_events {
-                        if let Some(stream_event_arc) = stream_event_opt {
-                            // Traverse the chain of StreamEvents at this position
-                            // stream_event_arc is &Arc<StreamEvent>, *stream_event_arc is Arc<StreamEvent> (via Deref)
-                            // which derefs to StreamEvent, so &*stream_event_arc gives &StreamEvent
-                            let stream_event_ref: &crate::core::event::stream::StreamEvent =
-                                &*stream_event_arc;
-                            let mut current_in_chain: Option<
-                                &dyn crate::core::event::ComplexEvent,
-                            > = Some(stream_event_ref);
+                    for stream_event_arc in state_event.stream_events.iter().flatten() {
+                        // Traverse the chain of StreamEvents at this position
+                        // stream_event_arc is &Arc<StreamEvent>, *stream_event_arc is Arc<StreamEvent> (via Deref)
+                        // which derefs to StreamEvent, so &*stream_event_arc gives &StreamEvent
+                        let stream_event_ref: &crate::core::event::stream::StreamEvent =
+                            stream_event_arc;
+                        let mut current_in_chain: Option<&dyn crate::core::event::ComplexEvent> =
+                            Some(stream_event_ref);
 
-                            while let Some(current) = current_in_chain {
-                                // Try to downcast to StreamEvent
-                                if let Some(se) = current
-                                    .as_any()
-                                    .downcast_ref::<crate::core::event::stream::StreamEvent>(
-                                ) {
-                                    let data = se
-                                        .output_data
-                                        .as_ref()
-                                        .unwrap_or(&se.before_window_data)
-                                        .clone();
-                                    let mut event = Event::new_with_data(se.timestamp, data);
-                                    event.is_expired = matches!(
-                                        state_event.event_type,
-                                        crate::core::event::complex_event::ComplexEventType::Expired
-                                    );
-                                    events.push(event);
+                        while let Some(current) = current_in_chain {
+                            // Try to downcast to StreamEvent
+                            if let Some(se) = current
+                                .as_any()
+                                .downcast_ref::<crate::core::event::stream::StreamEvent>(
+                            ) {
+                                let data = se
+                                    .output_data
+                                    .as_ref()
+                                    .unwrap_or(&se.before_window_data)
+                                    .clone();
+                                let mut event = Event::new_with_data(se.timestamp, data);
+                                event.is_expired = matches!(
+                                    state_event.event_type,
+                                    crate::core::event::complex_event::ComplexEventType::Expired
+                                );
+                                events.push(event);
 
-                                    // Move to next in chain
-                                    current_in_chain = se.next.as_ref().map(|b| b.as_ref());
-                                } else {
-                                    // Not a StreamEvent, stop traversing this chain
-                                    break;
-                                }
+                                // Move to next in chain
+                                current_in_chain = se.next.as_ref().map(|b| b.as_ref());
+                            } else {
+                                // Not a StreamEvent, stop traversing this chain
+                                break;
                             }
                         }
                     }
@@ -982,7 +981,7 @@ impl JunctionPerformanceMetrics {
         score -= error_rate * 2.0; // 2x penalty for errors
         score -= drop_rate * 1.5; // 1.5x penalty for drops
 
-        score.max(0.0).min(1.0)
+        score.clamp(0.0, 1.0)
     }
 
     /// Check if metrics indicate healthy operation

--- a/src/core/table/cache_table.rs
+++ b/src/core/table/cache_table.rs
@@ -193,9 +193,8 @@ impl Table for CacheTable {
                 for i in 0..stream_attr_count {
                     joined.before_window_data[i] = stream_event.before_window_data[i].clone();
                 }
-                for j in 0..row.len() {
-                    joined.before_window_data[stream_attr_count + j] = row[j].clone();
-                }
+                joined.before_window_data[stream_attr_count..(row.len() + stream_attr_count)]
+                    .clone_from_slice(&row[..]);
                 if let Some(AttributeValue::Bool(true)) = exec.execute(Some(&joined)) {
                     matched.push(row.clone());
                 }

--- a/src/core/table/jdbc_table.rs
+++ b/src/core/table/jdbc_table.rs
@@ -664,9 +664,8 @@ impl Table for JdbcTable {
                 for i in 0..stream_attr_count {
                     joined.before_window_data[i] = stream_event.before_window_data[i].clone();
                 }
-                for j in 0..vals.len() {
-                    joined.before_window_data[stream_attr_count + j] = vals[j].clone();
-                }
+                joined.before_window_data[stream_attr_count..(vals.len() + stream_attr_count)]
+                    .clone_from_slice(&vals[..]);
                 if let Some(AttributeValue::Bool(true)) = exec.execute(Some(&joined)) {
                     matched.push(vals);
                 }

--- a/src/core/table/mod.rs
+++ b/src/core/table/mod.rs
@@ -379,9 +379,8 @@ pub trait Table: Debug + Send + Sync {
                 for i in 0..stream_attr_count {
                     joined.before_window_data[i] = stream_event.before_window_data[i].clone();
                 }
-                for j in 0..row.len() {
-                    joined.before_window_data[stream_attr_count + j] = row[j].clone();
-                }
+                joined.before_window_data[stream_attr_count..(row.len() + stream_attr_count)]
+                    .clone_from_slice(&row[..]);
                 if let Some(AttributeValue::Bool(true)) = exec.execute(Some(&joined)) {
                     matched.push(row);
                 }
@@ -537,7 +536,7 @@ pub trait Table: Debug + Send + Sync {
         &self,
         stream_event: &StreamEvent,
         condition_executor: &dyn ExpressionExecutor,
-        set_column_indices: &[usize],
+        _set_column_indices: &[usize],
         set_value_executors: &[Box<dyn ExpressionExecutor>],
     ) -> Result<usize, crate::core::exception::EventFluxError> {
         // Fallback: If no SET executors (simple case), delegate to update_with_expression
@@ -550,13 +549,15 @@ pub trait Table: Debug + Send + Sync {
 
         // Dynamic SET expressions require table-specific atomic implementation
         // to prevent data loss from non-atomic delete-then-insert patterns
-        Err(crate::core::exception::EventFluxError::OperationNotSupported {
-            message: "UPDATE with SET expressions referencing table columns requires \
+        Err(
+            crate::core::exception::EventFluxError::OperationNotSupported {
+                message: "UPDATE with SET expressions referencing table columns requires \
                      table-specific implementation. Override update_with_set_executors() \
                      in your Table implementation. See InMemoryTable for reference."
-                .to_string(),
-            operation: Some("update_with_set_executors".to_string()),
-        })
+                    .to_string(),
+                operation: Some("update_with_set_executors".to_string()),
+            },
+        )
     }
 
     /// Delete rows matching a condition expression when evaluated against stream event + table row.
@@ -655,7 +656,7 @@ pub trait Table: Debug + Send + Sync {
         &self,
         stream_event: &StreamEvent,
         condition_executor: &dyn ExpressionExecutor,
-        set_column_indices: &[usize],
+        _set_column_indices: &[usize],
         set_value_executors: &[Box<dyn ExpressionExecutor>],
     ) -> Result<(usize, usize), crate::core::exception::EventFluxError> {
         // Fallback: If no SET executors (simple UPSERT), try find-then-update/insert pattern
@@ -673,11 +674,8 @@ pub trait Table: Debug + Send + Sync {
             }
 
             // Find matching rows using the condition
-            let matched = find_matching_rows_for_mutation(
-                self.all_rows()?,
-                stream_event,
-                condition_executor,
-            );
+            let matched =
+                find_matching_rows_for_mutation(self.all_rows()?, stream_event, condition_executor);
 
             if matched.is_empty() {
                 // No match - insert
@@ -688,9 +686,7 @@ pub trait Table: Debug + Send + Sync {
                 let cond = InMemoryCompiledCondition {
                     values: matched[0].clone(),
                 };
-                let us = InMemoryCompiledUpdateSet {
-                    values: new_values,
-                };
+                let us = InMemoryCompiledUpdateSet { values: new_values };
                 if self.update(&cond, &us)? {
                     return Ok((1, 0));
                 }
@@ -699,13 +695,15 @@ pub trait Table: Debug + Send + Sync {
         }
 
         // Dynamic SET expressions require table-specific atomic implementation
-        Err(crate::core::exception::EventFluxError::OperationNotSupported {
-            message: "UPSERT with SET expressions referencing table columns requires \
+        Err(
+            crate::core::exception::EventFluxError::OperationNotSupported {
+                message: "UPSERT with SET expressions referencing table columns requires \
                      table-specific implementation. Override upsert_with_set_executors() \
                      in your Table implementation. See InMemoryTable for reference."
-                .to_string(),
-            operation: Some("upsert_with_set_executors".to_string()),
-        })
+                    .to_string(),
+                operation: Some("upsert_with_set_executors".to_string()),
+            },
+        )
     }
 
     /// Clone helper for boxed trait objects.
@@ -922,7 +920,7 @@ impl Table for InMemoryTable {
 
         // Update index: add this row's index to the key's index list
         let mut index = self.index.write().unwrap();
-        index.entry(key).or_insert_with(Vec::new).push(new_index);
+        index.entry(key).or_default().push(new_index);
         Ok(())
     }
 
@@ -976,10 +974,7 @@ impl Table for InMemoryTable {
 
         // Update index: remove old key entries, add new key entries
         index.remove(&old_key);
-        index
-            .entry(new_key)
-            .or_insert_with(Vec::new)
-            .extend(indices_to_update);
+        index.entry(new_key).or_default().extend(indices_to_update);
 
         Ok(true)
     }
@@ -1017,7 +1012,7 @@ impl Table for InMemoryTable {
         index.clear();
         for (idx, row) in rows.iter().enumerate() {
             let row_key = Self::row_to_key(row);
-            index.entry(row_key).or_insert_with(Vec::new).push(idx);
+            index.entry(row_key).or_default().push(idx);
         }
 
         Ok(true)
@@ -1081,9 +1076,8 @@ impl Table for InMemoryTable {
                 for i in 0..stream_attr_count {
                     joined.before_window_data[i] = stream_event.before_window_data[i].clone();
                 }
-                for j in 0..row.len() {
-                    joined.before_window_data[stream_attr_count + j] = row[j].clone();
-                }
+                joined.before_window_data[stream_attr_count..(row.len() + stream_attr_count)]
+                    .clone_from_slice(&row[..]);
                 if let Some(AttributeValue::Bool(true)) = exec.execute(Some(&joined)) {
                     matched.push(row.clone());
                 }
@@ -1307,15 +1301,17 @@ impl Table for InMemoryTable {
                 let skipped = updates.len();
                 self.concurrent_modification_skips
                     .fetch_add(skipped as u64, std::sync::atomic::Ordering::Relaxed);
-                return Err(crate::core::exception::EventFluxError::QueryableRecordTable {
-                    message: format!(
-                        "Concurrent modification limit exceeded after {} retries. \
+                return Err(
+                    crate::core::exception::EventFluxError::QueryableRecordTable {
+                        message: format!(
+                            "Concurrent modification limit exceeded after {} retries. \
                          {} updates could not be applied due to table contention. \
                          Consider routing to fault stream or implementing backoff retry.",
-                        MAX_CONCURRENT_MODIFICATION_RETRIES, skipped
-                    ),
-                    table_name: None,
-                });
+                            MAX_CONCURRENT_MODIFICATION_RETRIES, skipped
+                        ),
+                        table_name: None,
+                    },
+                );
             }
 
             // Step 2: Apply all updates (all rows verified)
@@ -1332,7 +1328,7 @@ impl Table for InMemoryTable {
                             index.remove(&old_key);
                         }
                     }
-                    index.entry(new_key).or_insert_with(Vec::new).push(idx);
+                    index.entry(new_key).or_default().push(idx);
                 }
             }
 
@@ -1527,15 +1523,17 @@ impl Table for InMemoryTable {
                 let skipped = updates.len();
                 self.concurrent_modification_skips
                     .fetch_add(skipped as u64, std::sync::atomic::Ordering::Relaxed);
-                return Err(crate::core::exception::EventFluxError::QueryableRecordTable {
-                    message: format!(
-                        "Concurrent modification limit exceeded after {} retries. \
+                return Err(
+                    crate::core::exception::EventFluxError::QueryableRecordTable {
+                        message: format!(
+                            "Concurrent modification limit exceeded after {} retries. \
                          {} upsert updates could not be applied due to table contention. \
                          Consider routing to fault stream or implementing backoff retry.",
-                        MAX_CONCURRENT_MODIFICATION_RETRIES, skipped
-                    ),
-                    table_name: None,
-                });
+                            MAX_CONCURRENT_MODIFICATION_RETRIES, skipped
+                        ),
+                        table_name: None,
+                    },
+                );
             }
 
             // Step 2: Apply all updates (all rows verified)
@@ -1551,7 +1549,7 @@ impl Table for InMemoryTable {
                             index.remove(&old_key);
                         }
                     }
-                    index.entry(new_key).or_insert_with(Vec::new).push(idx);
+                    index.entry(new_key).or_default().push(idx);
                 }
             }
 
@@ -1617,7 +1615,7 @@ impl Table for InMemoryTable {
                                 index.remove(&old_key);
                             }
                         }
-                        index.entry(new_key).or_insert_with(Vec::new).push(idx);
+                        index.entry(new_key).or_default().push(idx);
                     }
                     Ok((1, 0)) // Updated, not inserted
                 } else {
@@ -1625,7 +1623,7 @@ impl Table for InMemoryTable {
                     let key = Self::row_to_key(&new_values);
                     let new_index = rows.len();
                     rows.push(new_values);
-                    index.entry(key).or_insert_with(Vec::new).push(new_index);
+                    index.entry(key).or_default().push(new_index);
                     Ok((0, 1))
                 }
             } else {
@@ -1734,15 +1732,17 @@ impl Table for InMemoryTable {
                 let skipped = matched_rows.len();
                 self.concurrent_modification_skips
                     .fetch_add(skipped as u64, std::sync::atomic::Ordering::Relaxed);
-                return Err(crate::core::exception::EventFluxError::QueryableRecordTable {
-                    message: format!(
-                        "Concurrent modification limit exceeded after {} retries. \
+                return Err(
+                    crate::core::exception::EventFluxError::QueryableRecordTable {
+                        message: format!(
+                            "Concurrent modification limit exceeded after {} retries. \
                          {} deletes could not be applied due to table contention. \
                          Consider routing to fault stream or implementing backoff retry.",
-                        MAX_CONCURRENT_MODIFICATION_RETRIES, skipped
-                    ),
-                    table_name: None,
-                });
+                            MAX_CONCURRENT_MODIFICATION_RETRIES, skipped
+                        ),
+                        table_name: None,
+                    },
+                );
             }
 
             // Step 2: Delete rows using swap_remove for O(1) per deletion
@@ -1917,15 +1917,17 @@ impl Table for InMemoryTable {
                 let skipped = updates.len();
                 self.concurrent_modification_skips
                     .fetch_add(skipped as u64, std::sync::atomic::Ordering::Relaxed);
-                return Err(crate::core::exception::EventFluxError::QueryableRecordTable {
-                    message: format!(
-                        "Concurrent modification limit exceeded after {} retries. \
+                return Err(
+                    crate::core::exception::EventFluxError::QueryableRecordTable {
+                        message: format!(
+                            "Concurrent modification limit exceeded after {} retries. \
                          {} updates could not be applied due to table contention. \
                          Consider routing to fault stream or implementing backoff retry.",
-                        MAX_CONCURRENT_MODIFICATION_RETRIES, skipped
-                    ),
-                    table_name: None,
-                });
+                            MAX_CONCURRENT_MODIFICATION_RETRIES, skipped
+                        ),
+                        table_name: None,
+                    },
+                );
             }
 
             // Step 2: Apply all updates (all rows verified)
@@ -1942,7 +1944,7 @@ impl Table for InMemoryTable {
                             index.remove(&old_key);
                         }
                     }
-                    index.entry(new_key).or_insert_with(Vec::new).push(idx);
+                    index.entry(new_key).or_default().push(idx);
                 }
             }
 

--- a/src/core/trigger/trigger_runtime.rs
+++ b/src/core/trigger/trigger_runtime.rs
@@ -78,9 +78,9 @@ impl TriggerRuntime {
                 }
                 .on_time(now);
             } else {
-                let _ =
-                    self.scheduler
-                        .schedule_cron(at, task, None, Some(Arc::clone(&active)));
+                let _ = self
+                    .scheduler
+                    .schedule_cron(at, task, None, Some(Arc::clone(&active)));
             }
         }
     }
@@ -88,7 +88,10 @@ impl TriggerRuntime {
     pub fn shutdown(&self) {
         self.started.store(false, Ordering::Release);
         // Deactivate current generation's tasks so old periodic loops become no-ops
-        self.active_flag.lock().unwrap().store(false, Ordering::Release);
+        self.active_flag
+            .lock()
+            .unwrap()
+            .store(false, Ordering::Release);
     }
 }
 
@@ -104,6 +107,8 @@ impl Schedulable for TriggerTask {
             return;
         }
         let ev = Event::new_with_data(timestamp, vec![AttributeValue::Long(timestamp)]);
-        self.junction.lock().unwrap().send_event(ev);
+        if let Err(e) = self.junction.lock().unwrap().send_event(ev) {
+            log::error!("Trigger failed to send event: {}", e);
+        }
     }
 }

--- a/src/core/util/compression.rs
+++ b/src/core/util/compression.rs
@@ -188,6 +188,7 @@ pub struct CompressionMetrics {
 }
 
 /// High-performance compression engine implementation with thread-local optimization
+#[allow(dead_code)]
 pub struct OptimizedCompressionEngine {
     /// Thread-local LZ4 contexts for zero-allocation compression
     lz4_contexts: ThreadLocal<LZ4Context>,
@@ -207,6 +208,7 @@ struct LZ4Context {
 }
 
 /// Thread-local Snappy compression context
+#[allow(dead_code)]
 struct SnapContext {
     encoder: snap::raw::Encoder,
     decoder: snap::raw::Decoder,
@@ -298,12 +300,12 @@ impl OptimizedCompressionEngine {
             }
             e if e < 6.0 => {
                 // Check if mostly ASCII text
-                let ascii_count = sample.iter().filter(|&&b| b >= 32 && b <= 126).count();
+                let ascii_count = sample.iter().filter(|&&b| (32..=126).contains(&b)).count();
                 if ascii_count > sample_size * 3 / 4 {
                     DataCharacteristics::TextBased
                 } else {
                     // Check if mostly numeric patterns
-                    let numeric_count = sample.iter().filter(|&&b| b >= b'0' && b <= b'9').count();
+                    let numeric_count = sample.iter().filter(|&&b| b.is_ascii_digit()).count();
                     if numeric_count > sample_size / 2 {
                         DataCharacteristics::Numeric
                     } else {

--- a/src/core/util/event_serialization.rs
+++ b/src/core/util/event_serialization.rs
@@ -525,6 +525,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::approx_constant)]
     fn test_serialization_service() {
         let mut event = StreamEvent::new(1000, 2, 0, 0);
         event.before_window_data = vec![

--- a/src/core/util/parser/expression_parser.rs
+++ b/src/core/util/parser/expression_parser.rs
@@ -201,9 +201,9 @@ pub struct ExpressionParserContext<'a> {
 /// Parses query_api::Expression into core::ExpressionExecutor instances.
 /// Current limitations: Variable resolution is simplified for single input streams.
 /// Does not handle full complexity of all expression types or contexts (e.g., aggregations within HAVING).
-pub fn parse_expression<'a>(
+pub fn parse_expression(
     api_expr: &ApiExpression,
-    context: &ExpressionParserContext<'a>,
+    context: &ExpressionParserContext<'_>,
 ) -> ExpressionParseResult<Box<dyn ExpressionExecutor>> {
     match api_expr {
         ApiExpression::Constant(api_const) => {

--- a/src/core/util/parser/query_parser.rs
+++ b/src/core/util/parser/query_parser.rs
@@ -1040,7 +1040,7 @@ impl QueryParser {
                                 let pre = chain.pre_processors[idx].clone();
                                 stream_to_processors
                                     .entry(elem.stream_id.clone())
-                                    .or_insert_with(Vec::new)
+                                    .or_default()
                                     .push(pre);
                             }
                         }
@@ -1153,7 +1153,7 @@ impl QueryParser {
                                     event.before_window_data[self.first_len + j] = val;
                                 }
                                 if let Some(ref next) = self.next_processor {
-                                    if let Ok(mut proc) = next.lock() {
+                                    if let Ok(proc) = next.lock() {
                                         proc.process(Some(Box::new(event)));
                                     }
                                 }

--- a/src/core/util/pipeline/event_pipeline.rs
+++ b/src/core/util/pipeline/event_pipeline.rs
@@ -429,7 +429,7 @@ mod tests {
     fn test_batch_processing() {
         let pipeline = PipelineBuilder::new().with_capacity(128).build().unwrap();
 
-        let events: Vec<_> = (0..10).map(|i| create_test_event(i)).collect();
+        let events: Vec<_> = (0..10).map(create_test_event).collect();
 
         let results = pipeline.publish_batch(events);
         assert_eq!(results.len(), 10);
@@ -484,7 +484,7 @@ mod tests {
         let handle = std::thread::spawn(move || {
             let mut count = 0;
             let result = pipeline_for_consume.consume(move |event, _sequence| {
-                if let Some(AttributeValue::Int(value)) = event.before_window_data.get(0) {
+                if let Some(AttributeValue::Int(value)) = event.before_window_data.first() {
                     events_clone.lock().unwrap().push(*value);
                     count += 1;
 

--- a/src/core/util/pipeline/metrics.rs
+++ b/src/core/util/pipeline/metrics.rs
@@ -322,7 +322,7 @@ impl MetricsSnapshot {
         score -= latency_penalty * 0.5;
 
         // Ensure score is in valid range
-        score.max(0.0).min(1.0)
+        score.clamp(0.0, 1.0)
     }
 }
 

--- a/src/core/util/pipeline/mod.rs
+++ b/src/core/util/pipeline/mod.rs
@@ -48,8 +48,8 @@ mod tests {
     use super::*;
     use crate::core::event::stream::StreamEvent;
     use crate::core::event::value::AttributeValue;
-    use std::sync::Arc;
-    use std::time::{Duration, Instant};
+
+    use std::time::Instant;
 
     fn create_test_event(id: i32) -> StreamEvent {
         StreamEvent::new_with_data(0, vec![AttributeValue::Int(id)])

--- a/src/core/util/pipeline/object_pool.rs
+++ b/src/core/util/pipeline/object_pool.rs
@@ -58,6 +58,7 @@ pub struct PooledEvent {
 
 impl PooledEvent {
     /// Create a new pooled event
+    #[allow(dead_code)]
     fn new(pool: Arc<EventPool>) -> Self {
         Self {
             event: None,

--- a/src/core/util/type_system_tests.rs
+++ b/src/core/util/type_system_tests.rs
@@ -19,7 +19,7 @@
 // Comprehensive tests for the type system implementation
 
 #[cfg(test)]
-mod type_system_tests {
+mod tests {
     use crate::core::event::value::AttributeValue;
     use crate::core::util::type_system::{
         get_arithmetic_result_type, TypeConverter, TypePrecedence,

--- a/src/core/validation/dlq_validation.rs
+++ b/src/core/validation/dlq_validation.rs
@@ -139,7 +139,7 @@ pub fn validate_dlq_schema(
     }
 
     // 5. Check for extra fields not in required schema
-    for (actual_name, _) in &actual_fields {
+    for actual_name in actual_fields.keys() {
         if !REQUIRED_DLQ_FIELDS
             .iter()
             .any(|(req_name, _)| req_name == actual_name)
@@ -252,7 +252,7 @@ mod tests {
 
     #[test]
     fn test_validate_dlq_schema_missing_field() {
-        let mut stream_def = StreamDefinition::new("IncompleteDLQ".to_string())
+        let stream_def = StreamDefinition::new("IncompleteDLQ".to_string())
             .attribute("originalEvent".to_string(), AttributeType::STRING)
             .attribute("errorMessage".to_string(), AttributeType::STRING);
         // Missing other required fields
@@ -271,7 +271,7 @@ mod tests {
 
     #[test]
     fn test_validate_dlq_schema_wrong_type() {
-        let mut stream_def = StreamDefinition::new("WrongTypeDLQ".to_string())
+        let stream_def = StreamDefinition::new("WrongTypeDLQ".to_string())
             .attribute("originalEvent".to_string(), AttributeType::STRING)
             .attribute("errorMessage".to_string(), AttributeType::STRING)
             .attribute("errorType".to_string(), AttributeType::STRING)
@@ -310,7 +310,7 @@ mod tests {
 
     #[test]
     fn test_validate_dlq_schema_wrong_field_name() {
-        let mut stream_def = StreamDefinition::new("WrongNameDLQ".to_string())
+        let stream_def = StreamDefinition::new("WrongNameDLQ".to_string())
             .attribute("original_event".to_string(), AttributeType::STRING) // Wrong name
             .attribute("errorMessage".to_string(), AttributeType::STRING)
             .attribute("errorType".to_string(), AttributeType::STRING)
@@ -383,7 +383,7 @@ mod tests {
     #[test]
     fn test_dlq_schema_field_order_independence() {
         // Fields can be in any order as long as all are present
-        let mut stream_def = StreamDefinition::new("ReorderedDLQ".to_string())
+        let stream_def = StreamDefinition::new("ReorderedDLQ".to_string())
             .attribute("streamName".to_string(), AttributeType::STRING)
             .attribute("attemptCount".to_string(), AttributeType::INT)
             .attribute("timestamp".to_string(), AttributeType::LONG)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,8 +21,8 @@ pub mod sql_compiler;
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
-    use std::sync::Arc; // For EventFluxApp's maps (not directly used in this test logic for app construction)
+
+    use std::sync::Arc;
 
     // query_api module items
     use crate::query_api::definition::{
@@ -52,7 +52,7 @@ mod tests {
     use crate::core::config::eventflux_context::EventFluxContext;
     // EventFluxAppContext is created inside EventFluxAppRuntime::new currently
     // use crate::core::config::eventflux_app_context::EventFluxAppContext;
-    use crate::core::event::event::Event;
+
     use crate::core::event::value::AttributeValue as CoreAttributeValue;
     use crate::core::eventflux_app_runtime::EventFluxAppRuntime;
     use crate::core::stream::output::stream_callback::LogStreamCallback; // Assuming LogStreamCallback is here
@@ -95,15 +95,13 @@ mod tests {
         // FROM InputStream[attribute1 > 10]
         let api_single_input_stream =
             ApiSingleInputStream::new_basic("InputStream".to_string(), false, false, None, {
-                let mut handlers = Vec::new();
-                handlers.push(
+                vec![
                     crate::query_api::execution::query::input::handler::StreamHandler::Filter(
                         crate::query_api::execution::query::input::handler::Filter::new(
                             filter_condition.clone(),
                         ),
                     ),
-                );
-                handlers
+                ]
             });
         // Assuming SingleInputStream from query_api has a method to add filters, or its handlers field is public.
         // For now, this relies on how `QueryParser` would interpret handlers.

--- a/src/query_api/definition/stream_definition.rs
+++ b/src/query_api/definition/stream_definition.rs
@@ -177,7 +177,7 @@ impl AsMut<EventFluxElement> for StreamDefinition {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::query_api::definition::attribute::{Attribute, Type as AttributeType};
+    use crate::query_api::definition::attribute::Type as AttributeType;
 
     #[test]
     fn test_stream_definition_creation_and_attributes() {

--- a/src/query_api/execution/execution_element.rs
+++ b/src/query_api/execution/execution_element.rs
@@ -23,6 +23,7 @@ use crate::query_api::execution::query::Query;
 
 // This enum will wrap concrete types that are considered ExecutionElements.
 #[derive(Clone, Debug, PartialEq)]
+#[allow(clippy::large_enum_variant)]
 pub enum ExecutionElement {
     Query(Query),
     Partition(Partition),

--- a/src/query_api/execution/partition/mod.rs
+++ b/src/query_api/execution/partition/mod.rs
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+#[allow(clippy::module_inception)]
 pub mod partition;
 pub mod partition_type;
 pub mod range_partition_type;

--- a/src/query_api/execution/partition/partition.rs
+++ b/src/query_api/execution/partition/partition.rs
@@ -51,6 +51,7 @@ impl Partition {
     }
 
     // Static factory `partition()` from Java
+    #[allow(clippy::self_named_constructors)]
     pub fn partition() -> Self {
         Self::new()
     }

--- a/src/query_api/execution/query/input/handler/stream_handler.rs
+++ b/src/query_api/execution/query/input/handler/stream_handler.rs
@@ -39,6 +39,7 @@ pub enum StreamHandler {
 
 impl StreamHandler {
     // Accessing the composed eventflux_element from the variants
+    #[allow(dead_code)]
     fn eventflux_element_ref(&self) -> &EventFluxElement {
         match self {
             StreamHandler::Filter(f) => &f.eventflux_element,
@@ -47,6 +48,7 @@ impl StreamHandler {
         }
     }
 
+    #[allow(dead_code)]
     fn eventflux_element_mut_ref(&mut self) -> &mut EventFluxElement {
         match self {
             StreamHandler::Filter(f) => &mut f.eventflux_element,

--- a/src/query_api/execution/query/input/state/mod.rs
+++ b/src/query_api/execution/query/input/state/mod.rs
@@ -22,6 +22,7 @@ pub mod count_state_element;
 pub mod every_state_element;
 pub mod logical_state_element;
 pub mod next_state_element;
+#[allow(clippy::module_inception)]
 pub mod state; // This is the factory class with static methods
 pub mod state_element; // Interface, will be an enum or trait
 pub mod stream_state_element;

--- a/src/query_api/execution/query/input/state/state_element.rs
+++ b/src/query_api/execution/query/input/state/state_element.rs
@@ -38,6 +38,7 @@ pub enum StateElement {
 
 // Implement EventFluxElement for the enum by dispatching to variants' composed eventflux_element field
 impl StateElement {
+    #[allow(dead_code)]
     fn eventflux_element_ref(&self) -> &EventFluxElement {
         match self {
             StateElement::Stream(s) => &s.eventflux_element,
@@ -49,6 +50,7 @@ impl StateElement {
         }
     }
 
+    #[allow(dead_code)]
     fn eventflux_element_mut_ref(&mut self) -> &mut EventFluxElement {
         match self {
             StateElement::Stream(s) => &mut s.eventflux_element,

--- a/src/query_api/execution/query/input/state/stream_state_element.rs
+++ b/src/query_api/execution/query/input/state/stream_state_element.rs
@@ -47,6 +47,7 @@ impl StreamStateElement {
     }
 
     // Helper method for StateInputStream or other internal uses.
+    #[allow(dead_code)]
     pub(crate) fn get_stream_id(&self) -> &str {
         // SingleInputStream has get_stream_id_str() directly.
         self.basic_single_input_stream.get_stream_id_str()

--- a/src/query_api/execution/query/input/store/input_store.rs
+++ b/src/query_api/execution/query/input/store/input_store.rs
@@ -51,6 +51,7 @@ impl InputStore {
     }
 
     // Helper to access the composed eventflux_element from variants
+    #[allow(dead_code)]
     fn eventflux_element_ref(&self) -> &EventFluxElement {
         match self {
             InputStore::Store(s) => &s.eventflux_element,
@@ -58,6 +59,7 @@ impl InputStore {
             InputStore::Aggregation(a) => &a.eventflux_element,
         }
     }
+    #[allow(dead_code)]
     fn eventflux_element_mut_ref(&mut self) -> &mut EventFluxElement {
         match self {
             InputStore::Store(s) => &mut s.eventflux_element,

--- a/src/query_api/execution/query/input/store/mod.rs
+++ b/src/query_api/execution/query/input/store/mod.rs
@@ -20,6 +20,7 @@
 pub mod aggregation_input_store;
 pub mod condition_input_store;
 pub mod input_store; // Interface, will be a trait or enum
+#[allow(clippy::module_inception)]
 pub mod store; // This is a BasicSingleInputStream that also implements InputStore
 
 // Re-export key types

--- a/src/query_api/execution/query/input/stream/input_stream.rs
+++ b/src/query_api/execution/query/input/stream/input_stream.rs
@@ -51,6 +51,7 @@ pub enum InputStream {
 impl InputStream {
     // These helpers assume that SingleInputStream, JoinInputStream, StateInputStream
     // will be refactored to compose `eventflux_element: EventFluxElement`.
+    #[allow(dead_code)]
     fn eventflux_element_ref(&self) -> &EventFluxElement {
         match self {
             InputStream::Single(s) => &s.eventflux_element,
@@ -59,6 +60,7 @@ impl InputStream {
         }
     }
 
+    #[allow(dead_code)]
     fn eventflux_element_mut_ref(&mut self) -> &mut EventFluxElement {
         match self {
             InputStream::Single(s) => &mut s.eventflux_element,

--- a/src/query_api/execution/query/mod.rs
+++ b/src/query_api/execution/query/mod.rs
@@ -20,6 +20,7 @@
 // Existing modules
 pub mod input;
 pub mod on_demand_query;
+#[allow(clippy::module_inception)]
 pub mod query;
 pub mod selection;
 pub mod store_query;

--- a/src/query_api/execution/query/query.rs
+++ b/src/query_api/execution/query/query.rs
@@ -47,6 +47,7 @@ impl Query {
     }
 
     // Static factory method from Java
+    #[allow(clippy::self_named_constructors)]
     pub fn query() -> Self {
         Self::new()
     }
@@ -112,6 +113,22 @@ impl Query {
 
     pub fn get_output_rate(&self) -> Option<&OutputRate> {
         self.output_rate.as_ref()
+    }
+}
+
+impl Default for Query {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// EventFluxElement is composed, access via `self.eventflux_element.query_context_start_index` etc.
+// Or implement Deref/DerefMut if desired for direct access.
+
+// Implement ExecutionElementTrait for Query
+impl ExecutionElementTrait for Query {
+    fn get_annotations(&self) -> &Vec<Annotation> {
+        &self.annotations
     }
 }
 
@@ -227,21 +244,5 @@ mod tests {
             q3.output_stream.get_output_event_type(),
             Some(OutputEventType::CurrentEvents)
         );
-    }
-}
-
-impl Default for Query {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-// EventFluxElement is composed, access via `self.eventflux_element.query_context_start_index` etc.
-// Or implement Deref/DerefMut if desired for direct access.
-
-// Implement ExecutionElementTrait for Query
-impl ExecutionElementTrait for Query {
-    fn get_annotations(&self) -> &Vec<Annotation> {
-        &self.annotations
     }
 }

--- a/src/query_api/execution/query/selection/selector.rs
+++ b/src/query_api/execution/query/selection/selector.rs
@@ -50,6 +50,7 @@ impl Selector {
     }
 
     // Static factory `selector()`
+    #[allow(clippy::self_named_constructors)]
     pub fn selector() -> Self {
         Self::new()
     }
@@ -60,7 +61,7 @@ impl Selector {
         if self
             .selection_list
             .iter()
-            .any(|attr| attr.get_rename().as_ref().map_or(false, |r| r == &rename))
+            .any(|attr| attr.get_rename().as_ref() == Some(&rename))
         {
             eprintln!(
                 "Warning: Duplicate column name '{}' in select clause",
@@ -100,11 +101,11 @@ impl Selector {
         for new_attr in &projection_list {
             if let Some(new_rename) = new_attr.get_rename() {
                 // Check against existing selections
-                if self.selection_list.iter().any(|attr| {
-                    attr.get_rename()
-                        .as_ref()
-                        .map_or(false, |r| r == new_rename)
-                }) {
+                if self
+                    .selection_list
+                    .iter()
+                    .any(|attr| attr.get_rename().as_ref() == Some(new_rename))
+                {
                     eprintln!(
                         "Warning: Duplicate column name '{}' in select clause",
                         new_rename
@@ -114,11 +115,7 @@ impl Selector {
                 // Check against other items in the same list
                 if projection_list
                     .iter()
-                    .filter(|attr| {
-                        attr.get_rename()
-                            .as_ref()
-                            .map_or(false, |r| r == new_rename)
-                    })
+                    .filter(|attr| attr.get_rename().as_ref() == Some(new_rename))
                     .count()
                     > 1
                 {
@@ -227,7 +224,7 @@ mod tests {
         Order as OrderByOrder, OrderByAttribute,
     };
     use crate::query_api::execution::query::selection::output_attribute::OutputAttribute;
-    use crate::query_api::expression::constant::{Constant, ConstantValueWithFloat};
+    use crate::query_api::expression::constant::Constant;
     use crate::query_api::expression::variable::Variable;
     use crate::query_api::expression::Expression;
 

--- a/src/query_api/expression/constant/mod.rs
+++ b/src/query_api/expression/constant/mod.rs
@@ -262,10 +262,7 @@ mod tests {
     #[test]
     fn test_time_util_hour() {
         let c = TimeUtil::hour(1); // 1 hour
-        assert_eq!(
-            c.get_value(),
-            &ConstantValueWithFloat::Time(1 * 60 * 60 * 1000)
-        );
+        assert_eq!(c.get_value(), &ConstantValueWithFloat::Time(60 * 60 * 1000));
     }
 
     #[test]
@@ -273,7 +270,7 @@ mod tests {
         let c = TimeUtil::day(1); // 1 day
         assert_eq!(
             c.get_value(),
-            &ConstantValueWithFloat::Time(1 * 24 * 60 * 60 * 1000)
+            &ConstantValueWithFloat::Time(24 * 60 * 60 * 1000)
         );
     }
 
@@ -282,7 +279,7 @@ mod tests {
         let c = TimeUtil::week(1); // 1 week
         assert_eq!(
             c.get_value(),
-            &ConstantValueWithFloat::Time(1 * 7 * 24 * 60 * 60 * 1000)
+            &ConstantValueWithFloat::Time(7 * 24 * 60 * 60 * 1000)
         );
     }
 

--- a/src/query_api/expression/expression.rs
+++ b/src/query_api/expression/expression.rs
@@ -116,6 +116,7 @@ impl Expression {
     }
 
     // Math
+    #[allow(clippy::should_implement_trait)]
     pub fn add(left: Expression, right: Expression) -> Self {
         Expression::Add(Box::new(Add::new(left, right)))
     }
@@ -142,6 +143,7 @@ impl Expression {
     pub fn or(left: Expression, right: Expression) -> Self {
         Expression::Or(Box::new(Or::new(left, right)))
     }
+    #[allow(clippy::should_implement_trait)]
     pub fn not(expr: Expression) -> Self {
         Expression::Not(Box::new(Not::new(expr)))
     }

--- a/src/query_api/expression/mod.rs
+++ b/src/query_api/expression/mod.rs
@@ -26,6 +26,7 @@ pub mod math;
 // Declare modules for individual expression types at this level
 pub mod attribute_function;
 pub mod cast;
+#[allow(clippy::module_inception)]
 pub mod expression;
 pub mod indexed_variable;
 pub mod variable; // This is the main Expression enum

--- a/src/sql_compiler/application.rs
+++ b/src/sql_compiler/application.rs
@@ -321,7 +321,7 @@ pub fn parse_sql_application(sql: &str) -> Result<SqlApplication, ApplicationErr
                                 // Has qualifier - validate it matches target table or alias
                                 let qualifier = &parts[0];
                                 let is_valid_qualifier = qualifier == &target_table
-                                    || target_alias.as_ref().map_or(false, |a| a == qualifier);
+                                    || (target_alias.as_ref() == Some(qualifier));
 
                                 if !is_valid_qualifier {
                                     return Err(ApplicationError::Converter(

--- a/src/sql_compiler/converter.rs
+++ b/src/sql_compiler/converter.rs
@@ -20,10 +20,10 @@
 //! Converts SQL statements to EventFlux query_api::Query structures.
 
 use sqlparser::ast::{
-    AccessExpr, BinaryOperator, Expr as SqlExpr, JoinConstraint, JoinOperator,
-    OutputRateLimit, OutputRateLimitMode, OutputRateLimitUnit, PartitionKey, PatternExpression,
-    PatternLogicalOp, PatternMode, Select as SqlSelect, SetExpr, Statement, Subscript,
-    TableFactor, UnaryOperator, WithinConstraint,
+    AccessExpr, BinaryOperator, Expr as SqlExpr, JoinConstraint, JoinOperator, OutputRateLimit,
+    OutputRateLimitMode, OutputRateLimitUnit, PartitionKey, PatternExpression, PatternLogicalOp,
+    PatternMode, Select as SqlSelect, SetExpr, Statement, Subscript, TableFactor, UnaryOperator,
+    WithinConstraint,
 };
 use sqlparser::dialect::GenericDialect;
 use sqlparser::parser::Parser;
@@ -417,15 +417,18 @@ impl SqlConverter {
                     OutputRateLimitMode::Snapshot => {
                         OutputRateVariant::Snapshot(SnapshotOutputRate::new(millis))
                     }
-                    OutputRateLimitMode::All => {
-                        OutputRateVariant::Time(TimeOutputRate::new(millis), OutputRateBehavior::All)
-                    }
-                    OutputRateLimitMode::First => {
-                        OutputRateVariant::Time(TimeOutputRate::new(millis), OutputRateBehavior::First)
-                    }
-                    OutputRateLimitMode::Last => {
-                        OutputRateVariant::Time(TimeOutputRate::new(millis), OutputRateBehavior::Last)
-                    }
+                    OutputRateLimitMode::All => OutputRateVariant::Time(
+                        TimeOutputRate::new(millis),
+                        OutputRateBehavior::All,
+                    ),
+                    OutputRateLimitMode::First => OutputRateVariant::Time(
+                        TimeOutputRate::new(millis),
+                        OutputRateBehavior::First,
+                    ),
+                    OutputRateLimitMode::Last => OutputRateVariant::Time(
+                        TimeOutputRate::new(millis),
+                        OutputRateBehavior::Last,
+                    ),
                 }
             }
         };
@@ -456,7 +459,7 @@ impl SqlConverter {
             (join_input, String::new())
         } else {
             // Handle single relation in FROM
-            let first = select.from.get(0).ok_or_else(|| {
+            let first = select.from.first().ok_or_else(|| {
                 ConverterError::ConversionFailed("No FROM clause found".to_string())
             })?;
 
@@ -665,6 +668,7 @@ impl SqlConverter {
     }
 
     /// Extract stream name from FROM clause
+    #[allow(dead_code)]
     fn extract_from_stream(
         from: &[sqlparser::ast::TableWithJoins],
     ) -> Result<String, ConverterError> {
@@ -696,6 +700,7 @@ impl SqlConverter {
     }
 
     /// Extract window specification from TableFactor (native AST field)
+    #[allow(dead_code)]
     fn extract_window_from_table_factor(
         from: &[sqlparser::ast::TableWithJoins],
     ) -> Option<&sqlparser::ast::StreamingWindowSpec> {

--- a/src/sql_compiler/type_inference.rs
+++ b/src/sql_compiler/type_inference.rs
@@ -1082,16 +1082,10 @@ impl<'a> TypeInferenceEngine<'a> {
         let context = self.build_context_from_query(query);
 
         // Validate WHERE clauses (in stream handlers)
-        if let Some(input_stream) = query.get_input_stream() {
-            if let InputStream::Single(single_stream) = input_stream {
-                for handler in single_stream.get_stream_handlers() {
-                    if let StreamHandler::Filter(filter) = handler {
-                        self.validate_boolean_expression(
-                            &filter.filter_expression,
-                            &context,
-                            "WHERE",
-                        )?;
-                    }
+        if let Some(InputStream::Single(single_stream)) = query.get_input_stream() {
+            for handler in single_stream.get_stream_handlers() {
+                if let StreamHandler::Filter(filter) = handler {
+                    self.validate_boolean_expression(&filter.filter_expression, &context, "WHERE")?;
                 }
             }
         }
@@ -1207,9 +1201,10 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::approx_constant)]
     fn test_constant_type_inference() {
         let catalog = create_test_catalog();
-        let engine = TypeInferenceEngine::new(&catalog);
+        let _engine = TypeInferenceEngine::new(&catalog);
 
         assert_eq!(
             TypeInferenceEngine::infer_constant_type(&Constant::int(42)).unwrap(),

--- a/tests/advanced_window_tests.rs
+++ b/tests/advanced_window_tests.rs
@@ -43,28 +43,37 @@ async fn test_unique_window_basic() {
         SELECT symbol, price, volume\n\
         FROM StockStream WINDOW('unique', symbol);\n";
 
-    let mut runner = AppRunner::new(app, "OutStream").await;
+    let runner = AppRunner::new(app, "OutStream").await;
 
     // First event for AAPL
-    runner.send("StockStream", vec![
-        AttributeValue::String("AAPL".to_string()),
-        AttributeValue::Double(150.0),
-        AttributeValue::Long(1000),
-    ]);
+    runner.send(
+        "StockStream",
+        vec![
+            AttributeValue::String("AAPL".to_string()),
+            AttributeValue::Double(150.0),
+            AttributeValue::Long(1000),
+        ],
+    );
 
     // First event for GOOG
-    runner.send("StockStream", vec![
-        AttributeValue::String("GOOG".to_string()),
-        AttributeValue::Double(2800.0),
-        AttributeValue::Long(500),
-    ]);
+    runner.send(
+        "StockStream",
+        vec![
+            AttributeValue::String("GOOG".to_string()),
+            AttributeValue::Double(2800.0),
+            AttributeValue::Long(500),
+        ],
+    );
 
     // Second event for AAPL - should replace the first
-    runner.send("StockStream", vec![
-        AttributeValue::String("AAPL".to_string()),
-        AttributeValue::Double(151.0),
-        AttributeValue::Long(2000),
-    ]);
+    runner.send(
+        "StockStream",
+        vec![
+            AttributeValue::String("AAPL".to_string()),
+            AttributeValue::Double(151.0),
+            AttributeValue::Long(2000),
+        ],
+    );
 
     let results = runner.shutdown();
 
@@ -82,24 +91,33 @@ async fn test_unique_window_replaces_old_event() {
         SELECT symbol, price\n\
         FROM StockStream WINDOW('unique', symbol);\n";
 
-    let mut runner = AppRunner::new(app, "OutStream").await;
+    let runner = AppRunner::new(app, "OutStream").await;
 
     // Send AAPL at $150
-    runner.send("StockStream", vec![
-        AttributeValue::String("AAPL".to_string()),
-        AttributeValue::Double(150.0),
-    ]);
+    runner.send(
+        "StockStream",
+        vec![
+            AttributeValue::String("AAPL".to_string()),
+            AttributeValue::Double(150.0),
+        ],
+    );
 
     // Send AAPL again at $155 - should expire the $150 event
-    runner.send("StockStream", vec![
-        AttributeValue::String("AAPL".to_string()),
-        AttributeValue::Double(155.0),
-    ]);
+    runner.send(
+        "StockStream",
+        vec![
+            AttributeValue::String("AAPL".to_string()),
+            AttributeValue::Double(155.0),
+        ],
+    );
 
     let results = runner.shutdown();
 
     // We should have received events - the second AAPL should trigger an expired + current
-    assert!(!results.is_empty(), "Should have received at least one event");
+    assert!(
+        !results.is_empty(),
+        "Should have received at least one event"
+    );
 }
 
 #[tokio::test]
@@ -111,30 +129,46 @@ async fn test_unique_window_multiple_keys() {
         SELECT symbol, price\n\
         FROM StockStream WINDOW('unique', symbol);\n";
 
-    let mut runner = AppRunner::new(app, "OutStream").await;
+    let runner = AppRunner::new(app, "OutStream").await;
 
     // Different symbols - all should be kept
-    runner.send("StockStream", vec![
-        AttributeValue::String("AAPL".to_string()),
-        AttributeValue::Double(150.0),
-    ]);
-    runner.send("StockStream", vec![
-        AttributeValue::String("GOOG".to_string()),
-        AttributeValue::Double(2800.0),
-    ]);
-    runner.send("StockStream", vec![
-        AttributeValue::String("MSFT".to_string()),
-        AttributeValue::Double(350.0),
-    ]);
-    runner.send("StockStream", vec![
-        AttributeValue::String("AMZN".to_string()),
-        AttributeValue::Double(3400.0),
-    ]);
+    runner.send(
+        "StockStream",
+        vec![
+            AttributeValue::String("AAPL".to_string()),
+            AttributeValue::Double(150.0),
+        ],
+    );
+    runner.send(
+        "StockStream",
+        vec![
+            AttributeValue::String("GOOG".to_string()),
+            AttributeValue::Double(2800.0),
+        ],
+    );
+    runner.send(
+        "StockStream",
+        vec![
+            AttributeValue::String("MSFT".to_string()),
+            AttributeValue::Double(350.0),
+        ],
+    );
+    runner.send(
+        "StockStream",
+        vec![
+            AttributeValue::String("AMZN".to_string()),
+            AttributeValue::Double(3400.0),
+        ],
+    );
 
     let results = runner.shutdown();
 
     // All 4 unique symbols should result in 4 events
-    assert_eq!(results.len(), 4, "Should have 4 events for 4 unique symbols");
+    assert_eq!(
+        results.len(),
+        4,
+        "Should have 4 events for 4 unique symbols"
+    );
 }
 
 // ============================================================================
@@ -151,30 +185,43 @@ async fn test_first_unique_window_basic() {
         SELECT symbol, price\n\
         FROM StockStream WINDOW('firstUnique', symbol);\n";
 
-    let mut runner = AppRunner::new(app, "OutStream").await;
+    let runner = AppRunner::new(app, "OutStream").await;
 
     // First AAPL - should be kept
-    runner.send("StockStream", vec![
-        AttributeValue::String("AAPL".to_string()),
-        AttributeValue::Double(150.0),
-    ]);
+    runner.send(
+        "StockStream",
+        vec![
+            AttributeValue::String("AAPL".to_string()),
+            AttributeValue::Double(150.0),
+        ],
+    );
 
     // Second AAPL - should be ignored
-    runner.send("StockStream", vec![
-        AttributeValue::String("AAPL".to_string()),
-        AttributeValue::Double(155.0),
-    ]);
+    runner.send(
+        "StockStream",
+        vec![
+            AttributeValue::String("AAPL".to_string()),
+            AttributeValue::Double(155.0),
+        ],
+    );
 
     // First GOOG - should be kept
-    runner.send("StockStream", vec![
-        AttributeValue::String("GOOG".to_string()),
-        AttributeValue::Double(2800.0),
-    ]);
+    runner.send(
+        "StockStream",
+        vec![
+            AttributeValue::String("GOOG".to_string()),
+            AttributeValue::Double(2800.0),
+        ],
+    );
 
     let results = runner.shutdown();
 
     // Only 2 events should pass: first AAPL and first GOOG
-    assert_eq!(results.len(), 2, "Only first occurrence per key should pass");
+    assert_eq!(
+        results.len(),
+        2,
+        "Only first occurrence per key should pass"
+    );
 }
 
 #[tokio::test]
@@ -186,20 +233,27 @@ async fn test_first_unique_window_ignores_duplicates() {
         SELECT symbol, price\n\
         FROM StockStream WINDOW('firstUnique', symbol);\n";
 
-    let mut runner = AppRunner::new(app, "OutStream").await;
+    let runner = AppRunner::new(app, "OutStream").await;
 
     // Send same symbol multiple times
     for i in 0..10 {
-        runner.send("StockStream", vec![
-            AttributeValue::String("AAPL".to_string()),
-            AttributeValue::Double(150.0 + i as f64),
-        ]);
+        runner.send(
+            "StockStream",
+            vec![
+                AttributeValue::String("AAPL".to_string()),
+                AttributeValue::Double(150.0 + i as f64),
+            ],
+        );
     }
 
     let results = runner.shutdown();
 
     // Only the first event should pass
-    assert_eq!(results.len(), 1, "Only first occurrence should pass, duplicates ignored");
+    assert_eq!(
+        results.len(),
+        1,
+        "Only first occurrence should pass, duplicates ignored"
+    );
 }
 
 // ============================================================================
@@ -216,13 +270,16 @@ async fn test_delay_window_basic() {
         SELECT symbol, price\n\
         FROM StockStream WINDOW('delay', 100);\n";
 
-    let mut runner = AppRunner::new(app, "OutStream").await;
+    let runner = AppRunner::new(app, "OutStream").await;
 
     // Send an event
-    runner.send("StockStream", vec![
-        AttributeValue::String("AAPL".to_string()),
-        AttributeValue::Double(150.0),
-    ]);
+    runner.send(
+        "StockStream",
+        vec![
+            AttributeValue::String("AAPL".to_string()),
+            AttributeValue::Double(150.0),
+        ],
+    );
 
     // Events are delayed, so immediate shutdown may not capture them
     // This test validates the window doesn't crash
@@ -242,12 +299,15 @@ async fn test_delay_window_with_wait() {
         SELECT symbol, price\n\
         FROM StockStream WINDOW('delay', 50);\n";
 
-    let mut runner = AppRunner::new(app, "OutStream").await;
+    let runner = AppRunner::new(app, "OutStream").await;
 
-    runner.send("StockStream", vec![
-        AttributeValue::String("AAPL".to_string()),
-        AttributeValue::Double(150.0),
-    ]);
+    runner.send(
+        "StockStream",
+        vec![
+            AttributeValue::String("AAPL".to_string()),
+            AttributeValue::Double(150.0),
+        ],
+    );
 
     // Allow some time for the delay
     tokio::time::sleep(std::time::Duration::from_millis(100)).await;
@@ -274,14 +334,17 @@ async fn test_expression_window_count_limit() {
         SELECT symbol, price\n\
         FROM StockStream WINDOW('expression', 'count() <= 3');\n";
 
-    let mut runner = AppRunner::new(app, "OutStream").await;
+    let runner = AppRunner::new(app, "OutStream").await;
 
     // Send 5 events
     for i in 0..5 {
-        runner.send("StockStream", vec![
-            AttributeValue::String(format!("SYM{}", i)),
-            AttributeValue::Double(100.0 + i as f64),
-        ]);
+        runner.send(
+            "StockStream",
+            vec![
+                AttributeValue::String(format!("SYM{}", i)),
+                AttributeValue::Double(100.0 + i as f64),
+            ],
+        );
     }
 
     let results = runner.shutdown();
@@ -301,13 +364,16 @@ async fn test_expression_window_count_limit_lt() {
         SELECT symbol, price\n\
         FROM StockStream WINDOW('expression', 'count() < 5');\n";
 
-    let mut runner = AppRunner::new(app, "OutStream").await;
+    let runner = AppRunner::new(app, "OutStream").await;
 
     for i in 0..6 {
-        runner.send("StockStream", vec![
-            AttributeValue::String(format!("SYM{}", i)),
-            AttributeValue::Double(100.0 + i as f64),
-        ]);
+        runner.send(
+            "StockStream",
+            vec![
+                AttributeValue::String(format!("SYM{}", i)),
+                AttributeValue::Double(100.0 + i as f64),
+            ],
+        );
     }
 
     let results = runner.shutdown();
@@ -330,29 +396,38 @@ async fn test_frequent_window_basic() {
         SELECT symbol, price\n\
         FROM StockStream WINDOW('frequent', 2);\n";
 
-    let mut runner = AppRunner::new(app, "OutStream").await;
+    let runner = AppRunner::new(app, "OutStream").await;
 
     // AAPL appears 3 times
     for _ in 0..3 {
-        runner.send("StockStream", vec![
-            AttributeValue::String("AAPL".to_string()),
-            AttributeValue::Double(150.0),
-        ]);
+        runner.send(
+            "StockStream",
+            vec![
+                AttributeValue::String("AAPL".to_string()),
+                AttributeValue::Double(150.0),
+            ],
+        );
     }
 
     // GOOG appears 2 times
     for _ in 0..2 {
-        runner.send("StockStream", vec![
-            AttributeValue::String("GOOG".to_string()),
-            AttributeValue::Double(2800.0),
-        ]);
+        runner.send(
+            "StockStream",
+            vec![
+                AttributeValue::String("GOOG".to_string()),
+                AttributeValue::Double(2800.0),
+            ],
+        );
     }
 
     // MSFT appears 1 time
-    runner.send("StockStream", vec![
-        AttributeValue::String("MSFT".to_string()),
-        AttributeValue::Double(350.0),
-    ]);
+    runner.send(
+        "StockStream",
+        vec![
+            AttributeValue::String("MSFT".to_string()),
+            AttributeValue::Double(350.0),
+        ],
+    );
 
     let results = runner.shutdown();
 
@@ -370,15 +445,18 @@ async fn test_frequent_window_eviction() {
         SELECT symbol, price\n\
         FROM StockStream WINDOW('frequent', 1);\n";
 
-    let mut runner = AppRunner::new(app, "OutStream").await;
+    let runner = AppRunner::new(app, "OutStream").await;
 
     // Alternate between symbols
     for i in 0..4 {
         let symbol = if i % 2 == 0 { "AAPL" } else { "GOOG" };
-        runner.send("StockStream", vec![
-            AttributeValue::String(symbol.to_string()),
-            AttributeValue::Double(100.0 + i as f64),
-        ]);
+        runner.send(
+            "StockStream",
+            vec![
+                AttributeValue::String(symbol.to_string()),
+                AttributeValue::Double(100.0 + i as f64),
+            ],
+        );
     }
 
     let results = runner.shutdown();
@@ -401,22 +479,28 @@ async fn test_lossy_frequent_window_basic() {
         SELECT symbol, price\n\
         FROM StockStream WINDOW('lossyFrequent', 0.3, 0.1);\n";
 
-    let mut runner = AppRunner::new(app, "OutStream").await;
+    let runner = AppRunner::new(app, "OutStream").await;
 
     // Send 10 events, AAPL appears 5 times (50%)
     for _ in 0..5 {
-        runner.send("StockStream", vec![
-            AttributeValue::String("AAPL".to_string()),
-            AttributeValue::Double(150.0),
-        ]);
+        runner.send(
+            "StockStream",
+            vec![
+                AttributeValue::String("AAPL".to_string()),
+                AttributeValue::Double(150.0),
+            ],
+        );
     }
 
     // Other symbols appear once each
     for symbol in &["GOOG", "MSFT", "AMZN", "META", "TSLA"] {
-        runner.send("StockStream", vec![
-            AttributeValue::String(symbol.to_string()),
-            AttributeValue::Double(100.0),
-        ]);
+        runner.send(
+            "StockStream",
+            vec![
+                AttributeValue::String(symbol.to_string()),
+                AttributeValue::Double(100.0),
+            ],
+        );
     }
 
     let results = runner.shutdown();
@@ -435,14 +519,17 @@ async fn test_lossy_frequent_window_default_error() {
         SELECT symbol, price\n\
         FROM StockStream WINDOW('lossyFrequent', 0.2);\n";
 
-    let mut runner = AppRunner::new(app, "OutStream").await;
+    let runner = AppRunner::new(app, "OutStream").await;
 
     // Send events
     for i in 0..10 {
-        runner.send("StockStream", vec![
-            AttributeValue::String(format!("SYM{}", i % 3)),
-            AttributeValue::Double(100.0 + i as f64),
-        ]);
+        runner.send(
+            "StockStream",
+            vec![
+                AttributeValue::String(format!("SYM{}", i % 3)),
+                AttributeValue::Double(100.0 + i as f64),
+            ],
+        );
     }
 
     let results = runner.shutdown();
@@ -494,13 +581,16 @@ async fn test_frequent_window_single_item() {
         SELECT symbol, price\n\
         FROM StockStream WINDOW('frequent', 5);\n";
 
-    let mut runner = AppRunner::new(app, "OutStream").await;
+    let runner = AppRunner::new(app, "OutStream").await;
 
     // Single event
-    runner.send("StockStream", vec![
-        AttributeValue::String("AAPL".to_string()),
-        AttributeValue::Double(150.0),
-    ]);
+    runner.send(
+        "StockStream",
+        vec![
+            AttributeValue::String("AAPL".to_string()),
+            AttributeValue::Double(150.0),
+        ],
+    );
 
     let results = runner.shutdown();
 
@@ -517,19 +607,26 @@ async fn test_expression_window_all_events_within_limit() {
         SELECT symbol, price\n\
         FROM StockStream WINDOW('expression', 'count() <= 10');\n";
 
-    let mut runner = AppRunner::new(app, "OutStream").await;
+    let runner = AppRunner::new(app, "OutStream").await;
 
     for i in 0..5 {
-        runner.send("StockStream", vec![
-            AttributeValue::String(format!("SYM{}", i)),
-            AttributeValue::Double(100.0),
-        ]);
+        runner.send(
+            "StockStream",
+            vec![
+                AttributeValue::String(format!("SYM{}", i)),
+                AttributeValue::Double(100.0),
+            ],
+        );
     }
 
     let results = runner.shutdown();
 
     // All 5 events should pass since count <= 10
-    assert_eq!(results.len(), 5, "All events should pass within expression limit");
+    assert_eq!(
+        results.len(),
+        5,
+        "All events should pass within expression limit"
+    );
 }
 
 // ============================================================================
@@ -545,20 +642,29 @@ async fn test_unique_window_with_aggregation() {
         SELECT sum(price) as totalPrice\n\
         FROM StockStream WINDOW('unique', symbol);\n";
 
-    let mut runner = AppRunner::new(app, "OutStream").await;
+    let runner = AppRunner::new(app, "OutStream").await;
 
-    runner.send("StockStream", vec![
-        AttributeValue::String("AAPL".to_string()),
-        AttributeValue::Double(100.0),
-    ]);
-    runner.send("StockStream", vec![
-        AttributeValue::String("GOOG".to_string()),
-        AttributeValue::Double(200.0),
-    ]);
-    runner.send("StockStream", vec![
-        AttributeValue::String("AAPL".to_string()),
-        AttributeValue::Double(150.0),
-    ]);
+    runner.send(
+        "StockStream",
+        vec![
+            AttributeValue::String("AAPL".to_string()),
+            AttributeValue::Double(100.0),
+        ],
+    );
+    runner.send(
+        "StockStream",
+        vec![
+            AttributeValue::String("GOOG".to_string()),
+            AttributeValue::Double(200.0),
+        ],
+    );
+    runner.send(
+        "StockStream",
+        vec![
+            AttributeValue::String("AAPL".to_string()),
+            AttributeValue::Double(150.0),
+        ],
+    );
 
     let results = runner.shutdown();
 
@@ -575,29 +681,44 @@ async fn test_first_unique_window_with_count() {
         SELECT count() as cnt\n\
         FROM StockStream WINDOW('firstUnique', symbol);\n";
 
-    let mut runner = AppRunner::new(app, "OutStream").await;
+    let runner = AppRunner::new(app, "OutStream").await;
 
     // Send 3 unique and 2 duplicate
-    runner.send("StockStream", vec![
-        AttributeValue::String("AAPL".to_string()),
-        AttributeValue::Double(100.0),
-    ]);
-    runner.send("StockStream", vec![
-        AttributeValue::String("GOOG".to_string()),
-        AttributeValue::Double(200.0),
-    ]);
-    runner.send("StockStream", vec![
-        AttributeValue::String("AAPL".to_string()), // duplicate
-        AttributeValue::Double(150.0),
-    ]);
-    runner.send("StockStream", vec![
-        AttributeValue::String("MSFT".to_string()),
-        AttributeValue::Double(300.0),
-    ]);
-    runner.send("StockStream", vec![
-        AttributeValue::String("GOOG".to_string()), // duplicate
-        AttributeValue::Double(250.0),
-    ]);
+    runner.send(
+        "StockStream",
+        vec![
+            AttributeValue::String("AAPL".to_string()),
+            AttributeValue::Double(100.0),
+        ],
+    );
+    runner.send(
+        "StockStream",
+        vec![
+            AttributeValue::String("GOOG".to_string()),
+            AttributeValue::Double(200.0),
+        ],
+    );
+    runner.send(
+        "StockStream",
+        vec![
+            AttributeValue::String("AAPL".to_string()), // duplicate
+            AttributeValue::Double(150.0),
+        ],
+    );
+    runner.send(
+        "StockStream",
+        vec![
+            AttributeValue::String("MSFT".to_string()),
+            AttributeValue::Double(300.0),
+        ],
+    );
+    runner.send(
+        "StockStream",
+        vec![
+            AttributeValue::String("GOOG".to_string()), // duplicate
+            AttributeValue::Double(250.0),
+        ],
+    );
 
     let results = runner.shutdown();
 

--- a/tests/app_runner_async_pool_stress.rs
+++ b/tests/app_runner_async_pool_stress.rs
@@ -19,7 +19,6 @@
 mod common;
 use common::AppRunner;
 use eventflux::core::event::value::AttributeValue;
-use std::collections::HashMap;
 use std::thread;
 use std::time::Duration;
 
@@ -48,7 +47,7 @@ async fn async_partition_pool_order() {
         runner.send(
             "In",
             vec![
-                AttributeValue::Int(i as i32),
+                AttributeValue::Int(i),
                 AttributeValue::String(part.to_string()),
             ],
         );

--- a/tests/app_runner_output_rate.rs
+++ b/tests/app_runner_output_rate.rs
@@ -26,9 +26,7 @@ use eventflux::query_api::execution::query::input::InputStream;
 use eventflux::query_api::execution::query::output::output_stream::{
     InsertIntoStreamAction, OutputStream, OutputStreamAction,
 };
-use eventflux::query_api::execution::query::output::ratelimit::{
-    OutputRate, OutputRateBehavior,
-};
+use eventflux::query_api::execution::query::output::ratelimit::{OutputRate, OutputRateBehavior};
 use eventflux::query_api::execution::query::selection::Selector;
 use eventflux::query_api::execution::query::Query;
 use eventflux::query_api::execution::ExecutionElement;

--- a/tests/app_runner_partition_stress.rs
+++ b/tests/app_runner_partition_stress.rs
@@ -40,7 +40,7 @@ async fn partition_async_ordered() {
         runner.send(
             "In",
             vec![
-                AttributeValue::Int(i as i32),
+                AttributeValue::Int(i),
                 AttributeValue::String(p.to_string()),
             ],
         );

--- a/tests/app_runner_patterns.rs
+++ b/tests/app_runner_patterns.rs
@@ -153,8 +153,7 @@ async fn kleene_star_pattern_rejected() {
 
 #[tokio::test]
 async fn sequence_with_timeout() {
-    let mut app =
-        eventflux::query_api::eventflux_app::EventFluxApp::new("Timeout".to_string());
+    let mut app = eventflux::query_api::eventflux_app::EventFluxApp::new("Timeout".to_string());
     let a_def = StreamDefinition::new("A".to_string()).attribute("val".to_string(), AttrType::INT);
     let b_def = StreamDefinition::new("B".to_string()).attribute("val".to_string(), AttrType::INT);
     let out_def = StreamDefinition::new("Out".to_string())
@@ -292,8 +291,7 @@ async fn pattern_alias_two_streams() {
     use eventflux::query_api::execution::query::Query;
     use eventflux::query_api::execution::ExecutionElement;
 
-    let mut app =
-        eventflux::query_api::eventflux_app::EventFluxApp::new("AliasTest".to_string());
+    let mut app = eventflux::query_api::eventflux_app::EventFluxApp::new("AliasTest".to_string());
     let a_def = StreamDefinition::new("StreamA".to_string())
         .attribute("price".to_string(), AttrType::DOUBLE)
         .attribute("symbol".to_string(), AttrType::STRING);

--- a/tests/app_runner_tables.rs
+++ b/tests/app_runner_tables.rs
@@ -80,7 +80,7 @@ fn setup_sqlite_table(ctx: &Arc<EventFluxContext>, name: &str) {
     let ds = ctx.get_data_source("DS1").unwrap();
     let conn_any = ds.get_connection().unwrap();
     let conn_arc = conn_any.downcast::<Arc<Mutex<Connection>>>().unwrap();
-    let mut conn = conn_arc.lock().unwrap();
+    let conn = conn_arc.lock().unwrap();
     let sql = match name {
         "J2" => format!("CREATE TABLE {} (roomNo INTEGER, type TEXT)", name),
         _ => format!("CREATE TABLE {} (v TEXT)", name),
@@ -129,7 +129,7 @@ async fn cache_table_crud_via_app_runner() {
 
 #[tokio::test]
 async fn jdbc_table_crud_via_app_runner() {
-    let mut manager = EventFluxManager::new();
+    let manager = EventFluxManager::new();
     manager
         .add_data_source(
             "DS1".to_string(),
@@ -195,12 +195,10 @@ async fn stream_table_join_basic() {
         FROM L JOIN R ON L.roomNo = R.roomNo;\n";
     let runner = AppRunner::new(query, "Out").await;
     let th = runner.runtime().get_table_input_handler("R").unwrap();
-    th.add(vec![
-        eventflux::core::event::event::Event::new_with_data(
-            0,
-            vec![AttributeValue::Int(1), AttributeValue::String("A".into())],
-        ),
-    ]);
+    th.add(vec![eventflux::core::event::event::Event::new_with_data(
+        0,
+        vec![AttributeValue::Int(1), AttributeValue::String("A".into())],
+    )]);
     runner.send(
         "L",
         vec![AttributeValue::Int(1), AttributeValue::String("v".into())],
@@ -218,7 +216,7 @@ async fn stream_table_join_basic() {
 
 #[tokio::test]
 async fn stream_table_join_jdbc() {
-    let mut manager = EventFluxManager::new();
+    let manager = EventFluxManager::new();
     manager
         .add_data_source(
             "DS1".to_string(),
@@ -238,12 +236,10 @@ async fn stream_table_join_jdbc() {
         FROM L JOIN J2 ON L.roomNo = J2.roomNo;\n";
     let runner = AppRunner::new_with_manager(manager, query, "Out").await;
     let th = runner.runtime().get_table_input_handler("J2").unwrap();
-    th.add(vec![
-        eventflux::core::event::event::Event::new_with_data(
-            0,
-            vec![AttributeValue::Int(2), AttributeValue::String("B".into())],
-        ),
-    ]);
+    th.add(vec![eventflux::core::event::event::Event::new_with_data(
+        0,
+        vec![AttributeValue::Int(2), AttributeValue::String("B".into())],
+    )]);
     runner.send(
         "L",
         vec![AttributeValue::Int(2), AttributeValue::String("x".into())],
@@ -262,7 +258,7 @@ async fn stream_table_join_jdbc() {
 #[tokio::test]
 #[ignore = "INSERT INTO TABLE runtime not implemented - need table insert processor in query execution pipeline"]
 async fn cache_and_jdbc_tables_eviction_and_queries() {
-    let mut manager = EventFluxManager::new();
+    let manager = EventFluxManager::new();
     manager
         .add_data_source(
             "DS1".to_string(),
@@ -373,15 +369,13 @@ async fn test_table_on_left_stream_on_right_join() {
 
     // Add data to table
     let th = runner.runtime().get_table_input_handler("T").unwrap();
-    th.add(vec![
-        eventflux::core::event::event::Event::new_with_data(
-            0,
-            vec![
-                AttributeValue::Int(42),
-                AttributeValue::String("test".into()),
-            ],
-        ),
-    ]);
+    th.add(vec![eventflux::core::event::event::Event::new_with_data(
+        0,
+        vec![
+            AttributeValue::Int(42),
+            AttributeValue::String("test".into()),
+        ],
+    )]);
 
     // Send stream event
     runner.send(
@@ -426,30 +420,26 @@ async fn test_multiple_tables_in_query() {
 
     // Add user data
     let user_handler = runner.runtime().get_table_input_handler("users").unwrap();
-    user_handler.add(vec![
-        eventflux::core::event::event::Event::new_with_data(
-            0,
-            vec![
-                AttributeValue::Int(100),
-                AttributeValue::String("Alice".into()),
-            ],
-        ),
-    ]);
+    user_handler.add(vec![eventflux::core::event::event::Event::new_with_data(
+        0,
+        vec![
+            AttributeValue::Int(100),
+            AttributeValue::String("Alice".into()),
+        ],
+    )]);
 
     // Add product data
     let product_handler = runner
         .runtime()
         .get_table_input_handler("products")
         .unwrap();
-    product_handler.add(vec![
-        eventflux::core::event::event::Event::new_with_data(
-            0,
-            vec![
-                AttributeValue::Int(200),
-                AttributeValue::String("Widget".into()),
-            ],
-        ),
-    ]);
+    product_handler.add(vec![eventflux::core::event::event::Event::new_with_data(
+        0,
+        vec![
+            AttributeValue::Int(200),
+            AttributeValue::String("Widget".into()),
+        ],
+    )]);
 
     // Send event
     runner.send(
@@ -483,15 +473,13 @@ async fn test_table_join_no_match() {
 
     // Add table data with id=1
     let th = runner.runtime().get_table_input_handler("T").unwrap();
-    th.add(vec![
-        eventflux::core::event::event::Event::new_with_data(
-            0,
-            vec![
-                AttributeValue::Int(1),
-                AttributeValue::String("label1".into()),
-            ],
-        ),
-    ]);
+    th.add(vec![eventflux::core::event::event::Event::new_with_data(
+        0,
+        vec![
+            AttributeValue::Int(1),
+            AttributeValue::String("label1".into()),
+        ],
+    )]);
 
     // Send stream event with id=999 (no match)
     runner.send(
@@ -525,15 +513,13 @@ async fn test_table_join_multiple_matches() {
 
     // Add multiple table rows with same category
     let th = runner.runtime().get_table_input_handler("T").unwrap();
-    th.add(vec![
-        eventflux::core::event::event::Event::new_with_data(
-            0,
-            vec![
-                AttributeValue::Int(5),
-                AttributeValue::String("label_a".into()),
-            ],
-        ),
-    ]);
+    th.add(vec![eventflux::core::event::event::Event::new_with_data(
+        0,
+        vec![
+            AttributeValue::Int(5),
+            AttributeValue::String("label_a".into()),
+        ],
+    )]);
 
     // Send stream event
     runner.send(
@@ -575,15 +561,13 @@ async fn test_stream_table_join_with_qualified_names() {
         .runtime()
         .get_table_input_handler("user_profiles")
         .unwrap();
-    th.add(vec![
-        eventflux::core::event::event::Event::new_with_data(
-            0,
-            vec![
-                AttributeValue::Int(123),
-                AttributeValue::String("US".into()),
-            ],
-        ),
-    ]);
+    th.add(vec![eventflux::core::event::event::Event::new_with_data(
+        0,
+        vec![
+            AttributeValue::Int(123),
+            AttributeValue::String("US".into()),
+        ],
+    )]);
 
     // Send order
     runner.send(

--- a/tests/async_annotation_tests.rs
+++ b/tests/async_annotation_tests.rs
@@ -32,13 +32,11 @@
 // - Async configuration with SQL queries
 
 // Tests for async stream configuration via SQL WITH and YAML
-use eventflux::core::config::eventflux_context::EventFluxContext;
 use eventflux::core::eventflux_manager::EventFluxManager;
-use eventflux::query_api::definition::attribute::Type as AttributeType;
 
 #[tokio::test]
 async fn test_async_with_sql_basic() {
-    let mut manager = EventFluxManager::new();
+    let manager = EventFluxManager::new();
 
     // MIGRATED: @Async annotation replaced with SQL WITH clause
     let eventflux_app_string = r#"
@@ -92,7 +90,7 @@ async fn test_async_with_sql_basic() {
 
 #[tokio::test]
 async fn test_async_with_sql_minimal() {
-    let mut manager = EventFluxManager::new();
+    let manager = EventFluxManager::new();
 
     // MIGRATED: Minimal @Async replaced with async.enabled property
     let eventflux_app_string = r#"
@@ -192,7 +190,7 @@ async fn test_app_level_async_via_yaml() {
 
 #[tokio::test]
 async fn test_multiple_async_streams_with_sql() {
-    let mut manager = EventFluxManager::new();
+    let manager = EventFluxManager::new();
 
     // MIGRATED: Multiple @Async annotations replaced with SQL WITH clauses
     let eventflux_app_string = r#"
@@ -247,7 +245,7 @@ async fn test_multiple_async_streams_with_sql() {
 
 #[tokio::test]
 async fn test_async_with_sql_query() {
-    let mut manager = EventFluxManager::new();
+    let manager = EventFluxManager::new();
 
     // MIGRATED: @Async + EventFluxQL query replaced with SQL WITH + SQL query
     let eventflux_app_string = r#"

--- a/tests/builtin_function_parsing.rs
+++ b/tests/builtin_function_parsing.rs
@@ -43,7 +43,7 @@ fn make_query_ctx(name: &str) -> Arc<EventFluxQueryContext> {
     ))
 }
 
-fn empty_ctx(query: &str) -> ExpressionParserContext {
+fn empty_ctx<'a>(query: &'a str) -> ExpressionParserContext<'a> {
     ExpressionParserContext {
         eventflux_app_context: make_app_ctx(),
         eventflux_query_context: make_query_ctx(query),

--- a/tests/builtin_function_parsing.rs
+++ b/tests/builtin_function_parsing.rs
@@ -43,7 +43,7 @@ fn make_query_ctx(name: &str) -> Arc<EventFluxQueryContext> {
     ))
 }
 
-fn empty_ctx<'a>(query: &'a str) -> ExpressionParserContext<'a> {
+fn empty_ctx(query: &str) -> ExpressionParserContext<'_> {
     ExpressionParserContext {
         eventflux_app_context: make_app_ctx(),
         eventflux_query_context: make_query_ctx(query),

--- a/tests/collection_aggregation_integration.rs
+++ b/tests/collection_aggregation_integration.rs
@@ -970,15 +970,15 @@ mod end_to_end_processor_tests {
     use eventflux::core::event::state::MetaStateEvent;
     use eventflux::core::event::state::StateEventCloner;
     use eventflux::core::event::state::StateEventFactory;
-    use eventflux::core::event::stream::MetaStreamEvent;
+
     use eventflux::core::event::stream::StreamEventCloner;
-    use eventflux::core::event::stream::StreamEventFactory;
+
     use eventflux::core::query::input::stream::state::count_post_state_processor::CountPostStateProcessor;
     use eventflux::core::query::input::stream::state::count_pre_state_processor::CountPreStateProcessor;
     use eventflux::core::query::input::stream::state::post_state_processor::PostStateProcessor;
     use eventflux::core::query::input::stream::state::pre_state_processor::PreStateProcessor;
     use eventflux::core::query::input::stream::state::stream_pre_state_processor::StateType;
-    use eventflux::query_api::definition::stream_definition::StreamDefinition;
+
     use eventflux::query_api::EventFluxApp;
 
     /// CapturingPreStateProcessor - captures StateEvents via add_state()
@@ -1082,7 +1082,6 @@ mod end_to_end_processor_tests {
     fn create_wired_count_processor(
         min: usize,
         max: usize,
-        attr_count: usize,
     ) -> (CountPreStateProcessor, Arc<Mutex<Vec<StateEvent>>>) {
         // Create context hierarchy
         let eventflux_ctx = Arc::new(EventFluxContext::new());
@@ -1184,7 +1183,7 @@ mod end_to_end_processor_tests {
     #[ignore = "E2E processor wiring produces double outputs - needs investigation"]
     fn test_e2e_exact_count_3_with_sum() {
         // Simulates: PATTERN (e1=Trade{{3}}) SELECT sum(e1.price)
-        let (mut processor, captured) = create_wired_count_processor(3, 3, 1);
+        let (mut processor, captured) = create_wired_count_processor(3, 3);
 
         // Send exactly 3 events with prices: 100, 200, 300
         processor.process(Some(Box::new(create_price_event(100.0))));
@@ -1229,7 +1228,7 @@ mod end_to_end_processor_tests {
     fn test_e2e_exact_count_3_with_all_aggregations() {
         // Simulates: PATTERN (e1=Trade{{3}})
         // SELECT count(e1), sum(e1.price), avg(e1.price), min(e1.price), max(e1.price)
-        let (mut processor, captured) = create_wired_count_processor(3, 3, 1);
+        let (mut processor, captured) = create_wired_count_processor(3, 3);
 
         processor.process(Some(Box::new(create_price_event(10.0))));
         processor.process(Some(Box::new(create_price_event(20.0))));
@@ -1298,7 +1297,7 @@ mod end_to_end_processor_tests {
     fn test_e2e_range_count_2_to_4_produces_multiple_outputs() {
         // Simulates: PATTERN (e1=Trade{{2,4}}) SELECT sum(e1.price)
         // Should output at count=2, count=3, count=4
-        let (mut processor, captured) = create_wired_count_processor(2, 4, 1);
+        let (mut processor, captured) = create_wired_count_processor(2, 4);
 
         processor.process(Some(Box::new(create_price_event(100.0))));
         processor.process(Some(Box::new(create_price_event(200.0)))); // Output 1: [100, 200]
@@ -1344,7 +1343,7 @@ mod end_to_end_processor_tests {
     #[ignore = "E2E processor wiring produces double outputs - needs investigation"]
     fn test_e2e_chain_order_preserved() {
         // Verify events are chained in arrival order
-        let (mut processor, captured) = create_wired_count_processor(5, 5, 1);
+        let (mut processor, captured) = create_wired_count_processor(5, 5);
 
         // Send events with sequential prices
         for i in 1..=5 {
@@ -1375,7 +1374,7 @@ mod end_to_end_processor_tests {
     fn test_e2e_stddev_on_processor_output() {
         // Simulates: PATTERN (e1=Trade{{8}}) SELECT stdDev(e1.price)
         // Values: [2, 4, 4, 4, 5, 5, 7, 9] -> mean=5, stddev=2
-        let (mut processor, captured) = create_wired_count_processor(8, 8, 1);
+        let (mut processor, captured) = create_wired_count_processor(8, 8);
 
         for price in &[2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0] {
             processor.process(Some(Box::new(create_price_event(*price))));
@@ -1401,7 +1400,7 @@ mod end_to_end_processor_tests {
     #[test]
     fn test_e2e_insufficient_events_no_output() {
         // Simulates: PATTERN (e1=Trade{{5}}) but only send 4 events
-        let (mut processor, captured) = create_wired_count_processor(5, 5, 1);
+        let (mut processor, captured) = create_wired_count_processor(5, 5);
 
         // Send only 4 events (less than required 5)
         for i in 1..=4 {
@@ -1420,7 +1419,7 @@ mod end_to_end_processor_tests {
     #[ignore = "E2E processor wiring produces double outputs - needs investigation"]
     fn test_e2e_min_1_produces_output_on_first_event() {
         // Simulates: PATTERN (e1=Trade{{1,3}}) - should output starting from first event
-        let (mut processor, captured) = create_wired_count_processor(1, 3, 1);
+        let (mut processor, captured) = create_wired_count_processor(1, 3);
 
         processor.process(Some(Box::new(create_price_event(100.0)))); // Output 1
         processor.process(Some(Box::new(create_price_event(200.0)))); // Output 2

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -28,11 +28,13 @@ use eventflux::core::stream::output::stream_callback::StreamCallback;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 
+#[allow(dead_code)]
 #[derive(Debug)]
 struct CollectCallback {
     events: Arc<Mutex<Vec<Vec<AttributeValue>>>>,
 }
 
+#[allow(dead_code)]
 impl StreamCallback for CollectCallback {
     fn receive_events(&self, events: &[Event]) {
         let mut vec = self.events.lock().unwrap();
@@ -42,6 +44,7 @@ impl StreamCallback for CollectCallback {
     }
 }
 
+#[allow(dead_code)]
 #[derive(Debug)]
 pub struct AppRunner {
     runtime: Arc<EventFluxAppRuntime>,
@@ -49,6 +52,7 @@ pub struct AppRunner {
     _manager: EventFluxManager,
 }
 
+#[allow(dead_code)]
 impl AppRunner {
     // ============================================================================
     // TIER 1: Basic Constructors (No Configuration)

--- a/tests/common/pattern_chain_test_utils.rs
+++ b/tests/common/pattern_chain_test_utils.rs
@@ -36,6 +36,7 @@ use eventflux::query_api::definition::stream_definition::StreamDefinition;
 use eventflux::query_api::eventflux_app::EventFluxApp;
 use std::sync::{Arc, Mutex};
 
+#[allow(dead_code)]
 /// Create test contexts for pattern chain tests
 pub fn create_test_contexts() -> (Arc<EventFluxAppContext>, Arc<EventFluxQueryContext>) {
     let eventflux_context = Arc::new(EventFluxContext::new());
@@ -54,6 +55,7 @@ pub fn create_test_contexts() -> (Arc<EventFluxAppContext>, Arc<EventFluxQueryCo
     (app_ctx, query_ctx)
 }
 
+#[allow(dead_code)]
 /// Create a stream definition for testing
 pub fn create_stream_definition(name: &str) -> Arc<StreamDefinition> {
     Arc::new(
@@ -61,11 +63,13 @@ pub fn create_stream_definition(name: &str) -> Arc<StreamDefinition> {
     )
 }
 
+#[allow(dead_code)]
 /// Create a StreamEvent with specified timestamp
 pub fn create_stream_event(timestamp: i64) -> StreamEvent {
     StreamEvent::new(timestamp, 0, 0, 0)
 }
 
+#[allow(dead_code)]
 /// Build a pattern chain with specified number of steps
 pub fn build_pattern_chain(
     steps: Vec<(String, String, usize, usize)>, // (alias, stream_name, min, max)
@@ -116,6 +120,7 @@ pub fn build_pattern_chain(
     (chain, collector)
 }
 
+#[allow(dead_code)]
 /// Build a pattern chain with WITHIN time constraint
 pub fn build_pattern_chain_with_within(
     steps: Vec<(String, String, usize, usize)>,
@@ -182,11 +187,13 @@ pub fn build_pattern_chain_with_within(
     (chain, collector)
 }
 
+#[allow(dead_code)]
 /// Output collector for capturing pattern match results
 pub struct OutputCollector {
     outputs: Arc<Mutex<Vec<StateEvent>>>,
 }
 
+#[allow(dead_code)]
 impl OutputCollector {
     pub fn new() -> Self {
         Self {
@@ -210,6 +217,7 @@ impl OutputCollector {
     }
 }
 
+#[allow(dead_code)]
 /// PostStateProcessor wrapper that captures outputs
 #[derive(Debug)]
 pub struct CollectorPostProcessor {

--- a/tests/compatibility/functions/math_functions.rs
+++ b/tests/compatibility/functions/math_functions.rs
@@ -786,6 +786,7 @@ async fn function_test_trunc_negative() {
 
 /// Test trunc function with precision
 #[tokio::test]
+#[allow(clippy::approx_constant)]
 async fn function_test_trunc_with_precision() {
     let app = "\
         CREATE STREAM inputStream (value DOUBLE);\n\
@@ -796,7 +797,9 @@ async fn function_test_trunc_with_precision() {
     runner.send("inputStream", vec![AttributeValue::Double(3.14159)]);
     let out = runner.shutdown();
     assert_eq!(out.len(), 1);
-    assert_eq!(out[0][0], AttributeValue::Double(3.14)); // Truncate to 2 decimal places
+    #[allow(clippy::approx_constant)]
+    let expected = AttributeValue::Double(3.14); // Truncate to 2 decimal places
+    assert_eq!(out[0][0], expected);
 }
 
 /// Test truncate alias
@@ -831,8 +834,8 @@ async fn function_test_asin_basic() {
     let out = runner.shutdown();
     assert_eq!(out.len(), 1);
     if let AttributeValue::Double(result) = out[0][0] {
-        // asin(0.5) ≈ 0.5235987755982989 (π/6)
-        assert!((result - 0.5235987755982989).abs() < 0.0001);
+        // asin(0.5) ≈ π/6
+        assert!((result - std::f64::consts::FRAC_PI_6).abs() < 0.0001);
     } else {
         panic!("Expected Double value");
     }
@@ -905,8 +908,8 @@ async fn function_test_acos_basic() {
     let out = runner.shutdown();
     assert_eq!(out.len(), 1);
     if let AttributeValue::Double(result) = out[0][0] {
-        // acos(0.5) ≈ 1.0471975511965979 (π/3)
-        assert!((result - 1.0471975511965979).abs() < 0.0001);
+        // acos(0.5) ≈ π/3
+        assert!((result - std::f64::consts::FRAC_PI_3).abs() < 0.0001);
     } else {
         panic!("Expected Double value");
     }

--- a/tests/compatibility/functions/utility_functions.rs
+++ b/tests/compatibility/functions/utility_functions.rs
@@ -591,7 +591,7 @@ async fn function_test_default_float_to_double() {
     let out = runner.shutdown();
     assert_eq!(out.len(), 1);
     if let AttributeValue::Double(v) = out[0][0] {
-        assert!((v - 3.14159265358979).abs() < 0.0001);
+        assert!((v - std::f64::consts::PI).abs() < 0.0001);
     } else {
         panic!("Expected Double value");
     }
@@ -599,6 +599,7 @@ async fn function_test_default_float_to_double() {
 
 /// Test default with INT and DOUBLE widening
 #[tokio::test]
+#[allow(clippy::approx_constant)]
 async fn function_test_default_int_to_double() {
     let app = "\
         CREATE STREAM inputStream (value INT);\n\

--- a/tests/compatibility/joins.rs
+++ b/tests/compatibility/joins.rs
@@ -2237,7 +2237,7 @@ async fn join_test_avg_agg() {
         };
         // Values should be in range of the input quantities
         assert!(
-            avg_val >= 3.0 && avg_val <= 9.0,
+            (3.0..=9.0).contains(&avg_val),
             "avg={} should be between 3 and 9",
             avg_val
         );

--- a/tests/compatibility/partitions.rs
+++ b/tests/compatibility/partitions.rs
@@ -3794,7 +3794,7 @@ async fn partition_test116_uuid() {
     let out = runner.shutdown();
     assert_eq!(out.len(), 1);
     if let AttributeValue::String(uuid) = &out[0][1] {
-        assert!(uuid.len() > 0);
+        assert!(!uuid.is_empty());
     } else {
         panic!("Expected string UUID");
     }

--- a/tests/compatibility/tables.rs
+++ b/tests/compatibility/tables.rs
@@ -1303,6 +1303,7 @@ async fn table_mutation_update_with_expression() {
 
 /// UPSERT with different data types
 #[tokio::test]
+#[allow(clippy::approx_constant)]
 async fn table_mutation_upsert_different_types() {
     let app = "\
         CREATE TABLE dataTable (id INT, name STRING, value DOUBLE, active BOOL) WITH (extension = 'inMemory');\n\
@@ -3079,7 +3080,7 @@ async fn table_test_coalesce() {
         ],
     );
     let out = runner.shutdown();
-    assert!(out.len() >= 1);
+    assert!(!out.is_empty());
     // First lookup returns table value "dark"
     assert_eq!(out[0][0], AttributeValue::String("dark".to_string()));
 }
@@ -3488,7 +3489,7 @@ async fn table_test_update_same_key() {
     );
     let out = runner.shutdown();
     // Should get at least one result
-    assert!(out.len() >= 1);
+    assert!(!out.is_empty());
 }
 
 /// Table with integer multiplication
@@ -3998,7 +3999,7 @@ async fn table_test_update() {
     );
     let out = runner.shutdown();
     // Second insert should update the value
-    assert!(out.len() >= 1);
+    assert!(!out.is_empty());
     let last = out.last().unwrap();
     assert_eq!(last[1], AttributeValue::Int(200));
 }
@@ -4975,7 +4976,7 @@ async fn table_test_update_on_duplicate() {
     );
     let out = runner.shutdown();
     // Second insert should update the row
-    assert!(out.len() >= 1);
+    assert!(!out.is_empty());
     // The last output should be "Bob"
     let last_name = &out[out.len() - 1][1];
     assert_eq!(last_name, &AttributeValue::String("Bob".to_string()));
@@ -5622,7 +5623,7 @@ async fn table_test_uuid_select() {
     let out = runner.shutdown();
     assert_eq!(out.len(), 1);
     if let AttributeValue::String(uuid) = &out[0][1] {
-        assert!(uuid.len() > 0);
+        assert!(!uuid.is_empty());
     } else {
         panic!("Expected string UUID");
     }

--- a/tests/compatibility/triggers.rs
+++ b/tests/compatibility/triggers.rs
@@ -169,6 +169,12 @@ async fn trigger_test10_batch_processing() {
     let runner = AppRunner::new(app, "outputStream").await;
     sleep(Duration::from_millis(50));
     let out = runner.shutdown();
-    // Output depends on window implementation
-    assert!(out.len() >= 0);
+    // No data was sent to inputStream. The sliding time window should produce
+    // no output because no events entered the window.
+    // Sleep (50ms) is shorter than the trigger interval (100ms) to minimize race risk.
+    assert!(
+        out.is_empty(),
+        "Expected no output since no data was sent to inputStream, got {} events",
+        out.len()
+    );
 }

--- a/tests/compatibility/windows.rs
+++ b/tests/compatibility/windows.rs
@@ -1111,7 +1111,7 @@ async fn time_window_test4_avg_aggregation() {
     // Check that avg values are reasonable (100-200 range depending on timing)
     let has_valid_avg = out.iter().any(|row| {
         if let AttributeValue::Double(avg) = row[0] {
-            avg >= 100.0 && avg <= 200.0
+            (100.0..=200.0).contains(&avg)
         } else {
             false
         }
@@ -1168,7 +1168,7 @@ async fn expression_window_test1_basic() {
         INSERT INTO outputStream\n\
         SELECT symbol, sum(price) AS total \
         FROM stockStream WINDOW('expression', 'count() <= 2');\n";
-    let mut runner = AppRunner::new(app, "outputStream").await;
+    let runner = AppRunner::new(app, "outputStream").await;
     runner.send(
         "stockStream",
         vec![
@@ -2724,10 +2724,15 @@ async fn time_batch_window_test_multi_group() {
             AttributeValue::Float(110.0),
         ],
     );
-    sleep(Duration::from_millis(2100));
+    // Allow generous margin above the 2000ms window for CI environments under load
+    sleep(Duration::from_millis(3500));
     let out = runner.shutdown();
-    // May have outputs depending on batch timing
-    assert!(out.len() >= 0);
+    // After the 2-second batch window expires, grouped results should be emitted.
+    // Two events with different (symbol, region) keys should produce 2 output rows.
+    assert!(
+        !out.is_empty(),
+        "Expected output from timeBatch window after batch expiry"
+    );
 }
 
 /// Window with uuid() function
@@ -3034,7 +3039,6 @@ async fn length_batch_window_test_count() {
     }
     let out = runner.shutdown();
     // Batch output may or may not fire depending on timing
-    assert!(out.len() >= 0);
     if !out.is_empty() {
         assert_eq!(out[0][0], AttributeValue::Long(3));
     }
@@ -3098,7 +3102,7 @@ async fn time_batch_window_test_with_filter() {
     tokio::time::sleep(tokio::time::Duration::from_millis(300)).await;
     let out = runner.shutdown();
     // Only events with price > 100 should be counted (150 + 200 = 350)
-    assert!(out.len() >= 1);
+    assert!(!out.is_empty());
 }
 
 /// Length batch window with MAX aggregation
@@ -3195,7 +3199,7 @@ async fn length_window_test_string_length_agg() {
     );
     let out = runner.shutdown();
     // Output for each event as window fills
-    assert!(out.len() >= 1);
+    assert!(!out.is_empty());
 }
 
 /// Time window with large interval
@@ -3214,7 +3218,7 @@ async fn time_window_test_large_interval() {
     runner.send("eventStream", vec![AttributeValue::Int(3)]);
     let out = runner.shutdown();
     // All events should be in the window
-    assert!(out.len() >= 1);
+    assert!(!out.is_empty());
     // Last output should have count of all events
     let last_count = match out.last().unwrap()[0] {
         AttributeValue::Int(c) => c,
@@ -3289,7 +3293,7 @@ async fn length_window_test_double_multiplication() {
         vec![AttributeValue::Double(20.25), AttributeValue::Int(3)],
     );
     let out = runner.shutdown();
-    assert!(out.len() >= 1);
+    assert!(!out.is_empty());
 }
 
 /// Length window with multiple COUNT aggregations
@@ -3324,7 +3328,7 @@ async fn length_window_test_multiple_counts() {
         ],
     );
     let out = runner.shutdown();
-    assert!(out.len() >= 1);
+    assert!(!out.is_empty());
 }
 
 /// Time batch window with AVG aggregation
@@ -3362,7 +3366,7 @@ async fn time_batch_window_test_avg() {
     tokio::time::sleep(tokio::time::Duration::from_millis(300)).await;
     let out = runner.shutdown();
     // Should have output with avg temperature around 22.0
-    assert!(out.len() >= 1);
+    assert!(!out.is_empty());
 }
 
 /// Length window with CASE WHEN in select (tier classification)
@@ -4486,7 +4490,7 @@ async fn length_window_test_not_equal_filter() {
     );
     let out = runner.shutdown();
     // Only ACTIVE status events pass the filter
-    assert!(out.len() >= 1);
+    assert!(!out.is_empty());
 }
 
 /// Length batch window with LTE filter

--- a/tests/custom_dyn_ext/Cargo.lock
+++ b/tests/custom_dyn_ext/Cargo.lock
@@ -431,6 +431,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "backon"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
+dependencies = [
+ "fastrand 2.3.0",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -814,9 +823,9 @@ dependencies = [
 
 [[package]]
 name = "deadpool-redis"
-version = "0.15.1"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff315fab2a7a42132352909afc81140d06b8bbfd1414b098ce278e3f95dd1b9"
+checksum = "bfae6799b68a735270e4344ee3e834365f707c72da09c9a8bb89b45cc3351395"
 dependencies = [
  "deadpool",
  "redis",
@@ -1680,6 +1689,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2330,7 +2348,7 @@ checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
  "heck",
- "itertools",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "once_cell",
@@ -2350,7 +2368,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn",
@@ -2510,24 +2528,26 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "0.25.4"
+version = "0.27.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0d7a6955c7511f60f3ba9e86c6d02b3c3f144f8c24b288d1f4e18074ab8bbec"
+checksum = "09d8f99a4090c89cc489a94833c901ead69bfbf3877b4867d5482e321ee875bc"
 dependencies = [
  "arc-swap",
  "async-trait",
+ "backon",
  "bytes",
  "combine",
  "futures",
  "futures-util",
+ "itertools 0.13.0",
  "itoa",
+ "num-bigint",
  "percent-encoding",
  "pin-project-lite",
  "ryu",
  "sha1_smol",
  "socket2 0.5.10",
  "tokio",
- "tokio-retry",
  "tokio-util",
  "url",
 ]
@@ -3221,17 +3241,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
- "tokio",
-]
-
-[[package]]
-name = "tokio-retry"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
-dependencies = [
- "pin-project",
- "rand 0.8.5",
  "tokio",
 ]
 

--- a/tests/custom_dyn_ext/src/lib.rs
+++ b/tests/custom_dyn_ext/src/lib.rs
@@ -15,18 +15,20 @@
  * limitations under the License.
  */
 
-use std::sync::{Arc, Mutex};
-use eventflux::core::config::{eventflux_app_context::EventFluxAppContext, eventflux_query_context::EventFluxQueryContext};
+use eventflux::core::config::{
+    eventflux_app_context::EventFluxAppContext, eventflux_query_context::EventFluxQueryContext,
+};
 use eventflux::core::event::complex_event::ComplexEvent;
 use eventflux::core::event::value::AttributeValue;
-use eventflux::core::extension::WindowProcessorFactory;
+use eventflux::core::eventflux_manager::EventFluxManager;
 use eventflux::core::executor::expression_executor::ExpressionExecutor;
 use eventflux::core::executor::function::scalar_function_executor::ScalarFunctionExecutor;
-use eventflux::core::query::processor::{CommonProcessorMeta, ProcessingMode, Processor};
+use eventflux::core::extension::WindowProcessorFactory;
 use eventflux::core::query::processor::stream::window::WindowProcessor;
-use eventflux::core::eventflux_manager::EventFluxManager;
+use eventflux::core::query::processor::{CommonProcessorMeta, ProcessingMode, Processor};
 use eventflux::query_api::definition::attribute::Type as AttrType;
 use eventflux::query_api::execution::query::input::handler::WindowHandler;
+use std::sync::{Arc, Mutex};
 
 #[derive(Debug)]
 struct DynWindowProcessor {
@@ -49,7 +51,12 @@ impl Processor for DynWindowProcessor {
     }
 
     fn clone_processor(&self, q: &Arc<EventFluxQueryContext>) -> Box<dyn Processor> {
-        Box::new(DynWindowProcessor { meta: CommonProcessorMeta::new(Arc::clone(&self.meta.eventflux_app_context), Arc::clone(q)) })
+        Box::new(DynWindowProcessor {
+            meta: CommonProcessorMeta::new(
+                Arc::clone(&self.meta.eventflux_app_context),
+                Arc::clone(q),
+            ),
+        })
     }
 
     fn get_eventflux_app_context(&self) -> Arc<EventFluxAppContext> {
@@ -73,11 +80,23 @@ impl WindowProcessor for DynWindowProcessor {}
 #[derive(Debug, Clone)]
 struct DynWindowFactory;
 impl WindowProcessorFactory for DynWindowFactory {
-    fn name(&self) -> &'static str { "dynWindow" }
-    fn create(&self, _h: &WindowHandler, app: Arc<EventFluxAppContext>, q: Arc<EventFluxQueryContext>, _parse_ctx: &eventflux::core::util::parser::expression_parser::ExpressionParserContext) -> Result<Arc<Mutex<dyn Processor>>, String> {
-        Ok(Arc::new(Mutex::new(DynWindowProcessor { meta: CommonProcessorMeta::new(app, q) })))
+    fn name(&self) -> &'static str {
+        "dynWindow"
     }
-    fn clone_box(&self) -> Box<dyn WindowProcessorFactory> { Box::new(self.clone()) }
+    fn create(
+        &self,
+        _h: &WindowHandler,
+        app: Arc<EventFluxAppContext>,
+        q: Arc<EventFluxQueryContext>,
+        _parse_ctx: &eventflux::core::util::parser::expression_parser::ExpressionParserContext,
+    ) -> Result<Arc<Mutex<dyn Processor>>, String> {
+        Ok(Arc::new(Mutex::new(DynWindowProcessor {
+            meta: CommonProcessorMeta::new(app, q),
+        })))
+    }
+    fn clone_box(&self) -> Box<dyn WindowProcessorFactory> {
+        Box::new(self.clone())
+    }
 }
 
 #[derive(Debug, Default)]
@@ -85,7 +104,9 @@ struct DynPlusOne {
     arg: Option<Box<dyn ExpressionExecutor>>,
 }
 impl Clone for DynPlusOne {
-    fn clone(&self) -> Self { Self { arg: None } }
+    fn clone(&self) -> Self {
+        Self { arg: None }
+    }
 }
 impl ExpressionExecutor for DynPlusOne {
     fn execute(&self, event: Option<&dyn ComplexEvent>) -> Option<AttributeValue> {
@@ -95,20 +116,32 @@ impl ExpressionExecutor for DynPlusOne {
             _ => None,
         }
     }
-    fn get_return_type(&self) -> AttrType { AttrType::INT }
+    fn get_return_type(&self) -> AttrType {
+        AttrType::INT
+    }
     fn clone_executor(&self, _c: &Arc<EventFluxAppContext>) -> Box<dyn ExpressionExecutor> {
         Box::new(self.clone())
     }
 }
 impl ScalarFunctionExecutor for DynPlusOne {
-    fn init(&mut self, args: &Vec<Box<dyn ExpressionExecutor>>, ctx: &Arc<EventFluxAppContext>) -> Result<(), String> {
-        if args.len() != 1 { return Err("dynPlusOne expects one argument".to_string()); }
+    fn init(
+        &mut self,
+        args: &[Box<dyn ExpressionExecutor>],
+        ctx: &Arc<EventFluxAppContext>,
+    ) -> Result<(), String> {
+        if args.len() != 1 {
+            return Err("dynPlusOne expects one argument".to_string());
+        }
         self.arg = Some(args[0].clone_executor(ctx));
         Ok(())
     }
     fn destroy(&mut self) {}
-    fn get_name(&self) -> String { "dynPlusOne".to_string() }
-    fn clone_scalar_function(&self) -> Box<dyn ScalarFunctionExecutor> { Box::new(self.clone()) }
+    fn get_name(&self) -> String {
+        "dynPlusOne".to_string()
+    }
+    fn clone_scalar_function(&self) -> Box<dyn ScalarFunctionExecutor> {
+        Box::new(self.clone())
+    }
 }
 
 #[no_mangle]
@@ -129,6 +162,10 @@ pub fn library_path() -> std::path::PathBuf {
     let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     p.push("../../target/debug/deps");
     p = p.canonicalize().unwrap_or(p);
-    p.push(format!("{}custom_dyn_ext.{}", std::env::consts::DLL_PREFIX, std::env::consts::DLL_EXTENSION));
+    p.push(format!(
+        "{}custom_dyn_ext.{}",
+        std::env::consts::DLL_PREFIX,
+        std::env::consts::DLL_EXTENSION
+    ));
     p
 }

--- a/tests/distributed_grpc_integration.rs
+++ b/tests/distributed_grpc_integration.rs
@@ -17,14 +17,12 @@
 
 // Integration test for gRPC transport in distributed mode
 
-use eventflux::core::distributed::grpc::simple_transport::{
-    SimpleGrpcConfig, SimpleGrpcTransport,
-};
+use eventflux::core::distributed::grpc::simple_transport::{SimpleGrpcConfig, SimpleGrpcTransport};
 use eventflux::core::distributed::transport::{Message, MessageType};
 
 #[tokio::test]
 async fn test_simple_grpc_transport_creation() {
-    let transport = SimpleGrpcTransport::new();
+    let _transport = SimpleGrpcTransport::new();
     // Transport created successfully
 
     let custom_config = SimpleGrpcConfig {
@@ -45,7 +43,7 @@ fn test_grpc_message_conversion() {
         .with_header("target_node".to_string(), "node2".to_string());
 
     let proto_message = transport.to_proto_message(&original_message);
-    let converted_message = transport.from_proto_message(&proto_message);
+    let converted_message = transport.decode_proto_message(&proto_message);
 
     assert_eq!(original_message.id, converted_message.id);
     assert_eq!(original_message.payload, converted_message.payload);
@@ -78,7 +76,7 @@ fn test_grpc_message_types() {
         };
 
         let proto_message = transport.to_proto_message(&original_message);
-        let converted_message = transport.from_proto_message(&proto_message);
+        let converted_message = transport.decode_proto_message(&proto_message);
 
         assert_eq!(
             original_message.message_type,
@@ -92,7 +90,7 @@ fn test_grpc_message_types() {
 fn test_grpc_config_validation() {
     let config = SimpleGrpcConfig::default();
     assert_eq!(config.connection_timeout_ms, 10000);
-    assert_eq!(config.enable_compression, true);
+    assert!(config.enable_compression);
     assert_eq!(config.server_address, "127.0.0.1:50051");
 
     let custom_config = SimpleGrpcConfig {
@@ -101,7 +99,7 @@ fn test_grpc_config_validation() {
         server_address: "0.0.0.0:9090".to_string(),
     };
     assert_eq!(custom_config.connection_timeout_ms, 15000);
-    assert_eq!(custom_config.enable_compression, false);
+    assert!(!custom_config.enable_compression);
     assert_eq!(custom_config.server_address, "0.0.0.0:9090");
 }
 
@@ -158,7 +156,7 @@ async fn test_grpc_message_serialization_with_headers() {
     assert_eq!(proto_message.priority, 5);
 
     // Test round-trip conversion
-    let converted_message = transport.from_proto_message(&proto_message);
+    let converted_message = transport.decode_proto_message(&proto_message);
     assert_eq!(original_message.id, converted_message.id);
     assert_eq!(original_message.payload, converted_message.payload);
     assert_eq!(

--- a/tests/distributed_redis_state.rs
+++ b/tests/distributed_redis_state.rs
@@ -23,9 +23,7 @@
 //! state management. Tests include connection pooling, state operations,
 //! checkpoint/restore functionality, and error handling.
 
-use eventflux::core::distributed::{
-    DistributedError, RedisBackend, RedisConfig, StateBackend,
-};
+use eventflux::core::distributed::{DistributedError, RedisBackend, RedisConfig, StateBackend};
 use std::time::Duration;
 use uuid::Uuid;
 

--- a/tests/distributed_tcp_integration.rs
+++ b/tests/distributed_tcp_integration.rs
@@ -22,7 +22,6 @@ use eventflux::core::distributed::transport::{
 };
 use eventflux::core::distributed::DistributedError;
 use std::sync::Arc;
-use tokio;
 
 fn is_socket_permission_denied(err: &DistributedError) -> bool {
     match err {

--- a/tests/error_handling_integration_tests.rs
+++ b/tests/error_handling_integration_tests.rs
@@ -346,6 +346,7 @@ fn test_dlq_event_delivery_action() {
 }
 
 #[test]
+#[allow(clippy::approx_constant)]
 fn test_dlq_preserves_original_event_data() {
     // Create event with complex data
     let original_event = Event::new_with_data(

--- a/tests/error_routing.rs
+++ b/tests/error_routing.rs
@@ -143,7 +143,12 @@ fn test_fault_stream_routing() {
             events: Arc::clone(&rec),
         })));
     main_junction.stop_processing();
-    main_junction.send_event(Event::new_with_data(0, vec![AttributeValue::Int(1)]));
+    // send_event after stop returns Err, but the error routing side effect is what we test
+    let result = main_junction.send_event(Event::new_with_data(0, vec![AttributeValue::Int(1)]));
+    assert!(
+        result.is_err(),
+        "Expected send to fail after stop_processing"
+    );
     assert_eq!(rec.lock().unwrap().len(), 1);
 }
 
@@ -175,6 +180,11 @@ fn test_error_store_routing() {
     .unwrap();
     junction.set_on_error_action(OnErrorAction::STORE);
     junction.stop_processing();
-    junction.send_event(Event::new_with_data(0, vec![AttributeValue::Int(2)]));
+    // send_event after stop returns Err, but the error routing side effect is what we test
+    let result = junction.send_event(Event::new_with_data(0, vec![AttributeValue::Int(2)]));
+    assert!(
+        result.is_err(),
+        "Expected send to fail after stop_processing"
+    );
     assert_eq!(error_store.errors().len(), 1);
 }

--- a/tests/expression_parser_complex.rs
+++ b/tests/expression_parser_complex.rs
@@ -127,9 +127,7 @@ fn test_compare_type_coercion_int_double() {
     let result = exec.execute(None);
     assert_eq!(
         result,
-        Some(eventflux::core::event::value::AttributeValue::Bool(
-            true
-        ))
+        Some(eventflux::core::event::value::AttributeValue::Bool(true))
     );
 }
 
@@ -171,7 +169,7 @@ fn test_variable_not_found_error() {
 #[test]
 fn test_table_variable_resolution() {
     use eventflux::query_api::definition::TableDefinition;
-    let table = TableDefinition::new("T".to_string()).attribute("val".to_string(), AttrType::INT);
+    let _table = TableDefinition::new("T".to_string()).attribute("val".to_string(), AttrType::INT);
     let stream_equiv = Arc::new(
         StreamDefinition::new("T".to_string()).attribute("val".to_string(), AttrType::INT),
     );
@@ -242,7 +240,7 @@ fn test_custom_udf_plus_one() {
     impl ScalarFunctionExecutor for PlusOneFn {
         fn init(
             &mut self,
-            args: &Vec<Box<dyn ExpressionExecutor>>,
+            args: &[Box<dyn ExpressionExecutor>],
             _ctx: &Arc<EventFluxAppContext>,
         ) -> Result<(), String> {
             if args.len() != 1 {
@@ -320,7 +318,7 @@ fn test_join_query_parsing() {
         None,
         None,
     );
-    let mut selector = eventflux::query_api::execution::query::selection::Selector::new();
+    let selector = eventflux::query_api::execution::query::selection::Selector::new();
     let insert_action =
         eventflux::query_api::execution::query::output::output_stream::InsertIntoStreamAction {
             target_id: "Out".to_string(),
@@ -389,7 +387,7 @@ fn test_join_query_parsing() {
     assert!(res.is_ok());
 
     // Also ensure expression parsing works standalone
-    let mut left_meta = MetaStreamEvent::new_for_single_input(Arc::clone(&left_def));
+    let left_meta = MetaStreamEvent::new_for_single_input(Arc::clone(&left_def));
     let mut right_meta = MetaStreamEvent::new_for_single_input(Arc::clone(&right_def));
     right_meta.apply_attribute_offset(1);
     let mut map = HashMap::new();
@@ -432,7 +430,7 @@ fn test_pattern_query_parsing() {
     let next = State::next(StateElement::Stream(sse1), StateElement::Stream(sse2));
     let state_stream = StateInputStream::sequence_stream(next, None);
     let input = InputStream::State(Box::new(state_stream));
-    let mut selector = eventflux::query_api::execution::query::selection::Selector::new();
+    let selector = eventflux::query_api::execution::query::selection::Selector::new();
     let insert_action =
         eventflux::query_api::execution::query::output::output_stream::InsertIntoStreamAction {
             target_id: "Out".to_string(),
@@ -615,7 +613,7 @@ async fn test_app_runner_table_in_lookup() {
         InsertIntoStreamAction, OutputStream, OutputStreamAction,
     };
     use eventflux::query_api::execution::query::selection::Selector;
-    use eventflux::query_api::execution::query::{OutputAttribute, Query};
+    use eventflux::query_api::execution::query::Query;
 
     use eventflux::core::config::stream_config::{FlatConfig, PropertySource};
 
@@ -741,7 +739,7 @@ async fn test_app_runner_custom_udf() {
     impl ScalarFunctionExecutor for PlusOneFn {
         fn init(
             &mut self,
-            args: &Vec<Box<dyn ExpressionExecutor>>,
+            args: &[Box<dyn ExpressionExecutor>],
             ctx: &std::sync::Arc<
                 eventflux::core::config::eventflux_app_context::EventFluxAppContext,
             >,
@@ -761,7 +759,7 @@ async fn test_app_runner_custom_udf() {
         }
     }
 
-    let mut manager = EventFluxManager::new();
+    let manager = EventFluxManager::new();
     manager.add_scalar_function_factory("plusOne".to_string(), Box::new(PlusOneFn::default()));
 
     let app = "\

--- a/tests/extensions.rs
+++ b/tests/extensions.rs
@@ -121,9 +121,8 @@ impl AttributeAggregatorFactory for ConstAggFactory {
     }
     fn create(
         &self,
-    ) -> Box<
-        dyn eventflux::core::query::selector::attribute::aggregator::AttributeAggregatorExecutor,
-    >{
+    ) -> Box<dyn eventflux::core::query::selector::attribute::aggregator::AttributeAggregatorExecutor>
+    {
         Box::new(ConstAggExec)
     }
     fn clone_box(&self) -> Box<dyn AttributeAggregatorFactory> {
@@ -283,20 +282,19 @@ fn test_register_window_factory() {
     ));
 
     // Create minimal ExpressionParserContext for the test
-    let parse_ctx =
-        eventflux::core::util::parser::expression_parser::ExpressionParserContext {
-            eventflux_app_context: Arc::clone(&app_ctx),
-            eventflux_query_context: Arc::clone(&q_ctx),
-            stream_meta_map: std::collections::HashMap::new(),
-            table_meta_map: std::collections::HashMap::new(),
-            window_meta_map: std::collections::HashMap::new(),
-            aggregation_meta_map: std::collections::HashMap::new(),
-            state_meta_map: std::collections::HashMap::new(),
-            stream_positions: std::collections::HashMap::new(),
-            default_source: String::new(),
-            query_name: "test_query",
-            is_mutation_context: false,
-        };
+    let parse_ctx = eventflux::core::util::parser::expression_parser::ExpressionParserContext {
+        eventflux_app_context: Arc::clone(&app_ctx),
+        eventflux_query_context: Arc::clone(&q_ctx),
+        stream_meta_map: std::collections::HashMap::new(),
+        table_meta_map: std::collections::HashMap::new(),
+        window_meta_map: std::collections::HashMap::new(),
+        aggregation_meta_map: std::collections::HashMap::new(),
+        state_meta_map: std::collections::HashMap::new(),
+        stream_positions: std::collections::HashMap::new(),
+        default_source: String::new(),
+        query_name: "test_query",
+        is_mutation_context: false,
+    };
 
     let res = eventflux::core::query::processor::stream::window::create_window_processor(
         &handler, app_ctx, q_ctx, &parse_ctx,

--- a/tests/in_expression_executor.rs
+++ b/tests/in_expression_executor.rs
@@ -34,7 +34,9 @@ fn make_context_with_table() -> Arc<EventFluxAppContext> {
         String::new(),
     ));
     let table: Arc<dyn Table> = Arc::new(InMemoryTable::new());
-    table.insert(&[AttributeValue::Int(1)]);
+    table
+        .insert(&[AttributeValue::Int(1)])
+        .expect("Failed to insert test data");
     ctx.get_eventflux_context()
         .add_table("MyTable".to_string(), table);
     ctx

--- a/tests/incremental_aggregation.rs
+++ b/tests/incremental_aggregation.rs
@@ -81,7 +81,7 @@ fn test_incremental_executor_basic() {
     );
     let exec = parse_expression(&expr, &ctx).unwrap();
     let table = Arc::new(InMemoryTable::new());
-    let mut inc = IncrementalExecutor::new(
+    let inc = IncrementalExecutor::new(
         TimeDuration::Seconds,
         vec![exec],
         Box::new(|_| "key".to_string()),

--- a/tests/integration_config_monitoring.rs
+++ b/tests/integration_config_monitoring.rs
@@ -22,12 +22,12 @@
 
 use eventflux::core::config::{
     monitoring::{
-        AlertRule, AlertingConfig, CheckResult, CustomMetric, EndpointConfig, HealthCheck,
-        HealthCheckConfig, HealthCheckType, HealthState, HealthStatus, LoggingConfig, MetricType,
-        MetricsConfig, MetricsExporter, MetricsExporterType, MonitoringConfig, NotificationChannel,
+        AlertRule, CheckResult, CustomMetric, EndpointConfig, HealthCheck, HealthCheckConfig,
+        HealthCheckType, HealthState, HealthStatus, LoggingConfig, MetricType, MetricsConfig,
+        MetricsExporter, MetricsExporterType, MonitoringConfig, NotificationChannel,
         NotificationChannelType, ObservabilityConfig, ProbeConfig, TracingConfig,
     },
-    ConfigManager, EventFluxConfig,
+    ConfigManager,
 };
 use std::collections::HashMap;
 use std::time::Duration;

--- a/tests/integration_config_runtime_integration.rs
+++ b/tests/integration_config_runtime_integration.rs
@@ -26,16 +26,13 @@ use eventflux::core::config::{
     ApplicationConfig, ConfigManager, ConfigValue, EventFluxConfig, ProcessorConfigReader,
     RuntimeMode,
 };
-use eventflux::core::event::{Event, StreamEvent};
-use eventflux::core::eventflux_manager::EventFluxManager as Manager;
+use eventflux::core::event::Event;
 use eventflux::core::stream::output::stream_callback::StreamCallback;
 use eventflux::core::EventFluxManager;
 use serial_test::serial;
-use std::collections::HashMap;
 use std::io::Write;
 use std::sync::{Arc, Mutex};
 use tempfile::NamedTempFile;
-use tokio;
 
 /// Test data structure to collect output events
 #[derive(Debug, Clone, Default)]
@@ -44,6 +41,7 @@ struct TestEventCollector {
     callback_count: Arc<Mutex<usize>>,
 }
 
+#[allow(dead_code)]
 impl TestEventCollector {
     fn new() -> Self {
         Self {
@@ -234,7 +232,7 @@ async fn test_yaml_config_to_runtime_integration() {
         .expect("Failed to start runtime");
 
     // Get input handler and send test events
-    let input_handler = eventflux_app_runtime
+    let _input_handler = eventflux_app_runtime
         .get_input_handler("InputStream")
         .expect("Failed to get input handler");
 
@@ -363,9 +361,11 @@ async fn test_config_manager_eventflux_manager_integration() {
     let mut config = EventFluxConfig::default();
     config.eventflux.runtime.mode = RuntimeMode::Distributed;
 
-    let mut perf_config = PerformanceConfig::default();
-    perf_config.event_buffer_size = 16384;
-    perf_config.batch_size = Some(5000);
+    let perf_config = PerformanceConfig {
+        event_buffer_size: 16384,
+        batch_size: Some(5000),
+        ..Default::default()
+    };
     config.eventflux.runtime.performance = perf_config;
 
     // Create application-specific config
@@ -404,6 +404,7 @@ async fn test_config_manager_eventflux_manager_integration() {
 
 #[tokio::test]
 #[serial]
+#[allow(clippy::approx_constant)]
 async fn test_config_value_type_conversions() {
     // Test ConfigValue type conversions
     let int_val = ConfigValue::Integer(42);

--- a/tests/integration_config_validation_api.rs
+++ b/tests/integration_config_validation_api.rs
@@ -32,13 +32,12 @@ use eventflux::core::config::{
     },
     EventFluxConfig,
 };
-use std::collections::HashMap;
 use std::sync::Arc;
 
 /// Test basic validation report functionality
 #[test]
 fn test_validation_report_creation() {
-    let mut report = ValidationReport::new();
+    let report = ValidationReport::new();
 
     assert!(report.is_valid);
     assert_eq!(report.errors.len(), 0);
@@ -345,7 +344,7 @@ async fn test_performance_validation_rule() {
     rule.validate(&config, &mut report2).await.unwrap();
 
     assert!(report2.is_valid); // Warnings don't invalidate
-    assert!(report2.warnings.len() > 0);
+    assert!(!report2.warnings.is_empty());
     assert!(report2
         .warnings
         .iter()
@@ -454,7 +453,10 @@ async fn test_configuration_validator_integration() {
     // Test with valid configuration
     let report = validator.validate(&config).await.unwrap();
     assert!(report.is_valid);
-    assert!(report.validation_duration.as_nanos() >= 0);
+    assert!(
+        report.validation_duration > std::time::Duration::ZERO,
+        "Validation duration should be recorded"
+    );
     assert!(report.metadata.contains_key("rules_executed"));
 
     // Test with invalid configuration
@@ -462,7 +464,7 @@ async fn test_configuration_validator_integration() {
     let report2 = validator.validate(&config).await.unwrap();
 
     assert!(!report2.is_valid);
-    assert!(report2.errors.len() > 0);
+    assert!(!report2.errors.is_empty());
     assert!(report2.validation_score < 1.0);
 }
 
@@ -547,7 +549,7 @@ async fn test_strict_mode() {
 
     // In strict mode, warnings become errors
     assert!(!report.is_valid);
-    assert!(report.errors.len() > 0);
+    assert!(!report.errors.is_empty());
     assert_eq!(report.warnings.len(), 0); // Warnings converted to errors
 }
 

--- a/tests/jdbc_table.rs
+++ b/tests/jdbc_table.rs
@@ -68,7 +68,7 @@ fn setup_table(ctx: &Arc<EventFluxContext>) {
     let ds = ctx.get_data_source("DS1").unwrap();
     let conn_any = ds.get_connection().unwrap();
     let conn_arc = conn_any.downcast::<Arc<Mutex<Connection>>>().unwrap();
-    let mut conn = conn_arc.lock().unwrap();
+    let conn = conn_arc.lock().unwrap();
     conn.execute("CREATE TABLE test (c0 TEXT, c1 TEXT)", [])
         .unwrap();
 }

--- a/tests/join_queries.rs
+++ b/tests/join_queries.rs
@@ -26,14 +26,12 @@ use eventflux::core::event::stream::meta_stream_event::MetaStreamEvent;
 use eventflux::core::event::stream::stream_event::StreamEvent;
 use eventflux::core::event::value::AttributeValue;
 use eventflux::core::query::output::callback_processor::CallbackProcessor;
-use eventflux::core::query::processor::stream::join::{
-    JoinProcessor, JoinProcessorSide, JoinSide,
-};
+use eventflux::core::query::processor::stream::join::{JoinProcessor, JoinProcessorSide, JoinSide};
 use eventflux::core::query::processor::{ProcessingMode, Processor};
 use eventflux::core::stream::output::stream_callback::StreamCallback;
 use eventflux::core::stream::stream_junction::StreamJunction;
+use eventflux::core::util::parser::ExpressionParserContext;
 use eventflux::core::util::parser::QueryParser;
-use eventflux::core::util::parser::{parse_expression, ExpressionParserContext};
 use eventflux::query_api::definition::attribute::Type as AttrType;
 use eventflux::query_api::definition::StreamDefinition;
 use eventflux::query_api::execution::query::input::stream::{
@@ -243,14 +241,16 @@ fn test_inner_join_runtime() {
         let left = junctions.get("LeftStream").unwrap();
         left.lock()
             .unwrap()
-            .send_event(Event::new_with_data(0, vec![AttributeValue::Int(1)]));
+            .send_event(Event::new_with_data(0, vec![AttributeValue::Int(1)]))
+            .unwrap();
     }
     {
         let right = junctions.get("RightStream").unwrap();
         right
             .lock()
             .unwrap()
-            .send_event(Event::new_with_data(0, vec![AttributeValue::Int(1)]));
+            .send_event(Event::new_with_data(0, vec![AttributeValue::Int(1)]))
+            .unwrap();
     }
 
     let out = collected.lock().unwrap().clone();
@@ -279,7 +279,8 @@ fn test_left_outer_join_runtime() {
         let left = junctions.get("LeftStream").unwrap();
         left.lock()
             .unwrap()
-            .send_event(Event::new_with_data(0, vec![AttributeValue::Int(2)]));
+            .send_event(Event::new_with_data(0, vec![AttributeValue::Int(2)]))
+            .unwrap();
     }
 
     let out = collected.lock().unwrap().clone();
@@ -289,9 +290,11 @@ fn test_left_outer_join_runtime() {
     );
 }
 
+type JoinEventPairs = Vec<(Option<i32>, Option<i32>)>;
+
 #[derive(Debug)]
 struct CollectStateEvents {
-    events: Arc<Mutex<Vec<(Option<i32>, Option<i32>)>>>,
+    events: Arc<Mutex<JoinEventPairs>>,
 }
 
 impl Processor for CollectStateEvents {
@@ -302,13 +305,13 @@ impl Processor for CollectStateEvents {
             if let Some(se) = ce.as_any().downcast_ref::<StateEvent>() {
                 let l = se
                     .get_stream_event(0)
-                    .and_then(|e| match e.before_window_data.get(0) {
+                    .and_then(|e| match e.before_window_data.first() {
                         Some(AttributeValue::Int(v)) => Some(*v),
                         _ => None,
                     });
                 let r = se
                     .get_stream_event(1)
-                    .and_then(|e| match e.before_window_data.get(0) {
+                    .and_then(|e| match e.before_window_data.first() {
                         Some(AttributeValue::Int(v)) => Some(*v),
                         _ => None,
                     });
@@ -359,13 +362,11 @@ impl Processor for CollectStateEvents {
     }
 }
 
+type JoinSideHandle = Arc<Mutex<JoinProcessorSide>>;
+
 fn setup_state_join(
     join_type: JoinType,
-) -> (
-    Arc<Mutex<JoinProcessorSide>>,
-    Arc<Mutex<JoinProcessorSide>>,
-    Arc<Mutex<Vec<(Option<i32>, Option<i32>)>>>,
-) {
+) -> (JoinSideHandle, JoinSideHandle, Arc<Mutex<JoinEventPairs>>) {
     let eventflux_context = Arc::new(EventFluxContext::new());
     let app = Arc::new(eventflux::query_api::eventflux_app::EventFluxApp::new(
         "App".to_string(),
@@ -409,7 +410,7 @@ fn setup_state_join(
         Arc::new(mse.get_meta_stream_event(1).unwrap().clone()),
     );
 
-    let ctx = ExpressionParserContext {
+    let _ctx = ExpressionParserContext {
         eventflux_app_context: Arc::clone(&app_ctx),
         eventflux_query_context: Arc::clone(&query_ctx),
         stream_meta_map: stream_meta,

--- a/tests/mapper_integration.rs
+++ b/tests/mapper_integration.rs
@@ -31,7 +31,6 @@ use eventflux::core::stream::mapper::{
         SourceMapperFactory,
     },
     validation::{validate_sink_mapper_config, validate_source_mapper_config},
-    SinkMapper, SourceMapper,
 };
 use std::collections::HashMap;
 

--- a/tests/optimized_stream_junction_integration.rs
+++ b/tests/optimized_stream_junction_integration.rs
@@ -30,7 +30,7 @@ use eventflux::core::event::stream::StreamEvent;
 use eventflux::core::event::value::AttributeValue;
 use eventflux::core::query::processor::{ProcessingMode, Processor};
 use eventflux::core::stream::{
-    BackpressureStrategy, JunctionBenchmark, JunctionConfig, StreamJunction, StreamJunctionFactory,
+    BackpressureStrategy, JunctionConfig, StreamJunction, StreamJunctionFactory,
 };
 use eventflux::query_api::definition::attribute::Type as AttrType;
 use eventflux::query_api::definition::StreamDefinition;
@@ -78,12 +78,12 @@ impl PerformanceTestProcessor {
 
 impl Processor for PerformanceTestProcessor {
     fn process(&self, mut chunk: Option<Box<dyn ComplexEvent>>) {
-        let received_time = Instant::now();
+        let _received_time = Instant::now();
 
         while let Some(mut ce) = chunk {
             chunk = ce.set_next(None);
 
-            if let Some(se) = ce.as_any().downcast_ref::<StreamEvent>() {
+            if let Some(_se) = ce.as_any().downcast_ref::<StreamEvent>() {
                 // Calculate latency from timestamp
                 // For testing purposes, we just count events rather than calculate real latency
                 // since the timestamps in the test are sequential numbers, not real timestamps
@@ -283,7 +283,7 @@ fn test_synchronous_mode_ordering_guarantee() {
             while let Some(mut ce) = chunk {
                 chunk = ce.set_next(None);
                 if let Some(se) = ce.as_any().downcast_ref::<StreamEvent>() {
-                    if let Some(AttributeValue::Int(value)) = se.before_window_data.get(0) {
+                    if let Some(AttributeValue::Int(value)) = se.before_window_data.first() {
                         self.received_order.lock().unwrap().push(*value);
                     }
                 }
@@ -432,7 +432,7 @@ fn test_concurrent_publishers_optimized_junction() {
                 let event = Event::new_with_data(
                     (thread_id * events_per_thread + i) as i64,
                     vec![
-                        AttributeValue::Int(thread_id as i32 * 1000 + i as i32),
+                        AttributeValue::Int(thread_id * 1000 + i),
                         AttributeValue::Long(
                             std::time::SystemTime::now()
                                 .duration_since(std::time::UNIX_EPOCH)

--- a/tests/output_rate_limit_comprehensive.rs
+++ b/tests/output_rate_limit_comprehensive.rs
@@ -75,13 +75,25 @@ async fn test_all_behavior_exact_batch_emission() {
 
     // Send 3 events - should emit all 3
     runner.send("Input", vec![AttributeValue::Int(10)]);
-    assert_eq!(runner.collected.lock().unwrap().len(), 0, "No output before batch complete");
+    assert_eq!(
+        runner.collected.lock().unwrap().len(),
+        0,
+        "No output before batch complete"
+    );
 
     runner.send("Input", vec![AttributeValue::Int(20)]);
-    assert_eq!(runner.collected.lock().unwrap().len(), 0, "No output before batch complete");
+    assert_eq!(
+        runner.collected.lock().unwrap().len(),
+        0,
+        "No output before batch complete"
+    );
 
     runner.send("Input", vec![AttributeValue::Int(30)]);
-    assert_eq!(runner.collected.lock().unwrap().len(), 3, "All 3 events emitted on batch complete");
+    assert_eq!(
+        runner.collected.lock().unwrap().len(),
+        3,
+        "All 3 events emitted on batch complete"
+    );
 
     // Verify the actual values emitted
     {
@@ -112,17 +124,29 @@ async fn test_all_behavior_multiple_batches() {
     // First batch
     runner.send("Input", vec![AttributeValue::Int(1)]);
     runner.send("Input", vec![AttributeValue::Int(2)]);
-    assert_eq!(runner.collected.lock().unwrap().len(), 2, "First batch emitted");
+    assert_eq!(
+        runner.collected.lock().unwrap().len(),
+        2,
+        "First batch emitted"
+    );
 
     // Second batch
     runner.send("Input", vec![AttributeValue::Int(3)]);
     runner.send("Input", vec![AttributeValue::Int(4)]);
-    assert_eq!(runner.collected.lock().unwrap().len(), 4, "Second batch emitted");
+    assert_eq!(
+        runner.collected.lock().unwrap().len(),
+        4,
+        "Second batch emitted"
+    );
 
     // Third batch
     runner.send("Input", vec![AttributeValue::Int(5)]);
     runner.send("Input", vec![AttributeValue::Int(6)]);
-    assert_eq!(runner.collected.lock().unwrap().len(), 6, "Third batch emitted");
+    assert_eq!(
+        runner.collected.lock().unwrap().len(),
+        6,
+        "Third batch emitted"
+    );
 
     // Verify values from each batch
     let out = runner.shutdown();
@@ -148,10 +172,34 @@ async fn test_all_behavior_preserves_order() {
 
     let runner = AppRunner::new(app, "Output").await;
 
-    runner.send("Input", vec![AttributeValue::Int(1), AttributeValue::String("first".to_string())]);
-    runner.send("Input", vec![AttributeValue::Int(2), AttributeValue::String("second".to_string())]);
-    runner.send("Input", vec![AttributeValue::Int(3), AttributeValue::String("third".to_string())]);
-    runner.send("Input", vec![AttributeValue::Int(4), AttributeValue::String("fourth".to_string())]);
+    runner.send(
+        "Input",
+        vec![
+            AttributeValue::Int(1),
+            AttributeValue::String("first".to_string()),
+        ],
+    );
+    runner.send(
+        "Input",
+        vec![
+            AttributeValue::Int(2),
+            AttributeValue::String("second".to_string()),
+        ],
+    );
+    runner.send(
+        "Input",
+        vec![
+            AttributeValue::Int(3),
+            AttributeValue::String("third".to_string()),
+        ],
+    );
+    runner.send(
+        "Input",
+        vec![
+            AttributeValue::Int(4),
+            AttributeValue::String("fourth".to_string()),
+        ],
+    );
 
     let out = runner.shutdown();
     assert_eq!(out.len(), 4);
@@ -551,16 +599,22 @@ async fn test_rate_limit_with_window() {
 
     let runner = AppRunner::new(app, "Output").await;
 
-    runner.send("Input", vec![
-        AttributeValue::String("IBM".to_string()),
-        AttributeValue::Float(100.0),
-    ]);
+    runner.send(
+        "Input",
+        vec![
+            AttributeValue::String("IBM".to_string()),
+            AttributeValue::Float(100.0),
+        ],
+    );
     assert_eq!(runner.collected.lock().unwrap().len(), 0);
 
-    runner.send("Input", vec![
-        AttributeValue::String("MSFT".to_string()),
-        AttributeValue::Float(200.0),
-    ]);
+    runner.send(
+        "Input",
+        vec![
+            AttributeValue::String("MSFT".to_string()),
+            AttributeValue::Float(200.0),
+        ],
+    );
     assert_eq!(runner.collected.lock().unwrap().len(), 2);
 
     let out = runner.shutdown();
@@ -854,7 +908,11 @@ async fn test_large_event_volume() {
     }
 
     let out = runner.shutdown();
-    assert_eq!(out.len(), 1000, "All events should be emitted in 10 batches");
+    assert_eq!(
+        out.len(),
+        1000,
+        "All events should be emitted in 10 batches"
+    );
 
     // Verify first and last values
     assert_eq!(get_int(&out[0], 0), 0);
@@ -924,13 +982,18 @@ async fn test_last_large_volume() {
 /// Test: Compare ALL vs FIRST vs LAST with same input
 #[tokio::test]
 async fn test_behavior_comparison() {
-    let base_app = |behavior: &str| format!(r#"
+    let base_app = |behavior: &str| {
+        format!(
+            r#"
         CREATE STREAM Input (value INT);
         CREATE STREAM Output (value INT);
         INSERT INTO Output
         SELECT value FROM Input
         OUTPUT {} EVERY 3 EVENTS;
-    "#, behavior);
+    "#,
+            behavior
+        )
+    };
 
     // Test ALL
     let runner_all = AppRunner::new(&base_app("ALL"), "Output").await;

--- a/tests/pattern_chain_integration.rs
+++ b/tests/pattern_chain_integration.rs
@@ -28,14 +28,7 @@
 mod common;
 
 use common::pattern_chain_test_utils::*;
-use eventflux::core::event::stream::stream_event::StreamEvent;
-use eventflux::core::query::input::stream::state::pattern_chain_builder::{
-    PatternChainBuilder, PatternStepConfig, ProcessorChain,
-};
-use eventflux::core::query::input::stream::state::post_state_processor::PostStateProcessor;
 use eventflux::core::query::input::stream::state::stream_pre_state_processor::StateType;
-use eventflux::query_api::definition::stream_definition::StreamDefinition;
-use std::sync::{Arc, Mutex};
 // Note: build_pattern_chain_with_within() is provided by common module
 
 // ============================================================================
@@ -131,7 +124,7 @@ fn test_integration_1_complex_count_quantifiers() {
     // - After B1, B2: First match (2 As, 2 Bs)
     // - Potentially more matches with A3
     assert!(
-        outputs.len() >= 1,
+        !outputs.is_empty(),
         "Expected at least 1 output from A{{2,3}} -> B{{2}} pattern"
     );
 
@@ -301,7 +294,7 @@ fn test_integration_3_concurrent_instances() {
     // With A{2} -> B{2}, we expect at least 1 match from (A1,A2) -> (B1,B2)
     // Potentially more with overlapping instances
     assert!(
-        outputs.len() >= 1,
+        !outputs.is_empty(),
         "Expected at least 1 output from concurrent A{{2}} -> B{{2}} instances"
     );
 

--- a/tests/pattern_chain_phase_2b1.rs
+++ b/tests/pattern_chain_phase_2b1.rs
@@ -440,7 +440,7 @@ fn test_2b1_6_range_quantifier() {
     // So we get 2 outputs: one for A{1}->B{2} and one for A{2}->B{2}
     let outputs = collector.get_outputs();
     println!("Final outputs count: {}", outputs.len());
-    assert!(outputs.len() >= 1, "Expected at least 1 output event");
+    assert!(!outputs.is_empty(), "Expected at least 1 output event");
     assert!(
         outputs.len() <= 2,
         "Expected at most 2 output events for A{{1,3}}"

--- a/tests/pattern_chain_phase_2b2.rs
+++ b/tests/pattern_chain_phase_2b2.rs
@@ -390,7 +390,7 @@ fn test_2b2_4_range_quantifiers() {
     // Each match flows through the chain and may produce outputs
     let outputs = collector.get_outputs();
     assert!(
-        outputs.len() >= 1,
+        !outputs.is_empty(),
         "Expected at least 1 output with range quantifiers"
     );
     assert!(

--- a/tests/pattern_chain_phase_2b3.rs
+++ b/tests/pattern_chain_phase_2b3.rs
@@ -24,7 +24,6 @@
 mod common;
 
 use common::pattern_chain_test_utils::*;
-use eventflux::core::event::stream::stream_event::StreamEvent;
 use eventflux::core::query::input::stream::state::stream_pre_state_processor::StateType;
 
 // ============================================================================

--- a/tests/pattern_chain_phase_2b4.rs
+++ b/tests/pattern_chain_phase_2b4.rs
@@ -24,14 +24,7 @@
 mod common;
 
 use common::pattern_chain_test_utils::*;
-use eventflux::core::event::stream::stream_event::StreamEvent;
-use eventflux::core::query::input::stream::state::pattern_chain_builder::{
-    PatternChainBuilder, PatternStepConfig, ProcessorChain,
-};
-use eventflux::core::query::input::stream::state::post_state_processor::PostStateProcessor;
 use eventflux::core::query::input::stream::state::stream_pre_state_processor::StateType;
-use eventflux::query_api::definition::stream_definition::StreamDefinition;
-use std::sync::{Arc, Mutex};
 
 // ============================================================================
 // PHASE 2b.4 TESTS: WITHIN Time Constraints

--- a/tests/pattern_every_overlapping_test.rs
+++ b/tests/pattern_every_overlapping_test.rs
@@ -150,12 +150,12 @@ fn test_every_pattern_overlapping_instances() {
     for (i, state) in collected.iter().enumerate() {
         println!("  Match {}: ", i + 1);
         if let Some(e1) = state.get_stream_event(0) {
-            if let Some(AttributeValue::Long(val)) = e1.before_window_data.get(0) {
+            if let Some(AttributeValue::Long(val)) = e1.before_window_data.first() {
                 println!("    e1.value = {}", val);
             }
         }
         if let Some(e2) = state.get_stream_event(1) {
-            if let Some(AttributeValue::Long(val)) = e2.before_window_data.get(0) {
+            if let Some(AttributeValue::Long(val)) = e2.before_window_data.first() {
                 println!("    e2.value = {}", val);
             }
         }
@@ -174,12 +174,12 @@ fn test_every_pattern_overlapping_instances() {
     // Validate first match: A(1) -> B(2)
     let match1 = &collected[0];
     if let Some(e1) = match1.get_stream_event(0) {
-        if let Some(AttributeValue::Long(val)) = e1.before_window_data.get(0) {
+        if let Some(AttributeValue::Long(val)) = e1.before_window_data.first() {
             assert_eq!(*val, 1, "First match should have e1.value = 1");
         }
     }
     if let Some(e2) = match1.get_stream_event(1) {
-        if let Some(AttributeValue::Long(val)) = e2.before_window_data.get(0) {
+        if let Some(AttributeValue::Long(val)) = e2.before_window_data.first() {
             assert_eq!(*val, 2, "First match should have e2.value = 2");
         }
     }
@@ -187,12 +187,12 @@ fn test_every_pattern_overlapping_instances() {
     // Validate second match: A(3) -> B(4)
     let match2 = &collected[1];
     if let Some(e1) = match2.get_stream_event(0) {
-        if let Some(AttributeValue::Long(val)) = e1.before_window_data.get(0) {
+        if let Some(AttributeValue::Long(val)) = e1.before_window_data.first() {
             assert_eq!(*val, 3, "Second match should have e1.value = 3");
         }
     }
     if let Some(e2) = match2.get_stream_event(1) {
-        if let Some(AttributeValue::Long(val)) = e2.before_window_data.get(0) {
+        if let Some(AttributeValue::Long(val)) = e2.before_window_data.first() {
             assert_eq!(*val, 4, "Second match should have e2.value = 4");
         }
     }
@@ -291,7 +291,7 @@ fn test_pattern_without_every_no_overlapping() {
     // Verify it's the A(1) - B(3) match (first complete sequence)
     let match1 = &collected[0];
     if let Some(e1) = match1.get_stream_event(0) {
-        if let Some(AttributeValue::Long(val)) = e1.before_window_data.get(0) {
+        if let Some(AttributeValue::Long(val)) = e1.before_window_data.first() {
             assert_eq!(
                 *val, 1,
                 "Match should be from A(1), the first complete sequence"
@@ -915,7 +915,7 @@ fn test_true_every_overlapping_multiple_a_before_b() {
                 e1.timestamp,
                 e1.before_window_data.len()
             );
-            if let Some(AttributeValue::Long(val)) = e1.before_window_data.get(0) {
+            if let Some(AttributeValue::Long(val)) = e1.before_window_data.first() {
                 println!("    e1.value = {}", val);
             }
         }
@@ -925,7 +925,7 @@ fn test_true_every_overlapping_multiple_a_before_b() {
                 e2.timestamp,
                 e2.before_window_data.len()
             );
-            if let Some(AttributeValue::Long(val)) = e2.before_window_data.get(0) {
+            if let Some(AttributeValue::Long(val)) = e2.before_window_data.first() {
                 println!("    e2.value = {}", val);
             }
         }
@@ -1206,7 +1206,7 @@ fn test_ultra_explicit_overlapping_proof() {
 ///   - Instance 1: [A1, A2, A3] waits for B
 ///   - Instance 2: [A2, A3, A4] waits for B
 ///   - Instance 3: [A3, A4, A5] waits for B
-///   When B6 arrives: 3 matches
+///   - When B6 arrives: 3 matches
 ///
 /// This is the sliding window behavior described in PATTERN_GRAMMAR_V1.2_TEST_SPEC.md Test 2.9
 ///

--- a/tests/pattern_filter_cross_stream_test.rs
+++ b/tests/pattern_filter_cross_stream_test.rs
@@ -78,10 +78,10 @@ fn test_filter_with_cross_stream_reference_simple() {
         // Access e1 (position 0) from StateEvent
         if let Some(e1) = state_event.get_stream_event(0) {
             // Get e1.price (attribute index 0)
-            if let Some(AttributeValue::Float(e1_price)) = e1.before_window_data.get(0) {
+            if let Some(AttributeValue::Float(e1_price)) = e1.before_window_data.first() {
                 // Access e2 (position 1) from StateEvent
                 if let Some(e2) = state_event.get_stream_event(1) {
-                    if let Some(AttributeValue::Float(e2_price)) = e2.before_window_data.get(0) {
+                    if let Some(AttributeValue::Float(e2_price)) = e2.before_window_data.first() {
                         return e2_price > e1_price;
                     }
                 }
@@ -165,9 +165,9 @@ fn test_filter_cross_stream_percentage() {
     // Filter: price > e1.price * 1.1
     e2_processor.set_condition(|state_event| {
         if let Some(e1) = state_event.get_stream_event(0) {
-            if let Some(AttributeValue::Float(e1_price)) = e1.before_window_data.get(0) {
+            if let Some(AttributeValue::Float(e1_price)) = e1.before_window_data.first() {
                 if let Some(e2) = state_event.get_stream_event(1) {
-                    if let Some(AttributeValue::Float(e2_price)) = e2.before_window_data.get(0) {
+                    if let Some(AttributeValue::Float(e2_price)) = e2.before_window_data.first() {
                         let threshold = e1_price * 1.1;
                         return e2_price > &threshold;
                     }
@@ -247,9 +247,9 @@ fn test_filter_cross_stream_string_equality() {
     // Filter: userId == e1.userId
     e2_processor.set_condition(|state_event| {
         if let Some(e1) = state_event.get_stream_event(0) {
-            if let Some(AttributeValue::String(e1_user)) = e1.before_window_data.get(0) {
+            if let Some(AttributeValue::String(e1_user)) = e1.before_window_data.first() {
                 if let Some(e2) = state_event.get_stream_event(1) {
-                    if let Some(AttributeValue::String(e2_user)) = e2.before_window_data.get(0) {
+                    if let Some(AttributeValue::String(e2_user)) = e2.before_window_data.first() {
                         return e1_user == e2_user;
                     }
                 }
@@ -336,10 +336,10 @@ fn test_filter_cross_stream_three_events() {
     e3_processor.set_condition(|state_event| {
         // Access e3 (position 2) from StateEvent
         if let Some(e3) = state_event.get_stream_event(2) {
-            if let Some(AttributeValue::Int(e3_value)) = e3.before_window_data.get(0) {
+            if let Some(AttributeValue::Int(e3_value)) = e3.before_window_data.first() {
                 // Check e1.value
                 if let Some(e1) = state_event.get_stream_event(0) {
-                    if let Some(AttributeValue::Int(e1_value)) = e1.before_window_data.get(0) {
+                    if let Some(AttributeValue::Int(e1_value)) = e1.before_window_data.first() {
                         if e3_value <= e1_value {
                             return false;
                         }
@@ -352,7 +352,7 @@ fn test_filter_cross_stream_three_events() {
 
                 // Check e2.value
                 if let Some(e2) = state_event.get_stream_event(1) {
-                    if let Some(AttributeValue::Int(e2_value)) = e2.before_window_data.get(0) {
+                    if let Some(AttributeValue::Int(e2_value)) = e2.before_window_data.first() {
                         return e3_value > e2_value;
                     }
                 }
@@ -436,9 +436,9 @@ fn test_filter_cross_stream_null_handling() {
     // Filter references e1, but we'll pass StateEvent without e1
     e2_processor.set_condition(|state_event| {
         if let Some(e1) = state_event.get_stream_event(0) {
-            if let Some(AttributeValue::Float(e1_price)) = e1.before_window_data.get(0) {
+            if let Some(AttributeValue::Float(e1_price)) = e1.before_window_data.first() {
                 if let Some(e2) = state_event.get_stream_event(1) {
-                    if let Some(AttributeValue::Float(e2_price)) = e2.before_window_data.get(0) {
+                    if let Some(AttributeValue::Float(e2_price)) = e2.before_window_data.first() {
                         return e2_price > e1_price;
                     }
                 }
@@ -482,7 +482,7 @@ fn test_filter_without_cross_stream_reference() {
     // Simple filter: value > 100 (accesses from position 0)
     e1_processor.set_condition(|state_event| {
         if let Some(e1) = state_event.get_stream_event(0) {
-            if let Some(AttributeValue::Int(value)) = e1.before_window_data.get(0) {
+            if let Some(AttributeValue::Int(value)) = e1.before_window_data.first() {
                 return *value > 100;
             }
         }

--- a/tests/pattern_queries.rs
+++ b/tests/pattern_queries.rs
@@ -145,12 +145,12 @@ fn build_sequence_query() -> Query {
 
 #[test]
 fn test_sequence_query_parse() {
-    let (app_ctx, mut junctions) = setup_context();
+    let (app_ctx, junctions) = setup_context();
     let q = build_sequence_query();
     let res = QueryParser::parse_query_test(
         &q,
         &app_ctx,
-        &mut junctions,
+        &junctions,
         &HashMap::new(),
         &HashMap::new(),
         None,

--- a/tests/persistence.rs
+++ b/tests/persistence.rs
@@ -17,9 +17,7 @@
 
 use eventflux::core::event::{value::AttributeValue, Event};
 use eventflux::core::eventflux_manager::EventFluxManager;
-use eventflux::core::persistence::{
-    InMemoryPersistenceStore, PersistenceStore, SnapshotService,
-};
+use eventflux::core::persistence::{InMemoryPersistenceStore, PersistenceStore, SnapshotService};
 use eventflux::core::stream::output::stream_callback::StreamCallback;
 use eventflux::core::util::{event_from_bytes, event_to_bytes};
 use eventflux::query_api::definition::{attribute::Type as AttrType, StreamDefinition};

--- a/tests/rabbitmq_integration.rs
+++ b/tests/rabbitmq_integration.rs
@@ -918,7 +918,7 @@ fn test_e2e_rabbitmq_filter_and_case_processing() {
     ];
 
     // Events that FAIL the filter (volume <= 1000) - should NOT appear in output
-    let fail_events = vec![
+    let fail_events = [
         json!({"symbol": "META", "price": 325.00, "volume": 800, "timestamp": 1702500003}),
         json!({"symbol": "NVDA", "price": 495.50, "volume": 500, "timestamp": 1702500004}),
     ];
@@ -1378,7 +1378,7 @@ fn test_e2e_query_based_rabbitmq_processing() {
     ];
 
     // Events that FAIL the filter (volume <= 1000)
-    let fail_events = vec![
+    let fail_events = [
         json!({"symbol": "META", "price": 325.00, "volume": 800}),
         json!({"symbol": "NVDA", "price": 495.50, "volume": 500}),
     ];

--- a/tests/redis_eventflux_persistence.rs
+++ b/tests/redis_eventflux_persistence.rs
@@ -351,7 +351,7 @@ async fn test_redis_aggregation_state_persistence() {
     let category_a_events: Vec<_> = out
         .iter()
         .filter(|event| {
-            if let Some(AttributeValue::String(cat)) = event.get(0) {
+            if let Some(AttributeValue::String(cat)) = event.first() {
                 cat == "A"
             } else {
                 false
@@ -669,7 +669,7 @@ async fn test_redis_aggregator_recovery_identical() {
     // Verify the aggregated values in the last output event (has complete aggregates)
     if let Some(last_event) = original_output.last() {
         // Total should be 100 + 200 + 50 = 350
-        if let Some(AttributeValue::Int(total)) = last_event.get(0) {
+        if let Some(AttributeValue::Int(total)) = last_event.first() {
             assert_eq!(*total, 350, "Original SUM should be 350 (100+200+50)");
         }
 
@@ -748,8 +748,8 @@ async fn test_redis_aggregator_recovery_identical() {
     {
         // Verify total (SUM) - should be 350 if state was restored
         assert_eq!(
-            original_event.get(0),
-            restored_event.get(0),
+            original_event.first(),
+            restored_event.first(),
             "SUM aggregate should match exactly (350 if state restored correctly, \
              50 if aggregator restarted from zero)"
         );

--- a/tests/redis_vs_memory_comparison.rs
+++ b/tests/redis_vs_memory_comparison.rs
@@ -99,14 +99,14 @@ async fn test_memory_store_with_count() {
     // Verify restoration worked: event 5 should cause event 1 to expire again
     let event_5_idx = out
         .iter()
-        .position(|e| e.get(0) == Some(&AttributeValue::Int(5)))
+        .position(|e| e.first() == Some(&AttributeValue::Int(5)))
         .expect("Event 5 should be in output");
 
     // The event before event 5 should be event 1 expiring with count 2
     if event_5_idx > 0 {
         let prev_event = &out[event_5_idx - 1];
         assert_eq!(
-            prev_event.get(0),
+            prev_event.first(),
             Some(&AttributeValue::Int(1)),
             "Event 1 should expire before event 5 enters"
         );
@@ -155,7 +155,7 @@ async fn test_count_aggregator_multiple_checkpoints() {
     // Verify: event 80 should have count=3 (window is [30,70,80])
     let event_80_idx = out
         .iter()
-        .rposition(|e| e.get(0) == Some(&AttributeValue::Int(80)))
+        .rposition(|e| e.first() == Some(&AttributeValue::Int(80)))
         .expect("Event 80 should be in output");
 
     assert_eq!(

--- a/tests/session_window_test.rs
+++ b/tests/session_window_test.rs
@@ -128,5 +128,5 @@ async fn test_session_window_gap_validation() {
     println!("Session gap test output: {:?}", output);
 
     // Should succeed with valid gap
-    assert!(true, "Valid session gap should work");
+    // Valid session gap should work - test passes if we reach this point
 }

--- a/tests/sort_window_test.rs
+++ b/tests/sort_window_test.rs
@@ -162,7 +162,7 @@ async fn test_sort_window_ordering() {
         match &event[0] {
             AttributeValue::Int(val) => {
                 assert!(
-                    vec![100, 200, 300].contains(val),
+                    [100, 200, 300].contains(val),
                     "Event value should be one of the sent values"
                 );
             }

--- a/tests/source_sink.rs
+++ b/tests/source_sink.rs
@@ -98,5 +98,5 @@ fn timer_source_to_log_sink() {
     std::thread::sleep(Duration::from_millis(20));
 
     let events = collected.lock().unwrap();
-    assert!(events.len() > 0);
+    assert!(!events.is_empty());
 }

--- a/tests/sql_integration_tests.rs
+++ b/tests/sql_integration_tests.rs
@@ -29,6 +29,7 @@ struct TestCallback {
     events: Arc<Mutex<Vec<Vec<AttributeValue>>>>,
 }
 
+#[allow(dead_code)]
 impl TestCallback {
     fn new() -> Self {
         TestCallback {
@@ -79,7 +80,7 @@ async fn test_sql_query_1_basic_filter() {
         .expect("Failed to add callback");
 
     // Start runtime
-    runtime.start();
+    runtime.start().expect("Failed to start runtime");
 
     // Get input handler
     let input_handler = runtime
@@ -174,7 +175,7 @@ async fn test_sql_query_2_arithmetic() {
         .add_callback("OutputStream", Box::new(callback.clone()))
         .expect("Failed to add callback");
 
-    runtime.start();
+    runtime.start().expect("Failed to start runtime");
 
     let input_handler = runtime
         .get_input_handler("StockStream")
@@ -236,7 +237,7 @@ async fn test_sql_query_7_builtin_function() {
         .add_callback("OutputStream", Box::new(callback.clone()))
         .expect("Failed to add callback");
 
-    runtime.start();
+    runtime.start().expect("Failed to start runtime");
 
     let input_handler = runtime
         .get_input_handler("StockStream")
@@ -324,7 +325,7 @@ async fn test_sql_query_3_window_tumbling_avg() {
         .add_callback("OutputStream", Box::new(callback.clone()))
         .expect("Failed to add callback");
 
-    runtime.start();
+    runtime.start().expect("Failed to start runtime");
 
     let input_handler = runtime
         .get_input_handler("StockStream")
@@ -358,7 +359,7 @@ async fn test_sql_query_3_window_tumbling_avg() {
 
     // Verify AVG calculation: (100 + 200) / 2 = 150
     assert!(
-        output_events.len() > 0,
+        !output_events.is_empty(),
         "Expected at least 1 event from tumbling window"
     );
 
@@ -388,7 +389,7 @@ async fn test_sql_query_4_window_length_count() {
         .add_callback("OutputStream", Box::new(callback.clone()))
         .expect("Failed to add callback");
 
-    runtime.start();
+    runtime.start().expect("Failed to start runtime");
 
     let input_handler = runtime
         .get_input_handler("StockStream")
@@ -446,7 +447,7 @@ async fn test_sql_query_9_order_by_limit() {
         .add_callback("OutputStream", Box::new(callback.clone()))
         .expect("Failed to add callback");
 
-    runtime.start();
+    runtime.start().expect("Failed to start runtime");
 
     let input_handler = runtime
         .get_input_handler("StockStream")
@@ -484,7 +485,7 @@ async fn test_sql_query_9_order_by_limit() {
     // Actual ordering and limiting behavior depends on runtime implementation.
 
     // Verify we got some events (conversion and execution succeeded)
-    assert!(output_events.len() > 0, "Expected at least 1 event");
+    assert!(!output_events.is_empty(), "Expected at least 1 event");
 
     // TODO: Once runtime implements ORDER BY/LIMIT properly, add assertions:
     // - assert!(output_events.len() <= 3, "LIMIT 3 should restrict to 3 events");
@@ -516,7 +517,7 @@ async fn test_sql_query_10_insert_into() {
         .add_callback("HighPriceAlerts", Box::new(callback.clone()))
         .expect("Failed to add callback");
 
-    runtime.start();
+    runtime.start().expect("Failed to start runtime");
 
     let input_handler = runtime
         .get_input_handler("StockStream")
@@ -600,7 +601,7 @@ async fn test_sql_query_6_sum_having() {
         .add_callback("OutputStream", Box::new(callback.clone()))
         .expect("Failed to add callback");
 
-    runtime.start();
+    runtime.start().expect("Failed to start runtime");
 
     let input_handler = runtime
         .get_input_handler("StockStream")
@@ -657,7 +658,10 @@ async fn test_sql_query_6_sum_having() {
 
     // Verify HAVING clause filters correctly
     // Should only have GOOGL (1100 > 1000), not AAPL (700 <= 1000)
-    assert!(output_events.len() > 0, "Expected at least 1 event (GOOGL)");
+    assert!(
+        !output_events.is_empty(),
+        "Expected at least 1 event (GOOGL)"
+    );
 
     // Find GOOGL in output
     let has_googl = output_events.iter().any(|event| {
@@ -716,7 +720,7 @@ async fn test_sql_query_8_multiple_aggregations() {
         .add_callback("OutputStream", Box::new(callback.clone()))
         .expect("Failed to add callback");
 
-    runtime.start();
+    runtime.start().expect("Failed to start runtime");
 
     let input_handler = runtime
         .get_input_handler("StockStream")
@@ -764,7 +768,7 @@ async fn test_sql_query_8_multiple_aggregations() {
 
     // Verify we got output
     assert!(
-        output_events.len() > 0,
+        !output_events.is_empty(),
         "Expected at least 1 event from tumbling window"
     );
 
@@ -854,7 +858,7 @@ async fn test_sql_query_5_stream_join() {
         .add_callback("OutputStream", Box::new(callback.clone()))
         .expect("Failed to add callback");
 
-    runtime.start();
+    runtime.start().expect("Failed to start runtime");
 
     let trades_handler = runtime
         .get_input_handler("Trades")
@@ -957,7 +961,7 @@ async fn test_tumbling_window_multi_batch_no_spurious_empty_events() {
         .add_callback("OutputStream", Box::new(callback.clone()))
         .expect("Failed to add callback");
 
-    let _ = runtime.start();
+    runtime.start().expect("Failed to start runtime");
 
     let input_handler = runtime
         .get_input_handler("TradeStream")
@@ -1094,7 +1098,7 @@ async fn test_length_batch_window_multi_batch_no_spurious_empty_events() {
         .add_callback("OutputStream", Box::new(callback.clone()))
         .expect("Failed to add callback");
 
-    let _ = runtime.start();
+    runtime.start().expect("Failed to start runtime");
 
     let input_handler = runtime
         .get_input_handler("TradeStream")
@@ -1233,7 +1237,7 @@ async fn test_external_time_batch_window_multi_batch_no_spurious_empty_events() 
         .add_callback("OutStream", Box::new(callback.clone()))
         .expect("Failed to add callback");
 
-    let _ = runtime.start();
+    runtime.start().expect("Failed to start runtime");
 
     let input_handler = runtime
         .get_input_handler("TradeStream")
@@ -1275,7 +1279,8 @@ async fn test_external_time_batch_window_multi_batch_no_spurious_empty_events() 
     }
 
     // === BATCH 3: Events at time 2000-2500ms (triggers flush of batch 2) ===
-    for (ts, price) in [(2000i64, 500.0)] {
+    {
+        let (ts, price) = (2000i64, 500.0);
         input_handler
             .lock()
             .unwrap()

--- a/tests/sql_with_end_to_end.rs
+++ b/tests/sql_with_end_to_end.rs
@@ -267,7 +267,7 @@ async fn test_sql_with_missing_extension_error() {
         }
         Ok(runtime) => {
             // Runtime created, but stream should not be attached
-            runtime.start();
+            runtime.start().expect("Failed to start runtime");
             assert!(
                 runtime.get_source_handler("BadStream").is_none(),
                 "Source should not be attached when extension is missing"
@@ -432,7 +432,7 @@ async fn test_sql_internal_stream_no_with() {
 
     // Should receive events through internal stream
     assert!(
-        out.len() >= 1,
+        !out.is_empty(),
         "Expected at least 1 event, got {}",
         out.len()
     );
@@ -458,7 +458,7 @@ async fn test_sql_with_empty_clause() {
     assert!(runtime_result.is_ok());
 
     let runtime = runtime_result.unwrap();
-    runtime.start();
+    runtime.start().expect("Failed to start runtime");
 
     // No source should be attached (no type specified)
     assert!(runtime.get_source_handler("EmptyWithStream").is_none());
@@ -476,7 +476,7 @@ async fn test_sql_with_properties_reach_factory() {
     use eventflux::core::extension::SourceFactory;
     use eventflux::core::stream::input::source::Source;
     use std::collections::HashMap;
-    use std::sync::{Arc, Mutex};
+    use std::sync::Mutex;
 
     // Counter to track factory calls
     static FACTORY_CALL_COUNT: Mutex<usize> = Mutex::new(0);

--- a/tests/stateful_udf.rs
+++ b/tests/stateful_udf.rs
@@ -74,7 +74,7 @@ impl ExpressionExecutor for StatefulCountFunction {
 impl ScalarFunctionExecutor for StatefulCountFunction {
     fn init(
         &mut self,
-        _arg_execs: &Vec<Box<dyn ExpressionExecutor>>,
+        _arg_execs: &[Box<dyn ExpressionExecutor>],
         _ctx: &Arc<EventFluxAppContext>,
     ) -> Result<(), String> {
         Ok(())

--- a/tests/stream_junction_async.rs
+++ b/tests/stream_junction_async.rs
@@ -93,13 +93,11 @@ impl Processor for RecordingProcessor {
     }
 }
 
+type SharedEventVec = Arc<Mutex<Vec<Vec<AttributeValue>>>>;
+
 fn setup_junction(
     async_mode: bool,
-) -> (
-    Arc<Mutex<StreamJunction>>,
-    Arc<Mutex<Vec<Vec<AttributeValue>>>>,
-    Arc<Mutex<Vec<Vec<AttributeValue>>>>,
-) {
+) -> (Arc<Mutex<StreamJunction>>, SharedEventVec, SharedEventVec) {
     let eventflux_context = Arc::new(EventFluxContext::new());
     let app = Arc::new(eventflux::query_api::eventflux_app::EventFluxApp::new(
         "App".to_string(),
@@ -150,7 +148,8 @@ fn test_sync_cloning() {
     junction
         .lock()
         .unwrap()
-        .send_event(Event::new_with_data(0, vec![AttributeValue::Int(1)]));
+        .send_event(Event::new_with_data(0, vec![AttributeValue::Int(1)]))
+        .unwrap();
     let v1 = r1.lock().unwrap().clone();
     let v2 = r2.lock().unwrap().clone();
     assert_eq!(v1, vec![vec![AttributeValue::Int(1)]]);
@@ -163,7 +162,8 @@ fn test_async_processing() {
     junction
         .lock()
         .unwrap()
-        .send_event(Event::new_with_data(0, vec![AttributeValue::Int(2)]));
+        .send_event(Event::new_with_data(0, vec![AttributeValue::Int(2)]))
+        .unwrap();
     // wait for async tasks
     thread::sleep(Duration::from_millis(200));
     let v1 = r1.lock().unwrap().clone();

--- a/tests/stream_junction_stress.rs
+++ b/tests/stream_junction_stress.rs
@@ -93,12 +93,9 @@ impl Processor for RecordingProcessor {
     }
 }
 
-fn setup_junction(
-    async_mode: bool,
-) -> (
-    Arc<Mutex<StreamJunction>>,
-    Arc<Mutex<Vec<Vec<AttributeValue>>>>,
-) {
+type SharedEventVec = Arc<Mutex<Vec<Vec<AttributeValue>>>>;
+
+fn setup_junction(async_mode: bool) -> (Arc<Mutex<StreamJunction>>, SharedEventVec) {
     let eventflux_context = Arc::new(EventFluxContext::new());
     let app = Arc::new(eventflux::query_api::eventflux_app::EventFluxApp::new(
         "App".to_string(),
@@ -149,10 +146,13 @@ fn stress_async_concurrent_publish() {
         let j = junction.clone();
         handles.push(thread::spawn(move || {
             for k in 0..500 {
-                j.lock().unwrap().send_event(Event::new_with_data(
-                    0,
-                    vec![AttributeValue::Int(i * 500 + k)],
-                ));
+                j.lock()
+                    .unwrap()
+                    .send_event(Event::new_with_data(
+                        0,
+                        vec![AttributeValue::Int(i * 500 + k)],
+                    ))
+                    .expect("stress test: send_event failed under contention");
             }
         }));
     }

--- a/tests/type_validation_test.rs
+++ b/tests/type_validation_test.rs
@@ -166,6 +166,7 @@ fn test_1_2_string_int_comparison_rejected() {
 }
 
 #[test]
+#[allow(clippy::approx_constant)]
 fn test_1_2_string_double_comparison_rejected() {
     let left = Box::new(ConstantExpressionExecutor::new(
         AttributeValue::String("test".to_string()),
@@ -435,6 +436,7 @@ fn test_1_6_not_non_boolean_rejected() {
 }
 
 #[test]
+#[allow(clippy::approx_constant)]
 fn test_1_6_not_double_rejected() {
     let double_exec = Box::new(ConstantExpressionExecutor::new(
         AttributeValue::Double(3.14),
@@ -557,14 +559,13 @@ fn test_1_8_direct_aggregation_query_rejected() {
 
     let result = parse(sql);
     // Expected: Direct aggregation query should be rejected
-    if result.is_err() {
-        let err = result.unwrap_err().to_string();
-        assert!(
-            err.contains("aggregation") || err.contains("Aggregation"),
-            "Error should mention aggregation: {}",
-            err
-        );
-    }
+    assert!(result.is_err(), "Expected invalid SQL to be rejected");
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("aggregation") || err.contains("Aggregation"),
+        "Error should mention aggregation: {}",
+        err
+    );
 }
 
 // ============================================================================
@@ -633,14 +634,13 @@ fn test_1_10_every_aggregation_in_pattern_rejected() {
 
     let result = parse(sql);
     // Expected: Aggregation in pattern should be rejected
-    if result.is_err() {
-        let err = result.unwrap_err().to_string();
-        assert!(
-            err.contains("aggregation") || err.contains("pattern"),
-            "Error should mention aggregation in pattern: {}",
-            err
-        );
-    }
+    assert!(result.is_err(), "Expected invalid SQL to be rejected");
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("aggregation") || err.contains("pattern"),
+        "Error should mention aggregation in pattern: {}",
+        err
+    );
 }
 
 // ============================================================================
@@ -682,6 +682,7 @@ fn test_int_long_comparison_allowed() {
 }
 
 #[test]
+#[allow(clippy::approx_constant)]
 fn test_float_double_comparison_allowed() {
     let float_exec = Box::new(ConstantExpressionExecutor::new(
         AttributeValue::Float(3.14),

--- a/tests/udf_invocation.rs
+++ b/tests/udf_invocation.rs
@@ -28,7 +28,6 @@ use eventflux::core::eventflux_manager::EventFluxManager;
 use eventflux::core::executor::expression_executor::ExpressionExecutor;
 use eventflux::core::executor::function::scalar_function_executor::ScalarFunctionExecutor;
 use eventflux::query_api::definition::attribute::Type as AttrType;
-use eventflux::query_api::eventflux_app::EventFluxApp;
 use std::sync::Arc;
 
 #[derive(Debug, Default)]
@@ -66,7 +65,7 @@ impl ExpressionExecutor for PlusOneFn {
 impl ScalarFunctionExecutor for PlusOneFn {
     fn init(
         &mut self,
-        args: &Vec<Box<dyn ExpressionExecutor>>,
+        args: &[Box<dyn ExpressionExecutor>],
         ctx: &Arc<EventFluxAppContext>,
     ) -> Result<(), String> {
         if args.len() != 1 {
@@ -87,7 +86,7 @@ impl ScalarFunctionExecutor for PlusOneFn {
 #[tokio::test]
 #[ignore = "Old EventFluxQL syntax not part of M1"]
 async fn udf_invoked_in_query() {
-    let mut manager = EventFluxManager::new();
+    let manager = EventFluxManager::new();
     manager.add_scalar_function_factory("plusOne".to_string(), Box::new(PlusOneFn::default()));
 
     let app = "\


### PR DESCRIPTION
## Summary

- **cargo fmt** — applied across entire workspace (src + vendor sqlparser)
- **cargo clippy** — fixed ~233 warnings: `unwrap_or_default`, `redundant_closure`, `needless_borrows_for_generic_args`, `await_holding_lock` (WebSocket/RabbitMQ sinks restructured), idiomatic `FromStr` trait implementations, dead code removal
- **typos** — fixed typos, added `.typos.toml` with domain-term exceptions
- **cargo machete** — added `[package.metadata.cargo-machete]` for feature-gated false positives
- **cargo sort** — sorted all `Cargo.toml` dependency sections
- **CI workflow** — merged quality + build into single job, pinned all actions to commit SHAs, updated `crate-ci/typos` to v1.44.0, added source-hash cache key
- **CONTRIBUTING.md** — rewritten for EventFlux (was copy-pasted from another project)
- **DEV_GUIDE.md** — updated contributing section with quality check commands
- **.pre-commit-config.yaml** — added for local pre-commit hooks via `prek`
- **Bug fixes**: wired up `cleanup_checkpoints` `before` parameter (was deleting all checkpoints), fixed `json_mapper` date format H/h/m/s single-vs-double char distinction, fixed vacuous test assertions, restructured WebSocket sink to use `tokio::sync::Mutex` for async safety

## Deferred items (tracked as issues)

- #78 — DistributedEngine drops events (pre-existing placeholder)
- #79 — Recovery engine apply_changelog placeholder
- #80 — Error config parsed then discarded
- #81 — YAML stream config extraction not implemented
- #82 — Table insert failures not routed to error handler/DLQ
- #83 — Dead code suppressions for unimplemented distributed components
- #84 — DefinitionConfig large enum variant
- #85 — Memory/Distributed backend stub cleanup_checkpoints

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `typos` passes
- [x] `cargo machete` passes
- [x] `cargo sort --workspace --check` passes
- [x] Full test suite: 1,375+ tests, 0 failures