### PR TITLE
feat: add comprehensive code quality tooling

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,2 @@
+[profile.default]
+slow-timeout = { period = "30s", terminate-after = 4 }

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owners for everything
+* @grainier

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,54 @@
+name: Bug Report
+description: Report a bug
+labels: ["bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug description
+      description: What happened? What did you expect?
+      placeholder: |
+        Describe the bug clearly. Include:
+        - What you were doing
+        - What you expected
+        - What actually happened
+    validations:
+      required: true
+
+  - type: dropdown
+    id: deployment
+    attributes:
+      label: Deployment method
+      options:
+        - Docker
+        - Compiled from source
+        - Pre-built binary
+        - Not applicable
+    validations:
+      required: false
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      placeholder: "e.g., 0.1.0 or commit SHA"
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / error output
+    validations:
+      required: false
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Start with ...
+        2. Run ...
+        3. Observe ...
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Design Discussion
+    url: https://github.com/eventflux-io/eventflux/discussions
+    about: For larger features that need design discussion first.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,30 @@
+name: Feature Request
+description: Suggest a new feature or enhancement
+labels: ["feature"]
+body:
+  - type: markdown
+    attributes:
+      value: >
+        **Tip:** For bigger features, consider starting a Discussion first.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What do you want and why?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed-solution
+    attributes:
+      label: Proposed solution
+    validations:
+      required: false
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+    validations:
+      required: false

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    rebase-strategy: "disabled"
+    commit-message:
+      prefix: "chore(deps): "
+    groups:
+      minor-and-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci(deps): "

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,8 +21,13 @@ on:
   pull_request:
     branches: [ "main" ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
+  pull-requests: read
 
 env:
   CARGO_TERM_COLOR: always
@@ -32,6 +37,28 @@ env:
   RUSTFLAGS: "-C debuginfo=0"
 
 jobs:
+  pr-title:
+    name: PR Title Convention
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017  # v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+
   ci:
     name: Quality, Build & Test
     runs-on: ubuntu-latest
@@ -69,12 +96,12 @@ jobs:
       uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
       with:
         path: |
+          ~/.cargo/bin
           ~/.cargo/registry
           ~/.cargo/git
           target
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('src/**') }}
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
         restore-keys: |
-          ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-
           ${{ runner.os }}-cargo-
 
     - name: Check formatting
@@ -83,15 +110,15 @@ jobs:
     - name: Run clippy
       # Note: Not using --all-features because cloud-native features (kubernetes, consul,
       # etcd, vault) require external system dependencies not available in CI.
-      run: cargo clippy --all-targets -- -D warnings
+      run: cargo clippy --all-targets -- -D warnings -A clippy::nursery
 
     - name: Check typos
       uses: crate-ci/typos@631208b7aac2daa8b707f55e7331f9112b0e062d  # v1.44.0
 
-    - name: Install cargo-machete and cargo-sort
+    - name: Install tools
       uses: taiki-e/install-action@cbb1dcaa26e1459e2876c39f61c1e22a1258aac5  # v2
       with:
-        tool: cargo-machete,cargo-sort
+        tool: cargo-machete,cargo-sort,cargo-nextest,taplo-cli
 
     - name: Check unused dependencies
       run: cargo machete
@@ -99,8 +126,14 @@ jobs:
     - name: Check dependency sorting
       run: cargo sort --workspace --check
 
+    - name: Check TOML formatting
+      run: taplo fmt --check
+
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo nextest run --verbose
+
+    - name: Run doctests
+      run: cargo test --doc
 
     - name: Run vendor parser tests
       run: cargo test --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -74,6 +74,16 @@ jobs:
         ports:
           - 6379:6379
 
+      rabbitmq:
+        image: rabbitmq:3-alpine
+        options: >-
+          --health-cmd "rabbitmq-diagnostics -q check_running"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5672:5672
+
     steps:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       with:
@@ -131,6 +141,9 @@ jobs:
 
     - name: Run tests
       run: cargo nextest run --verbose
+
+    - name: Run RabbitMQ integration tests
+      run: cargo nextest run --test rabbitmq_integration --run-ignored ignored-only --verbose
 
     - name: Run doctests
       run: cargo test --doc

