### PR TITLE
fix: join source worker threads on stop for synchronous shutdown

### DIFF
--- a/docs/writing_extensions.md
+++ b/docs/writing_extensions.md
@@ -51,6 +51,88 @@ using compiled values.
 Extensions for other storage engines can follow these examples to provide their
 own compiled condition formats.
 
+## Source Extensions
+
+A source extension implements the `Source` trait and provides a `SourceFactory`
+(see the RabbitMQ connector in `src/core/stream/input/source/rabbitmq_source.rs`
+for a complete reference implementation).
+
+### Worker thread lifecycle: use `SourceWorker`
+
+`Source::stop()` has a hard contract: **it must be synchronous**. When `stop()`
+returns, the worker thread must have terminated — no `SourceCallback` may fire
+afterwards, and repeated `stop()` calls must be no-ops. This is what makes
+application shutdown deterministic (no events delivered into a runtime that is
+tearing down).
+
+Do not hand-roll a `running: Arc<AtomicBool>` + `JoinHandle` pair. Embed a
+`SourceWorker` (from `core::stream::input::source`), which captures the pattern
+once and cannot be misused:
+
+```rust
+use eventflux::core::stream::input::source::{Source, SourceCallback, SourceWorker};
+
+pub struct MySource {
+    config: MyConfig,
+    worker: SourceWorker,
+}
+
+impl MySource {
+    pub fn new(config: MyConfig) -> Self {
+        Self {
+            config,
+            worker: SourceWorker::new("MySource"),
+        }
+    }
+}
+
+impl Source for MySource {
+    fn start(&mut self, callback: Arc<dyn SourceCallback>) {
+        let config = self.config.clone();
+        self.worker.start(move |running| {
+            while running.load(Ordering::SeqCst) {
+                // Read from the external system and deliver bytes:
+                //     callback.on_data(&bytes)
+                // Poll `running` at least every ~100ms so stop() is fast.
+            }
+        });
+    }
+
+    fn stop(&mut self) {
+        self.worker.stop(); // signals the flag + joins the thread (bounded)
+    }
+
+    fn clone_box(&self) -> Box<dyn Source> {
+        Box::new(Self {
+            config: self.config.clone(),
+            worker: self.worker.clone(), // clones as a fresh, unstarted worker
+        })
+    }
+}
+```
+
+What `SourceWorker` guarantees:
+
+- `stop()` signals the running flag and joins the thread, bounded by
+  `SOURCE_STOP_GRACE_PERIOD` (5s) — a worker stuck in slow I/O is detached
+  with a warning instead of hanging shutdown
+- `stop()` is idempotent (safe without `start()`, safe to call twice)
+- `Drop` calls `stop()` — a source dropped without being stopped still shuts
+  its worker down
+- `Clone` yields a fresh, unstarted worker, so runtime state never leaks into
+  clones
+
+The runtime stops sources in parallel during bulk shutdown, so a correct
+`stop()` is all a source needs to provide — total shutdown stays bounded by
+one grace period regardless of source count.
+
+The only obligation left on the implementer is inside the loop: **poll the
+`running` flag at least every ~100ms** — use a poll/read timeout around
+blocking I/O (as the RabbitMQ and WebSocket sources do), and
+`sleep_while_running(&running, interval)` instead of `thread::sleep` for waits
+between iterations (as TimerSource does), so long intervals never delay
+shutdown.
+
 ## Dynamic Extensions
 
 Extensions can also be distributed as separate crates compiled into dynamic

--- a/src/core/eventflux_app_runtime.rs
+++ b/src/core/eventflux_app_runtime.rs
@@ -605,10 +605,18 @@ impl EventFluxAppRuntime {
     }
 
     /// Stop all registered source handlers
+    ///
+    /// Joins run in parallel via scoped threads, so total shutdown is
+    /// bounded by one grace period instead of one per source — without
+    /// requiring anything from `Source` implementations beyond a correct
+    /// `stop()`.
     pub fn stop_all_sources(&self) {
-        for handler in self.source_handlers.read().unwrap().values() {
-            handler.stop();
-        }
+        let handlers = self.source_handlers.read().unwrap();
+        std::thread::scope(|s| {
+            for handler in handlers.values() {
+                s.spawn(|| handler.stop());
+            }
+        });
     }
 
     /// Start all registered sink handlers

