### PR TITLE
fix: pin dependency resolver to MSRV-aware v3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,9 @@ name = "eventflux"
 version = "0.1.0"
 edition = "2021"
 rust-version = "1.85"
+# MSRV-aware dependency resolution: keep resolved versions compatible with
+# rust-version above so `cargo update` never pulls deps requiring newer rustc.
+resolver = "3"
 license = "Apache-2.0"
 repository = "https://github.com/eventflux-io/eventflux"
 homepage = "https://eventflux.io"


### PR DESCRIPTION
## Problem

Building after any dependency re-resolution (`cargo update`, or a lockfile regeneration) fails on the declared MSRV:

```
error: rustc 1.85.0 is not supported by the following package:
  ar_archive_writer@0.5.2 requires rustc 1.88.0
```

The project declares `rust-version = "1.85"`, but edition 2021 defaults to **resolver v2, which ignores `rust-version` during dependency resolution**. So a re-resolve greedily bumps `object` 0.36 → 0.37 (pulling in `ar_archive_writer@0.5.2`, which needs rustc 1.88), along with `time`, `home`, and `libloading` jumping to 1.88-requiring versions.

## Fix

Set `resolver = "3"` in `[package]`. Resolver v3 is MSRV-aware: it caps every dependency at the newest version still compatible with `rust-version = "1.85"`.

Verified — a re-resolve now reports:

```
Locking 153 packages to latest Rust 1.85 compatible versions
```

and selects `ar_archive_writer 0.5.1` / 1.85-compatible `time` instead of the 1.88 versions. `object` stays at 0.36.7, the committed `Cargo.lock` is unchanged, and the build succeeds on rustc 1.85.0.