--- a/.github/workflows/stale-prs.yml
+++ b/.github/workflows/stale-prs.yml
@@ -1,0 +1,45 @@
+# Copyright 2025-2026 EventFlux.io
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Stale PRs
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+permissions:
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899  # v10
+        with:
+          days-before-pr-stale: 7
+          days-before-pr-close: 7
+          stale-pr-label: "stale"
+          stale-pr-message: >
+            This pull request has been automatically marked as stale because
+            it has not had recent activity. It will be closed in 7 days if
+            no further activity occurs.
+          close-pr-message: >
+            This pull request was automatically closed due to inactivity.
+            Feel free to reopen if you'd like to continue.
+          exempt-pr-labels: "pinned"
+          exempt-draft-pr: true
+          days-before-issue-stale: -1
+          days-before-issue-close: -1

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,11 @@
 **/*.rs.bk
 *.pdb
 
+# Fuzz testing artifacts
+fuzz/target/
+fuzz/corpus/
+fuzz/artifacts/
+
 # Cargo.lock is committed for binaries but not libraries
 # Since this is a binary/application project, we keep Cargo.lock
 # Cargo.lock

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,6 @@
+{
+    "MD033": false,
+    "MD013": { "line_length": 500 },
+    "MD024": { "siblings_only": true },
+    "MD041": false
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,41 +1,66 @@
 # Pre-commit hooks for EventFlux Engine
-# Install: cargo install prek && prek install
-# Run all: prek run --all-files
+# Install: pip install pre-commit && pre-commit install --install-hooks
+# Run all: pre-commit run --all-files
+
+default_stages: [pre-commit]
+default_install_hook_types: [pre-commit, pre-push]
 
 repos:
+  # Standard file checks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: mixed-line-endings
+
+  # Fast checks on pre-commit (< 5s)
   - repo: local
     hooks:
+      - id: typos
+        name: typos (spelling check)
+        entry: typos -w
+        language: system
+        types: [text]
+        pass_filenames: false
+
+      - id: taplo
+        name: taplo (TOML format)
+        entry: taplo fmt
+        language: system
+        types: [toml]
+        pass_filenames: false
+
       - id: cargo-fmt
         name: cargo fmt
-        entry: cargo fmt --all -- --check
-        language: system
-        types: [rust]
-        pass_filenames: false
-
-      - id: cargo-clippy
-        name: cargo clippy
-        entry: cargo clippy --all-targets -- -D warnings
-        language: system
-        types: [rust]
-        pass_filenames: false
-
-      - id: typos
-        name: typos
-        entry: typos
-        language: system
-        types: [file]
-        pass_filenames: false
-
-      - id: cargo-machete
-        name: cargo machete
-        entry: cargo machete
+        entry: cargo fmt --all
         language: system
         types: [rust]
         pass_filenames: false
 
       - id: cargo-sort
         name: cargo sort
-        entry: cargo sort --workspace --check
+        entry: cargo sort --no-format --workspace
         language: system
-        types: [toml]
+        files: (^|/)Cargo\.toml$
         pass_filenames: false
+
+  # Slow checks on pre-push only
+  - repo: local
+    hooks:
+      - id: cargo-clippy
+        name: cargo clippy
+        entry: cargo clippy --all-targets -- -D warnings -A clippy::nursery
+        language: system
+        types: [rust]
+        pass_filenames: false
+        stages: [pre-push]
+
+      - id: cargo-machete
+        name: cargo machete (unused deps)
+        entry: cargo machete
+        language: system
+        types: [rust]
+        pass_filenames: false
+        stages: [pre-push]

--- a/.taplo.toml
+++ b/.taplo.toml
@@ -1,0 +1,16 @@
+[formatting]
+align_entries = false
+array_trailing_comma = true
+array_auto_expand = true
+array_auto_collapse = false
+column_width = 100
+compact_inline_tables = false
+indent_string = "    "
+reorder_keys = false
+reorder_arrays = false
+allowed_blank_lines = 1
+trailing_newline = true
+crlf = false
+
+include = ["**/*.toml"]
+exclude = ["target/**", "vendor/**", ".git/**"]

--- a/.taplo.toml
+++ b/.taplo.toml
@@ -1,3 +1,6 @@
+include = ["**/*.toml"]
+exclude = ["target/**", "vendor/**", ".git/**"]
+
 [formatting]
 align_entries = false
 array_trailing_comma = true
@@ -11,6 +14,3 @@ reorder_arrays = false
 allowed_blank_lines = 1
 trailing_newline = true
 crlf = false