--- a/src/core/stream/input/source/mod.rs
+++ b/src/core/stream/input/source/mod.rs
@@ -23,7 +23,10 @@ use crate::core::exception::EventFluxError;
 use crate::core::stream::input::input_handler::InputHandler;
 use crate::core::stream::input::mapper::SourceMapper;
 use std::fmt::Debug;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
+use std::thread::JoinHandle;
+use std::time::{Duration, Instant};
 
 /// Callback for receiving data from sources
 ///
@@ -52,7 +55,14 @@ pub trait Source: Debug + Send + Sync {
     /// Source::read() → bytes → SourceCallback::on_data() → SourceMapper → Events → InputHandler
     /// ```
     fn start(&mut self, callback: Arc<dyn SourceCallback>);
+
+    /// Stop the source.
+    ///
+    /// Contract: synchronous (no callback may fire after it returns) and
+    /// idempotent. Do not implement by hand — embed a [`SourceWorker`] and
+    /// delegate to [`SourceWorker::stop`], which guarantees both.
     fn stop(&mut self);
+
     fn clone_box(&self) -> Box<dyn Source>;
 
     /// Phase 2 validation: Verify connectivity and external resource availability
@@ -116,6 +126,148 @@ impl Clone for Box<dyn Source> {
     }
 }
 
