### PR TITLE
docs: Document vendored sqlparser submodule setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,16 @@ These require design discussion in the issue before coding:
 
 Authors of PRs must run the code locally. "Relying on CI" is not acceptable.
 
+Clone with submodules — the SQL parser is a vendored submodule and the build fails without it:
+
+```bash
+git clone --recursive <your-fork-url>
+# or, if already cloned:
+git submodule update --init --recursive
+```
+
+See [DEV_GUIDE.md](DEV_GUIDE.md#git-submodules-required) for details.
+
 ### Single Purpose
 
 One PR = one thing. Bug fix, refactor, feature — separate PRs. Mixed PRs will be closed.

--- a/DEV_GUIDE.md
+++ b/DEV_GUIDE.md
@@ -20,6 +20,7 @@ This guide covers building, testing, running, and contributing to EventFlux.
 
 - Rust 1.85 or later
 - Protocol Buffer Compiler (for gRPC features)
+- Git submodules (the SQL parser is vendored — see below)
 
 MSRV is enforced via `Cargo.toml` (`package.rust-version`) and CI. If you don’t want to install Rust locally, use the
 official Docker image (`ghcr.io/eventflux-io/eventflux:latest`) for running `.eventflux` queries.
@@ -34,6 +35,42 @@ apt-get install protobuf-compiler
 
 # Verify
 protoc --version
+```
+
+### Git Submodules (required)
+
+EventFlux depends on a **vendored fork** of `datafusion-sqlparser-rs`, wired in as a git submodule at
+`vendor/datafusion-sqlparser-rs`. `Cargo.toml` references it via a `path` dependency:
+
+```toml
+sqlparser = { path = "vendor/datafusion-sqlparser-rs" }
+```
+
+The fork lives at [`eventflux-io/datafusion-sqlparser-rs`](https://github.com/eventflux-io/datafusion-sqlparser-rs)
+and is pinned to the `eventflux-extensions` branch, which carries EventFlux's streaming SQL extensions (native
+`WINDOW` clause, `EventFluxDialect`, etc.). **`cargo build` fails with a missing-manifest error if the submodule
+is not checked out**, because the `path` target is an empty directory.
+
+```bash
+# Preferred: clone with submodules in one step
+git clone --recursive git@github.com:eventflux-io/eventflux.git
+
+# Already cloned without --recursive? Initialize the submodule:
+git submodule update --init --recursive
+
+# Verify it is populated (should list Cargo.toml, src/, etc.)
+ls vendor/datafusion-sqlparser-rs
+```
+
+Updating the pinned parser version (maintainers):
+
+```bash
+# Pull the latest commit on the tracked branch into the submodule
+git submodule update --remote vendor/datafusion-sqlparser-rs
+
+# Commit the new submodule pointer in the parent repo
+git add vendor/datafusion-sqlparser-rs
+git commit -m "Update vendored sqlparser submodule"
 ```
 
 ### Build Commands
@@ -409,7 +446,8 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the full contribution guide.
 ### Development Setup
 
 1. Fork the repository
-2. Clone your fork
+2. Clone your fork with submodules: `git clone --recursive <your-fork-url>`
+   (or run `git submodule update --init --recursive` after cloning)
 3. Install pre-commit hooks:
    ```bash
    pip install pre-commit

--- a/README.md
+++ b/README.md
@@ -27,17 +27,24 @@ EventFlux runs as a single binary. No cluster. No JVM. No YAML manifests. Just S
 # Docker
 docker run -v ./app.sql:/app.sql ghcr.io/eventflux-io/eventflux /app.sql
 
-# Or build from source
-git clone https://github.com/eventflux-io/eventflux.git
+# Or build from source (--recursive pulls in the vendored SQL parser submodule)
+git clone --recursive https://github.com/eventflux-io/eventflux.git
 cd eventflux
 cargo build --release
 ./target/release/run_eventflux app.sql
+```
+
+Already cloned without `--recursive`? Fetch the submodule before building:
+
+```bash
+git submodule update --init --recursive
 ```
 
 ### Prerequisites (for building)
 
 - Rust 1.85+
 - Protocol Buffer compiler (for gRPC features)
+- Git submodules initialized (see above) — the SQL parser is a vendored submodule
 
 ## Example
 


### PR DESCRIPTION
## Summary

The SQL parser is a vendored fork of `datafusion-sqlparser-rs`, wired in as a git submodule at `vendor/datafusion-sqlparser-rs` and referenced by `Cargo.toml` via a `path` dependency. This setup was undocumented, so a fresh `git clone` without `--recursive` leaves the vendor directory empty and `cargo build` fails with a missing-manifest error.

## Changes

- **README.md** — Quick Start now clones with `--recursive`, with a fallback `git submodule update --init --recursive` and a submodule prerequisite note.
- **DEV_GUIDE.md** — new "Git Submodules (required)" section explaining the vendored fork, the `path` dependency, why the build fails without it, how to initialize, and how maintainers bump the pinned version. Development Setup steps updated to clone recursively.
- **CONTRIBUTING.md** — submodule clone/init instructions under "Run It Locally" with a cross-link to DEV_GUIDE.

Docs-only change; no code or configuration modified.