-
-include = ["**/*.toml"]
-exclude = ["target/**", "vendor/**", ".git/**"]

--- a/.typos.toml
+++ b/.typos.toml
@@ -5,6 +5,10 @@ extend-exclude = [
     "target/",
     "studio/webview/dist/",
     "*.lock",
+    "**/CHANGELOG.md",
+    "**/*.snap",
+    "**/fixtures/**",
+    "rust-project-quality-guide.md",
 ]
 
 [default.extend-identifiers]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,16 +42,28 @@ All checks must pass before submitting:
 
 ```bash
 cargo fmt --all -- --check
-cargo clippy --all-targets -- -D warnings
+cargo clippy --all-targets -- -D warnings -A clippy::nursery
 typos
 cargo machete
 cargo sort --workspace --check
-cargo test
+taplo fmt --check
+cargo nextest run        # or: cargo test
+cargo test --doc
 ```
 
-To auto-fix formatting: `cargo fmt --all`
+Or run everything at once with [just](https://github.com/casey/just):
 
-To auto-fix typos: `typos --write-changes`
+```bash
+just check-all
+```
+
+To auto-fix formatting and typos:
+
+```bash
+cargo fmt --all
+typos --write-changes
+taplo fmt
+```
 
 ### Typos
 
@@ -66,20 +78,29 @@ If a word is a valid domain term (e.g., SQL keywords, proper nouns), add an exce
 
 ### Pre-commit Hooks
 
-We use [prek](https://github.com/j178/prek) to run quality checks before each commit:
+We use [pre-commit](https://pre-commit.com/) to run quality checks automatically:
 
 ```bash
-cargo install prek
-prek install
+pip install pre-commit
+pre-commit install --install-hooks
 ```
 
-This installs git hooks that automatically run fmt, clippy, typos, machete, and sort checks on every commit. To run all hooks manually:
+This installs git hooks that run fast checks (fmt, sort, typos, taplo) on every commit and slow checks (clippy, machete) on push. To run all hooks manually:
 
 ```bash
-prek run --all-files
+pre-commit run --all-files
 ```
 
-> **Note**: `prek` is optional for local development. CI runs the same checks independently. The `.pre-commit-config.yaml` is also compatible with standard [pre-commit](https://pre-commit.com/) if you prefer that tool.
+### Test Runner
+
+We use [cargo-nextest](https://nexte.st/) for faster, parallelized test execution:
+
+```bash
+cargo install cargo-nextest
+cargo nextest run                          # run all tests
+cargo nextest run --nocapture -- test_name # run specific test with output
+cargo test --doc                           # doctests (nextest doesn't run these)
+```
 
 ## Code Style
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,6 @@ etcd = ["etcd-rs"]
 vault = ["dep:vault"]
 cloud-native = ["kubernetes", "consul", "etcd", "vault"]
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 async-trait = "0.1"
 base64 = { version = "0.22", optional = true }
@@ -89,6 +87,81 @@ custom_dyn_ext = { path = "tests/custom_dyn_ext" }
 serial_test = "3.0"
 tempfile = "3"
 tokio = { version = "1", features = ["full", "test-util"] }
+
+[lints.clippy]
+pedantic = { level = "deny", priority = -1 }
+nursery = { level = "warn", priority = -1 }
+enum_glob_use = "allow"
+# Documentation lints — address incrementally
+doc_markdown = "allow"
+missing_errors_doc = "allow"
+missing_panics_doc = "allow"
+must_use_candidate = "allow"
+return_self_not_must_use = "allow"
+# Cast lints — common in systems/numeric code
+cast_lossless = "allow"
+cast_possible_truncation = "allow"
+cast_possible_wrap = "allow"
+cast_precision_loss = "allow"
+cast_sign_loss = "allow"
+# Style lints — subjective or too noisy for existing codebase
+assigning_clones = "allow"
+bool_to_int_with_if = "allow"
+default_trait_access = "allow"
+doc_link_with_quotes = "allow"
+explicit_into_iter_loop = "allow"
+explicit_iter_loop = "allow"
+float_cmp = "allow"
+fn_params_excessive_bools = "allow"
+if_not_else = "allow"
+implicit_hasher = "allow"
+items_after_statements = "allow"
+manual_let_else = "allow"
+map_unwrap_or = "allow"
+match_same_arms = "allow"
+match_wildcard_for_single_variants = "allow"
+module_name_repetitions = "allow"
+needless_pass_by_value = "allow"
+redundant_closure_for_method_calls = "allow"
+redundant_else = "allow"
+ref_option_ref = "allow"
+semicolon_if_nothing_returned = "allow"
+similar_names = "allow"
+single_char_pattern = "allow"
+single_match_else = "allow"
+struct_excessive_bools = "allow"
+struct_field_names = "allow"
+too_many_lines = "allow"
+trivially_copy_pass_by_ref = "allow"
+uninlined_format_args = "allow"
+unnecessary_wraps = "allow"
+unnested_or_patterns = "allow"
+unreadable_literal = "allow"
+unused_async = "allow"
+unused_self = "allow"
+used_underscore_binding = "allow"
+wildcard_imports = "allow"
+# Additional pedantic lints — fix incrementally
+checked_conversions = "allow"
+ignored_unit_patterns = "allow"
+implicit_clone = "allow"
+missing_fields_in_debug = "allow"
+option_as_ref_cloned = "allow"
+unchecked_duration_subtraction = "allow"
+unnecessary_literal_bound = "allow"
+used_underscore_items = "allow"
+stable_sort_primitive = "allow"
+ref_option = "allow"
+inefficient_to_string = "allow"
+manual_string_new = "allow"
+match_on_vec_items = "allow"
+needless_raw_string_hashes = "allow"
+# Nursery lints — suppressed because nursery is warn-level
+option_if_let_else = "allow"
+
+[profile.release]
+lto = true
+codegen-units = 1
 
 [[bench]]
 name = "lock_contention_bench"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -166,4 +166,3 @@ codegen-units = 1
 [[bench]]
 name = "lock_contention_bench"
 harness = false
-

--- a/DEV_GUIDE.md
+++ b/DEV_GUIDE.md
@@ -52,7 +52,7 @@ cargo check
 cargo fmt
 
 # Run linter
-cargo clippy
+cargo clippy --all-targets -- -D warnings -A clippy::nursery
 ```
 
 ---
@@ -205,7 +205,7 @@ eventflux/
 ### Module Overview
 
 - `query_api`: Defines AST for EventFlux applications, streams, queries, expressions
-- `sql_compiler`: LALRPOP-based parser for EventFluxQL with streaming extensions
+- `sql_compiler`: SQL parser with EventFlux streaming extensions (vendored sqlparser-rs)
 - `core`: Runtime execution including processors, executors, state management
 
 ---
@@ -408,19 +408,16 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the full contribution guide.
 2. Clone your fork
 3. Install pre-commit hooks:
    ```bash
-   cargo install prek
-   prek install
+   pip install pre-commit
+   pre-commit install --install-hooks
    ```
 4. Create a feature branch
 5. Make changes
 6. Run quality checks:
    ```bash
-   cargo fmt --all -- --check
-   cargo clippy --all-targets -- -D warnings
-   typos
-   cargo machete
-   cargo sort --workspace --check
-   cargo test
+   just check-all
+   cargo nextest run
+   cargo test --doc
    ```
 7. Submit pull request
 

--- a/README.md
+++ b/README.md
@@ -109,9 +109,10 @@ Active development. Core CEP works. 1,400+ tests passing. See [ROADMAP.md](ROADM
 ## Contributing
 
 ```bash
-cargo test        # run tests
-cargo clippy      # lint
-cargo fmt         # format
+cargo nextest run   # run tests
+just lint           # clippy
+cargo fmt           # format
+just check-all      # all quality checks
 ```
 
 See [DEV_GUIDE.md](DEV_GUIDE.md) for setup.

--- a/build.rs
+++ b/build.rs
@@ -23,7 +23,7 @@ fn main() {
         .out_dir("src/core/distributed/grpc")
         .compile(&["proto/transport.proto"], &["proto"])
     {
-        eprintln!("Protobuf compilation failed: {}", e);
+        eprintln!("Protobuf compilation failed: {e}");
         // Don't exit here, as gRPC might be optional
     }
 }

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,23 @@
+[changelog]
+body = """
+## What's Changed
+{%- if version %} in {{ version }}{%- endif -%}
+{% for commit in commits %}
+  {% if commit.remote.pr_title -%}
+    {%- set commit_message = commit.remote.pr_title -%}
+  {%- else -%}
+    {%- set commit_message = commit.message -%}
+  {%- endif -%}
+  * {{ commit_message | split(pat="\n") | first | trim }}\
+    {% if commit.remote.username %} by @{{ commit.remote.username }}{%- endif -%}
+    {% if commit.remote.pr_number %} in \
+      [#{{ commit.remote.pr_number }}](https://github.com/eventflux-io/eventflux/pull/{{ commit.remote.pr_number }}) \
+    {%- endif %}
+{%- endfor -%}
+"""
+trim = true
+
+[git]
+conventional_commits = true
+filter_unconventional = false
+sort_commits = "newest"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "eventflux-fuzz"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+sqlparser = { path = "../vendor/datafusion-sqlparser-rs" }
+
+[[bin]]
+name = "fuzz_sql_parser"
+path = "fuzz_targets/fuzz_sql_parser.rs"
+doc = false

--- a/fuzz/fuzz_targets/fuzz_sql_parser.rs
+++ b/fuzz/fuzz_targets/fuzz_sql_parser.rs
@@ -1,0 +1,9 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(s) = std::str::from_utf8(data) {
+        let dialect = sqlparser::dialect::GenericDialect {};
+        let _ = sqlparser::parser::Parser::parse_sql(&dialect, s);
+    }
+});

--- a/justfile
+++ b/justfile
@@ -1,0 +1,67 @@
+alias b  := build
+alias t  := test
+alias n  := nextest
+
+build:
+  cargo build
+
+test: build
+  cargo test
+
+# Run a specific test by name
+tests TEST: build
+  cargo test {{TEST}}
+
+nextest: build
+  cargo nextest run
+
+# Run with output visible
+nextests TEST: build
+  cargo nextest run --nocapture -- {{TEST}}
+
+server *ARGS:
+  cargo run --bin run_eventflux {{ARGS}}
+
+# Code quality
+lint:
+  cargo clippy --all-targets -- -D warnings -A clippy::nursery
+
+fmt:
+  cargo fmt --all
+
+fmt-check:
+  cargo fmt --all -- --check
+
+sort:
+  cargo sort --workspace
+
+machete:
+  cargo machete
+
+# TOML formatting
+taplo:
+  taplo fmt
+
+taplo-check:
+  taplo fmt --check
+
+# Spelling check
+typos:
+  typos
+
+# Code coverage
+coverage:
+  cargo llvm-cov --all-features --lcov --output-path lcov.info
+
+# All quality checks (run before PR)
+check-all: fmt sort taplo lint
+  cargo machete
+  typos
+
+# Generate changelog
+changelog:
+  git cliff -o CHANGELOG.md
+
+# Generate release notes for latest version
+release-notes:
+  git cliff --latest -o RELEASE_NOTES.md

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.85.0"
+components = ["rustfmt", "clippy"]
+profile = "default"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+edition = "2021"
+max_width = 100

--- a/src/core/stream/input/source/rabbitmq_source.rs
+++ b/src/core/stream/input/source/rabbitmq_source.rs
@@ -740,17 +740,26 @@ impl Source for RabbitMQSource {
         let validate_future = async move {
             let uri = config.amqp_uri();
 
-            // Try to connect
-            let connection =
-                lapin::Connection::connect(&uri, lapin::ConnectionProperties::default())
-                    .await
-                    .map_err(|e| EventFluxError::ConnectionUnavailable {
-                        message: format!(
-                            "Failed to connect to RabbitMQ at {}:{}: {}",
-                            config.host, config.port, e
-                        ),
-                        source: Some(Box::new(e)),
-                    })?;
+            // Try to connect with a timeout to avoid hanging on unreachable brokers
+            let connection = tokio::time::timeout(
+                std::time::Duration::from_secs(10),
+                lapin::Connection::connect(&uri, lapin::ConnectionProperties::default()),
+            )
+            .await
+            .map_err(|_| EventFluxError::ConnectionUnavailable {
+                message: format!(
+                    "Failed to connect to RabbitMQ at {}:{}: Connection timeout after 10s",
+                    config.host, config.port
+                ),
+                source: None,
+            })?
+            .map_err(|e| EventFluxError::ConnectionUnavailable {
+                message: format!(
+                    "Failed to connect to RabbitMQ at {}:{}: {}",
+                    config.host, config.port, e
+                ),
+                source: Some(Box::new(e)),
+            })?;
 
             // Create channel and check queue exists
             let channel = connection.create_channel().await.map_err(|e| {

--- a/src/core/stream/output/sink/rabbitmq_sink.rs
+++ b/src/core/stream/output/sink/rabbitmq_sink.rs
@@ -522,17 +522,26 @@ impl Sink for RabbitMQSink {
         let validate_future = async move {
             let uri = config.amqp_uri();
 
-            // Try to connect
-            let connection =
-                lapin::Connection::connect(&uri, lapin::ConnectionProperties::default())
-                    .await
-                    .map_err(|e| EventFluxError::ConnectionUnavailable {
-                        message: format!(
-                            "Failed to connect to RabbitMQ at {}:{}: {}",
-                            config.host, config.port, e
-                        ),
-                        source: Some(Box::new(e)),
-                    })?;
+            // Try to connect with a timeout to avoid hanging on unreachable brokers
+            let connection = tokio::time::timeout(
+                std::time::Duration::from_secs(10),
+                lapin::Connection::connect(&uri, lapin::ConnectionProperties::default()),
+            )
+            .await
+            .map_err(|_| EventFluxError::ConnectionUnavailable {
+                message: format!(
+                    "Failed to connect to RabbitMQ at {}:{}: Connection timeout after 10s",
+                    config.host, config.port
+                ),
+                source: None,
+            })?
+            .map_err(|e| EventFluxError::ConnectionUnavailable {
+                message: format!(
+                    "Failed to connect to RabbitMQ at {}:{}: {}",
+                    config.host, config.port, e
+                ),
+                source: Some(Box::new(e)),
+            })?;
 
             // Create channel and check exchange exists (if not declaring)
             let channel = connection.create_channel().await.map_err(|e| {

--- a/tests/rabbitmq_integration.rs
+++ b/tests/rabbitmq_integration.rs
@@ -1628,19 +1628,17 @@ fn test_e2e_query_based_rabbitmq_processing() {
     );
 
     // Verify each output event has price_category
-    // Note: The JSON sink mapper uses generic field names (field_0, field_1, etc.)
-    // field_3 = price_category (4th field in the schema)
     for (i, event) in output_events.iter().enumerate() {
         let category = event
-            .get("field_3")
-            .expect("Output event should have field_3 (price_category)");
+            .get("price_category")
+            .expect("Output event should have price_category");
         assert!(
             category == "low" || category == "medium" || category == "high",
             "Event {} has invalid price_category: {:?}",
             i,
             category
         );
-        let symbol = event.get("field_0").unwrap();
+        let symbol = event.get("symbol").unwrap();
         println!("  [OK] Event {}: {} → {}", i, symbol, category);
     }
 


### PR DESCRIPTION
## Summary

- **Toolchain pinning**: `rust-toolchain.toml` (1.85.0), `rustfmt.toml` (edition 2021, max_width 100)
- **Clippy lints**: `[lints.clippy]` in Cargo.toml with `pedantic = "deny"`, `nursery = "warn"`, and targeted allows for existing codebase
- **Release profile**: LTO + single codegen unit for optimized binaries
- **Pre-commit hooks**: Rewrote `.pre-commit-config.yaml` with standard `pre-commit` framework — fast hooks on commit (fmt, sort, typos, taplo, trailing whitespace/newline), slow hooks on push (clippy, machete)
- **CI enhancements**: Concurrency settings, PR title convention check (semantic-pull-request), nextest runner, taplo TOML check, doctests, cached `~/.cargo/bin`
- **GitHub configs**: Dependabot (cargo + actions), CODEOWNERS, issue templates (bug report, feature request), stale PR workflow
- **Task runner**: `justfile` with build, test, lint, fmt, sort, taplo, typos, coverage, changelog recipes
- **Changelog**: `cliff.toml` for git-cliff changelog generation
- **Fuzz testing**: `fuzz/` directory with SQL parser fuzz target (libfuzzer)
- **Additional configs**: `.taplo.toml`, `.markdownlint.json`, `.config/nextest.toml`
- **Documentation**: Updated CONTRIBUTING.md, DEV_GUIDE.md, README.md with new tooling commands

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings -A clippy::nursery` passes (0 errors)
- [x] `typos` passes
- [x] `cargo machete` passes (0 unused deps)
- [x] `cargo sort --workspace --check` passes
- [x] `cargo test` passes — 2,880 tests, 0 failures