+/// Default grace period sources wait for their worker thread in `stop()`.
+pub const SOURCE_STOP_GRACE_PERIOD: Duration = Duration::from_secs(5);
+
+/// Lifecycle handle for a source's worker thread.
+///
+/// Every thread-based source embeds one of these instead of hand-rolling a
+/// `running: Arc<AtomicBool>` + `JoinHandle` pair. It captures the shutdown
+/// pattern once so implementations cannot get it wrong:
+///
+/// - [`start`](Self::start) sets the running flag and spawns the worker
+/// - [`stop`](Self::stop) clears the flag and joins the thread (bounded by
+///   [`SOURCE_STOP_GRACE_PERIOD`]), making `Source::stop()` synchronous —
+///   no callback can fire after it returns. Idempotent.
+/// - `Drop` calls `stop()`, so a source that is dropped without being
+///   stopped still shuts its worker down (RAII)
+/// - `Clone` yields a fresh, unstarted worker — runtime state never leaks
+///   into clones
+///
+/// Worker loops that wait between iterations should use
+/// [`sleep_while_running`] instead of `thread::sleep` so long intervals don't
+/// delay shutdown.
+///
+/// # Usage
+///
+/// ```rust,ignore
+/// pub struct MySource {
+///     config: MyConfig,
+///     worker: SourceWorker,
+/// }
+///
+/// impl Source for MySource {
+///     fn start(&mut self, callback: Arc<dyn SourceCallback>) {
+///         let config = self.config.clone();
+///         self.worker.start(move |running| {
+///             while running.load(Ordering::SeqCst) {
+///                 // poll `running` at least every ~100ms so stop() is fast
+///             }
+///         });
+///     }
+///
+///     fn stop(&mut self) {
+///         self.worker.stop();
+///     }
+///     // ...
+/// }
+/// ```
+#[derive(Debug)]
+pub struct SourceWorker {
+    /// Source name used in shutdown log messages
+    name: &'static str,
+    /// Running flag polled by the worker loop
+    running: Arc<AtomicBool>,
+    /// Worker thread handle, joined in `stop()`
+    handle: Option<JoinHandle<()>>,
+}
+
+impl SourceWorker {
+    /// Create an unstarted worker. `name` appears in shutdown log messages.
+    pub fn new(name: &'static str) -> Self {
+        Self {
+            name,
+            running: Arc::new(AtomicBool::new(false)),
+            handle: None,
+        }
+    }
+
+    /// Set the running flag and spawn the worker thread.
+    ///
+    /// The closure receives the running flag and must poll it at least every
+    /// ~100ms so that `stop()` returns promptly (use [`sleep_while_running`]
+    /// for waits between iterations).
+    pub fn start<F>(&mut self, body: F)
+    where
+        F: FnOnce(Arc<AtomicBool>) + Send + 'static,
+    {
+        self.running.store(true, Ordering::SeqCst);
+        let running = Arc::clone(&self.running);
+        self.handle = Some(std::thread::spawn(move || body(running)));
+    }
+
+    /// Signal shutdown and join the worker thread.
+    ///
+    /// Bounded by [`SOURCE_STOP_GRACE_PERIOD`]; a worker stuck in slow I/O is
+    /// detached with a warning. Idempotent — safe to call without `start()`
+    /// or multiple times.
+    pub fn stop(&mut self) {
+        self.running.store(false, Ordering::SeqCst);
+        if let Some(handle) = self.handle.take() {
+            join_with_timeout(handle, SOURCE_STOP_GRACE_PERIOD, self.name);
+        }
+    }
+}
+
+impl Drop for SourceWorker {
+    fn drop(&mut self) {
+        // RAII: a source dropped without stop() still shuts its worker down.
+        self.stop();
+    }
+}
+
+impl Clone for SourceWorker {
+    fn clone(&self) -> Self {
+        // Runtime state (flag, handle) never leaks into clones.
+        Self::new(self.name)
+    }
+}
+
+/// Sleep for `duration`, waking early when `running` is cleared.
+///
+/// Worker loops use this instead of `thread::sleep` for waits between
+/// iterations, so a long interval (e.g. a 60s timer) never delays `stop()`:
+/// the sleep is taken in ≤100ms slices with the flag checked between slices.
+pub fn sleep_while_running(running: &AtomicBool, duration: Duration) {
+    let deadline = Instant::now() + duration;
+    while running.load(Ordering::SeqCst) {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            return;
+        }
+        std::thread::sleep(remaining.min(Duration::from_millis(100)));
+    }
+}
+
+/// Join a worker thread, bounded by `timeout`. Internal to [`SourceWorker`].
+///
+/// std has no native timed join, so this polls [`JoinHandle::is_finished`]
+/// until the deadline. On timeout the worker is detached (its handle is
+/// dropped) with a warning — no extra threads, nothing left parked.
+fn join_with_timeout(handle: JoinHandle<()>, timeout: Duration, source_name: &str) {
+    let deadline = Instant::now() + timeout;
+    while !handle.is_finished() {
+        if Instant::now() >= deadline {
+            log::warn!("[{source_name}] Worker thread did not stop within {timeout:?}; detaching");
+            return; // dropping the handle detaches the thread
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    if handle.join().is_err() {
+        log::warn!("[{source_name}] Worker thread panicked during shutdown");
+    }
+}
+
 /// Adapter that connects the Source architecture (produces bytes) with SourceMapper and InputHandler
 ///
 /// This adapter implements the clean architecture flow:
@@ -159,5 +311,149 @@ impl SourceCallback for SourceCallbackAdapter {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::time::{Duration, Instant};
+
+    #[test]
+    fn test_join_with_timeout_completes_promptly() {
+        let finished = Arc::new(AtomicBool::new(false));
+        let finished_clone = Arc::clone(&finished);
+        let handle = std::thread::spawn(move || {
+            finished_clone.store(true, Ordering::SeqCst);
+        });
+
+        let start = Instant::now();
+        join_with_timeout(handle, Duration::from_secs(5), "TestSource");
+
+        assert!(finished.load(Ordering::SeqCst), "worker must have finished");
+        assert!(
+            start.elapsed() < Duration::from_secs(1),
+            "join must return promptly for a fast worker, not wait for the timeout"
+        );
+    }
+
+    #[test]
+    fn test_join_with_timeout_detaches_slow_worker() {
+        let running = Arc::new(AtomicBool::new(true));
+        let running_clone = Arc::clone(&running);
+        let handle = std::thread::spawn(move || {
+            while running_clone.load(Ordering::SeqCst) {
+                std::thread::sleep(Duration::from_millis(10));
+            }
+        });
+
+        let start = Instant::now();
+        join_with_timeout(handle, Duration::from_millis(100), "TestSource");
+        let elapsed = start.elapsed();
+
+        assert!(
+            elapsed >= Duration::from_millis(100),
+            "join must wait the full grace period before detaching"
+        );
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "join must not block past the grace period"
+        );
+
+        // Let the detached worker exit so the test doesn't leak a spinning thread
+        running.store(false, Ordering::SeqCst);
+    }
+
+    #[test]
+    fn test_join_with_timeout_survives_worker_panic() {
+        let handle = std::thread::spawn(|| {
+            panic!("intentional test panic");
+        });
+
+        // Must log and return, not propagate the panic
+        join_with_timeout(handle, Duration::from_secs(5), "TestSource");
+    }
+
+    // =========================================================================
+    // SourceWorker Tests
+    // =========================================================================
+
+    use std::sync::atomic::AtomicU64;
+
+    #[test]
+    fn test_source_worker_stop_joins_thread() {
+        let ticks = Arc::new(AtomicU64::new(0));
+        let ticks_clone = Arc::clone(&ticks);
+
+        let mut worker = SourceWorker::new("TestSource");
+        worker.start(move |running| {
+            while running.load(Ordering::SeqCst) {
+                ticks_clone.fetch_add(1, Ordering::SeqCst);
+                std::thread::sleep(Duration::from_millis(5));
+            }
+        });
+
+        std::thread::sleep(Duration::from_millis(30));
+        worker.stop();
+
+        // stop() joined the worker — the tick count must be frozen
+        let at_stop = ticks.load(Ordering::SeqCst);
+        assert!(at_stop > 0, "worker should have run");
+        std::thread::sleep(Duration::from_millis(30));
+        assert_eq!(
+            ticks.load(Ordering::SeqCst),
+            at_stop,
+            "worker must not run after stop() returns"
+        );
+    }
+
+    #[test]
+    fn test_source_worker_stop_is_idempotent() {
+        let mut worker = SourceWorker::new("TestSource");
+        worker.stop(); // Without start — no-op
+        worker.start(|running| while running.load(Ordering::SeqCst) {});
+        worker.stop();
+        worker.stop(); // Handle already taken — no-op
+    }
+
+    #[test]
+    fn test_source_worker_drop_stops_thread() {
+        let exited = Arc::new(AtomicBool::new(false));
+        let exited_clone = Arc::clone(&exited);
+
+        {
+            let mut worker = SourceWorker::new("TestSource");
+            worker.start(move |running| {
+                while running.load(Ordering::SeqCst) {
+                    std::thread::sleep(Duration::from_millis(5));
+                }
+                exited_clone.store(true, Ordering::SeqCst);
+            });
+            // Dropped without stop()
+        }
+
+        assert!(
+            exited.load(Ordering::SeqCst),
+            "drop must signal and join the worker (RAII)"
+        );
+    }
+
+    #[test]
+    fn test_source_worker_clone_is_unstarted() {
+        let mut worker = SourceWorker::new("TestSource");
+        worker.start(|running| while running.load(Ordering::SeqCst) {});
+
+        let clone = worker.clone();
+        assert!(
+            clone.handle.is_none(),
+            "a cloned worker must start unstarted"
+        );
+        assert!(
+            !clone.running.load(Ordering::SeqCst),
+            "a cloned worker must not be running"
+        );
+
+        worker.stop();
     }
 }

--- a/src/core/stream/input/source/rabbitmq_source.rs
+++ b/src/core/stream/input/source/rabbitmq_source.rs
@@ -38,7 +38,7 @@
 //! let source = RabbitMQSource::from_properties(&properties, None, "RabbitMQStream")?;
 //! ```
 
-use super::{Source, SourceCallback};
+use super::{Source, SourceCallback, SourceWorker};
 use crate::core::error::handler::ErrorAction;
 use crate::core::error::source_support::{ErrorConfigBuilder, SourceErrorContext};
 use crate::core::event::value::AttributeValue;
@@ -48,11 +48,7 @@ use crate::core::extension::SourceFactory;
 use crate::core::stream::input::input_handler::InputHandler;
 use std::collections::HashMap;
 use std::fmt::Debug;
-use std::sync::{
-    atomic::{AtomicBool, Ordering},
-    Arc, Mutex,
-};
-use std::thread;
+use std::sync::{atomic::Ordering, Arc, Mutex};
 use std::time::Duration;
 
 /// Configuration for RabbitMQ source
@@ -182,8 +178,8 @@ impl RabbitMQSourceConfig {
 pub struct RabbitMQSource {
     /// Configuration
     config: RabbitMQSourceConfig,
-    /// Running flag for graceful shutdown
-    running: Arc<AtomicBool>,
+    /// Worker thread lifecycle (spawn, signal, join on stop)
+    worker: SourceWorker,
     /// Optional error handling context (M5 integration)
     error_ctx: Option<SourceErrorContext>,
 }
@@ -193,7 +189,7 @@ impl RabbitMQSource {
     pub fn new(config: RabbitMQSourceConfig) -> Self {
         Self {
             config,
-            running: Arc::new(AtomicBool::new(false)),
+            worker: SourceWorker::new("RabbitMQSource"),
             error_ctx: None,
         }
     }
@@ -242,7 +238,7 @@ impl RabbitMQSource {
 
         Ok(Self {
             config,
-            running: Arc::new(AtomicBool::new(false)),
+            worker: SourceWorker::new("RabbitMQSource"),
             error_ctx,
         })
     }
@@ -252,22 +248,20 @@ impl Clone for RabbitMQSource {
     fn clone(&self) -> Self {
         Self {
             config: self.config.clone(),
-            running: Arc::new(AtomicBool::new(false)),
-            error_ctx: None, // Error context contains runtime state, not cloneable
+            worker: self.worker.clone(), // Clones as a fresh, unstarted worker
+            error_ctx: None,             // Error context contains runtime state, not cloneable
         }
     }
 }
 
 impl Source for RabbitMQSource {
     fn start(&mut self, callback: Arc<dyn SourceCallback>) {
-        let running = self.running.clone();
-        running.store(true, Ordering::SeqCst);
         let config = self.config.clone();
 
         // Move error_ctx into the thread
         let mut error_ctx = self.error_ctx.take();
 
-        thread::spawn(move || {
+        self.worker.start(move |running| {
             // Create a tokio runtime for lapin async operations
             let rt = match tokio::runtime::Runtime::new() {
                 Ok(rt) => rt,
@@ -720,7 +714,7 @@ impl Source for RabbitMQSource {
 
     fn stop(&mut self) {
         log::info!("[RabbitMQSource] Stopping...");
-        self.running.store(false, Ordering::SeqCst);
+        self.worker.stop();
     }
 
     fn clone_box(&self) -> Box<dyn Source> {
@@ -1171,5 +1165,35 @@ mod tests {
             result.is_ok(),
             "Factory should accept DLQ strategy (junction wired later by stream_initializer)"
         );
+    }
+
+    // =========================================================================
+    // Shutdown Lifecycle Tests (no broker required)
+    // =========================================================================
+    // Idempotency and stop-without-start are covered by the SourceWorker
+    // tests in source/mod.rs; this test adds the connect-failure join path.
+
+    #[test]
+    fn test_start_stop_joins_worker() {
+        #[derive(Debug)]
+        struct NoopCallback;
+        impl SourceCallback for NoopCallback {
+            fn on_data(&self, _data: &[u8]) -> Result<(), EventFluxError> {
+                Ok(())
+            }
+        }
+
+        // Port 1 refuses connections immediately — the worker fails to connect
+        // and exits; stop() must join it without hanging.
+        let config = RabbitMQSourceConfig {
+            host: "127.0.0.1".to_string(),
+            port: 1,
+            queue: "test".to_string(),
+            ..Default::default()
+        };
+        let mut source = RabbitMQSource::new(config);
+        source.start(Arc::new(NoopCallback));
+        source.stop();
+        source.stop(); // Second stop: handle already taken, must be a no-op
     }
 }

--- a/src/core/stream/input/source/timer_source.rs
+++ b/src/core/stream/input/source/timer_source.rs
@@ -41,7 +41,7 @@
 //! let source = TimerSource::from_properties(&properties, None, "TimerStream")?;
 //! ```
 
-use super::{Source, SourceCallback};
+use super::{sleep_while_running, Source, SourceCallback, SourceWorker};
 use crate::core::error::source_support::{ErrorConfigBuilder, SourceErrorContext};
 use crate::core::event::event::Event;
 use crate::core::event::value::AttributeValue;
@@ -50,11 +50,7 @@ use crate::core::stream::input::input_handler::InputHandler;
 use crate::core::stream::input::mapper::PassthroughMapper;
 use std::collections::HashMap;
 use std::fmt::Debug;
-use std::sync::{
-    atomic::{AtomicBool, Ordering},
-    Arc, Mutex,
-};
-use std::thread;
+use std::sync::{atomic::Ordering, Arc, Mutex};
 use std::time::Duration;
 
 /// Timer source that generates tick events at regular intervals
@@ -68,8 +64,8 @@ use std::time::Duration;
 pub struct TimerSource {
     /// Interval between ticks in milliseconds
     interval_ms: u64,
-    /// Running flag for graceful shutdown
-    running: Arc<AtomicBool>,
+    /// Worker thread lifecycle (spawn, signal, join on stop)
+    worker: SourceWorker,
     /// Optional error handling context (M5 integration)
     error_ctx: Option<SourceErrorContext>,
     /// Optional simulated failure rate for testing (0.0 = never, 1.0 = always)
@@ -84,7 +80,7 @@ impl TimerSource {
     pub fn new(interval_ms: u64) -> Self {
         Self {
             interval_ms,
-            running: Arc::new(AtomicBool::new(false)),
+            worker: SourceWorker::new("TimerSource"),
             error_ctx: None,
             #[cfg(test)]
             simulate_failure_rate: 0.0,
@@ -144,7 +140,7 @@ impl TimerSource {
 
         Ok(Self {
             interval_ms,
-            running: Arc::new(AtomicBool::new(false)),
+            worker: SourceWorker::new("TimerSource"),
             error_ctx,
             #[cfg(test)]
             simulate_failure_rate: 0.0,
@@ -188,8 +184,8 @@ impl Clone for TimerSource {
     fn clone(&self) -> Self {
         Self {
             interval_ms: self.interval_ms,
-            running: Arc::new(AtomicBool::new(false)),
-            error_ctx: None, // Error context is not cloneable (contains runtime state)
+            worker: self.worker.clone(), // Clones as a fresh, unstarted worker
+            error_ctx: None,             // Error context is not cloneable (contains runtime state)
             #[cfg(test)]
             simulate_failure_rate: self.simulate_failure_rate,
         }
@@ -198,8 +194,6 @@ impl Clone for TimerSource {
 
 impl Source for TimerSource {
     fn start(&mut self, callback: Arc<dyn SourceCallback>) {
-        let running = self.running.clone();
-        running.store(true, Ordering::SeqCst);
         let interval = self.interval_ms;
 
         // Move error_ctx into the thread (take ownership)
@@ -208,7 +202,7 @@ impl Source for TimerSource {
         #[cfg(test)]
         let failure_rate = self.simulate_failure_rate;
 
-        thread::spawn(move || {
+        self.worker.start(move |running| {
             while running.load(Ordering::SeqCst) {
                 // Create event
                 let event =
@@ -288,13 +282,14 @@ impl Source for TimerSource {
                     }
                 }
 
-                thread::sleep(Duration::from_millis(interval));
+                // Interruptible sleep: a long interval must not delay stop()
+                sleep_while_running(&running, Duration::from_millis(interval));
             }
         });
     }
 
     fn stop(&mut self) {
-        self.running.store(false, Ordering::SeqCst);
+        self.worker.stop();
     }
 
     fn clone_box(&self) -> Box<dyn Source> {
@@ -305,6 +300,7 @@ impl Source for TimerSource {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::thread;
 
     // Note: Full timer source tests with actual event delivery are in tests/source_sink.rs
     // These tests focus on error handling configuration
@@ -370,5 +366,51 @@ mod tests {
         // Verify error handling is configured
         assert!(source.error_ctx.is_some());
         assert_eq!(source.simulate_failure_rate, 0.3);
+    }
+
+    // =========================================================================
+    // Shutdown Lifecycle Tests
+    // =========================================================================
+
+    use std::sync::atomic::AtomicU64;
+
+    #[derive(Debug)]
+    struct CountingCallback {
+        count: Arc<AtomicU64>,
+    }
+
+    impl SourceCallback for CountingCallback {
+        fn on_data(&self, _data: &[u8]) -> Result<(), EventFluxError> {
+            self.count.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    // Idempotency and stop-without-start are covered once at the mechanism
+    // level by the SourceWorker tests in source/mod.rs; this end-to-end test
+    // proves the delegation through the Source trait.
+    #[test]
+    fn test_no_callbacks_after_stop_returns() {
+        let count = Arc::new(AtomicU64::new(0));
+        let mut source = TimerSource::new(10);
+        source.start(Arc::new(CountingCallback {
+            count: Arc::clone(&count),
+        }));
+
+        // Let the worker deliver a few ticks
+        thread::sleep(Duration::from_millis(50));
+        source.stop();
+
+        // stop() joined the worker — the count must be frozen from here on.
+        // Before the join this assertion was racy: the worker could still be
+        // mid-iteration when stop() returned.
+        let count_at_stop = count.load(Ordering::SeqCst);
+        assert!(count_at_stop > 0, "worker should have delivered ticks");
+        thread::sleep(Duration::from_millis(50));
+        assert_eq!(
+            count.load(Ordering::SeqCst),
+            count_at_stop,
+            "no callback may fire after stop() returns"
+        );
     }
 }

--- a/src/core/stream/input/source/websocket_source.rs
+++ b/src/core/stream/input/source/websocket_source.rs
@@ -37,7 +37,7 @@
 //! let source = WebSocketSource::from_properties(&properties, None, "TradeStream")?;
 //! ```
 
-use super::{Source, SourceCallback};
+use super::{Source, SourceCallback, SourceWorker};
 use crate::core::error::handler::ErrorAction;
 use crate::core::error::source_support::{ErrorConfigBuilder, SourceErrorContext};
 use crate::core::event::value::AttributeValue;
@@ -53,7 +53,6 @@ use std::sync::{
     atomic::{AtomicBool, Ordering},
     Arc, Mutex,
 };
-use std::thread;
 use std::time::Duration;
 use tokio::net::TcpStream;
 use tokio_tungstenite::{
@@ -167,8 +166,8 @@ impl WebSocketSourceConfig {
 pub struct WebSocketSource {
     /// Configuration
     config: WebSocketSourceConfig,
-    /// Running flag for graceful shutdown
-    running: Arc<AtomicBool>,
+    /// Worker thread lifecycle (spawn, signal, join on stop)
+    worker: SourceWorker,
     /// Optional error handling context (M5 integration)
     error_ctx: Option<SourceErrorContext>,
 }
@@ -178,7 +177,7 @@ impl WebSocketSource {
     pub fn new(config: WebSocketSourceConfig) -> Self {
         Self {
             config,
-            running: Arc::new(AtomicBool::new(false)),
+            worker: SourceWorker::new("WebSocketSource"),
             error_ctx: None,
         }
     }
@@ -249,7 +248,7 @@ impl WebSocketSource {
 
         Ok(Self {
             config,
-            running: Arc::new(AtomicBool::new(false)),
+            worker: SourceWorker::new("WebSocketSource"),
             error_ctx,
         })
     }
@@ -526,22 +525,20 @@ impl Clone for WebSocketSource {
     fn clone(&self) -> Self {
         Self {
             config: self.config.clone(),
-            running: Arc::new(AtomicBool::new(false)),
-            error_ctx: None, // Error context contains runtime state, not cloneable
+            worker: self.worker.clone(), // Clones as a fresh, unstarted worker
+            error_ctx: None,             // Error context contains runtime state, not cloneable
         }
     }
 }
 
 impl Source for WebSocketSource {
     fn start(&mut self, callback: Arc<dyn SourceCallback>) {
-        let running = self.running.clone();
-        running.store(true, Ordering::SeqCst);
         let config = self.config.clone();
 
         // Move error_ctx into the thread
         let error_ctx = self.error_ctx.take();
 
-        thread::spawn(move || {
+        self.worker.start(move |running| {
             // Create a tokio runtime for async WebSocket operations
             let rt = match tokio::runtime::Runtime::new() {
                 Ok(rt) => rt,
@@ -557,7 +554,9 @@ impl Source for WebSocketSource {
 
     fn stop(&mut self) {
         log::info!("[WebSocketSource] Stopping...");
-        self.running.store(false, Ordering::SeqCst);
+        // A worker blocked in a connect attempt (10s timeout) is detached
+        // after the grace period.
+        self.worker.stop();
     }
 
     fn clone_box(&self) -> Box<dyn Source> {
@@ -919,4 +918,8 @@ mod tests {
         let result = factory.create_initialized(&config);
         assert!(result.is_ok(), "Factory should accept error.* config");
     }
+
+    // Shutdown lifecycle (stop-without-start, double-stop, join-on-stop) is
+    // covered by the SourceWorker tests in source/mod.rs — WebSocketSource
+    // delegates its lifecycle entirely to SourceWorker.
 }


### PR DESCRIPTION
## Problem

All three sources (RabbitMQ, WebSocket, Timer) spawned their worker thread and discarded the `JoinHandle`; `stop()` only flipped an `AtomicBool` and returned immediately. Shutdown was fire-and-forget:

- callbacks could still fire after `stop()` returned (events delivered into a runtime that is tearing down)
- app teardown raced connector cleanup (channel/connection close running concurrently with runtime destruction)
- stop-then-assert tests were inherently racy

## Fix

Rather than patching each source, the worker-thread lifecycle is captured once in a **`SourceWorker`** struct (`source/mod.rs`) that sources embed by composition — the join cannot be forgotten because it lives inside the abstraction:

- `start(body)` sets the running flag and spawns the worker; the closure receives the flag
- `stop()` signals + joins, bounded by `SOURCE_STOP_GRACE_PERIOD` (5s) — a worker stuck in slow I/O is detached with a warning instead of hanging shutdown. Idempotent.
- `Drop` calls `stop()` (RAII) — a source dropped without being stopped still shuts its worker down
- `Clone` yields a fresh, unstarted worker — runtime state never leaks into clones

The timed join polls `JoinHandle::is_finished()` against a deadline — no watcher threads, nothing left parked on timeout.

Supporting changes:

- **`Source::stop()` contract documented on the trait**: synchronous, idempotent, no callbacks after return — with a pointer to `SourceWorker`
- **`sleep_while_running()` helper**: interruptible sleep in ≤100ms slices; TimerSource now uses it, so a 60s-interval timer stops in ~100ms instead of blocking shutdown for the full grace period
- **`stop_all_sources()` joins in parallel** via `std::thread::scope`, bounding bulk shutdown at ~one grace period regardless of source count — with no obligations on `Source` implementations beyond a correct `stop()`
- All three sources refactored to embed `SourceWorker`; their hand-rolled `running`/handle fields are gone
- `docs/writing_extensions.md` gains a "Source Extensions" section documenting the pattern for new connector authors (Kafka will use it from day one)

## Tests

- `SourceWorker` unit tests: stop joins the thread (count frozen after return), idempotent stop, Drop-RAII shuts the worker down, clone starts unstarted, slow-worker detach after grace period, worker panic contained
- End-to-end through the `Source` trait: TimerSource delivers no callbacks after `stop()` returns; RabbitMQSource start/stop joins cleanly after a failed connect (no broker needed)
- Full suite: 3,041 passed, 0 failed; doctests pass; clippy clean under CI flags

Part 2 of the connector infrastructure fixes preceding the Kafka connector (Part 1: #115).