### PR TITLE
feat: gate connectors behind per-connector cargo features

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -120,7 +120,14 @@ jobs:
     - name: Run clippy
       # Note: Not using --all-features because cloud-native features (kubernetes, consul,
       # etcd, vault) require external system dependencies not available in CI.
-      run: cargo clippy --all-targets -- -D warnings -A clippy::nursery
+      run: cargo clippy --all-targets --features connectors-all -- -D warnings -A clippy::nursery
+
+    - name: Check per-connector feature gating
+      # Each connector alone (including test code) — catches missing #[cfg]s
+      # and accidental cross-feature dependencies.
+      run: |
+        cargo check --all-targets --features rabbitmq
+        cargo check --all-targets --features websocket
 
     - name: Check typos
       uses: crate-ci/typos@37bb98842b0d8c4ffebdb75301a13db0267cef89  # v1.47.2
@@ -140,13 +147,19 @@ jobs:
       run: taplo fmt --check
 
     - name: Run tests
+      run: cargo nextest run --features connectors-all --verbose
+
+    - name: Run tests (minimal build, no connectors)
+      # The advertised lightweight baseline must not just compile — its test
+      # suite (including cfg(not(feature))-gated tests like the
+      # unavailable-extension hint) must pass.
       run: cargo nextest run --verbose
 
     - name: Run RabbitMQ integration tests
-      run: cargo nextest run --test rabbitmq_integration --run-ignored ignored-only --verbose
+      run: cargo nextest run --features rabbitmq --test rabbitmq_integration --run-ignored ignored-only --verbose
 
     - name: Run doctests
-      run: cargo test --doc
+      run: cargo test --doc --features connectors-all
 
     - name: Run vendor parser tests
       run: cargo test --verbose

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,7 +51,9 @@ repos:
     hooks:
       - id: cargo-clippy
         name: cargo clippy
-        entry: cargo clippy --all-targets -- -D warnings -A clippy::nursery
+        # connectors-all so feature-gated connector code is linted too —
+        # a plain clippy run would silently skip it.
+        entry: cargo clippy --all-targets --features connectors-all -- -D warnings -A clippy::nursery
         language: system
         types: [rust]
         pass_filenames: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,17 +48,23 @@ One PR = one thing. Bug fix, refactor, feature — separate PRs. Mixed PRs will 
 
 ### Quality Checks
 
-All checks must pass before submitting:
+All checks must pass before submitting. Connector code is feature-gated, so
+lint/test commands use `--features connectors-all` — without it, gated code is
+silently skipped:
 
 ```bash
 cargo fmt --all -- --check
-cargo clippy --all-targets -- -D warnings -A clippy::nursery
+cargo clippy --all-targets --features connectors-all -- -D warnings -A clippy::nursery
 typos
 cargo machete
 cargo sort --workspace --check
 taplo fmt --check
-cargo nextest run        # or: cargo test
-cargo test --doc
+cargo nextest run --features connectors-all        # or: cargo test --features connectors-all
+cargo nextest run                                  # minimal build tests (no connectors)
+cargo test --doc --features connectors-all
+cargo check --all-targets                          # minimal baseline compiles
+cargo check --all-targets --features rabbitmq      # each connector alone
+cargo check --all-targets --features websocket
 ```
 
 Or run everything at once with [just](https://github.com/casey/just):

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1275,7 +1275,6 @@ dependencies = [
  "tonic 0.11.0",
  "tonic-build 0.11.0",
  "tower",
- "tungstenite",
  "urlencoding",
  "uuid",
  "vault",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,15 @@ etcd = ["etcd-rs"]
 vault = ["dep:vault"]
 cloud-native = ["kubernetes", "consul", "etcd", "vault"]
 
+# Connectors — one cargo feature per connector, named exactly after the SQL
+# extension name (WITH extension = '...'). The default set is fully minimal:
+# no connector ships in a plain `cargo build`. Release/Docker builds use
+# `--features connectors-all`. See docs/writing_extensions.md for the
+# per-connector gating checklist.
+rabbitmq = ["dep:lapin", "dep:urlencoding"]
+websocket = ["dep:tokio-tungstenite"]
+connectors-all = ["rabbitmq", "websocket"]
+
 [dependencies]
 async-trait = "0.1"
 base64 = { version = "0.22", optional = true }
@@ -47,7 +56,7 @@ etcd-rs = { version = "1.0", optional = true }
 futures = "0.3"
 k8s-openapi = { version = "0.20", features = ["v1_28"], optional = true }
 kube = { version = "0.87", features = ["runtime", "derive"], optional = true }
-lapin = "2.3"
+lapin = { version = "2.3", optional = true }
 libloading = "0.8"
 log = "0.4"
 lz4 = "1.24"
@@ -71,12 +80,11 @@ thiserror = "2.0"
 thread_local = "1.1"
 tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1"
-tokio-tungstenite = { version = "0.24", features = ["native-tls"] }
+tokio-tungstenite = { version = "0.24", features = ["native-tls"], optional = true }
 toml = "0.8"
 tonic = { version = "0.11", features = ["tls"] }
 tower = "0.4"
-tungstenite = "0.24"
-urlencoding = "2.1"
+urlencoding = { version = "2.1", optional = true }
 uuid = { version = "1", features = ["v4"] }
 vault = { version = "10.1", optional = true }
 zstd = "0.13"

--- a/DEV_GUIDE.md
+++ b/DEV_GUIDE.md
@@ -76,11 +76,14 @@ git commit -m "Update vendored sqlparser submodule"
 ### Build Commands
 
 ```bash
-# Development build
+# Development build (minimal — no external connectors)
 cargo build
 
-# Release build
-cargo build --release
+# Development build with all connectors (RabbitMQ, WebSocket, ...)
+cargo build --features connectors-all
+
+# Release build (shipped artifacts include all connectors)
+cargo build --release --features connectors-all
 
 # Check for compilation errors
 cargo check
@@ -88,9 +91,15 @@ cargo check
 # Format code
 cargo fmt
 
-# Run linter
-cargo clippy --all-targets -- -D warnings -A clippy::nursery
+# Run linter (CI runs this with connectors enabled)
+cargo clippy --all-targets --features connectors-all -- -D warnings -A clippy::nursery
 ```
+
+Connectors are cargo features named after their SQL extension name
+(`rabbitmq`, `websocket`, ...; umbrella: `connectors-all`). The default build
+is fully minimal. See the feature-flags table in [README.md](README.md) and
+the gating checklist in
+[docs/writing_extensions.md](docs/writing_extensions.md).
 
 ---
 
@@ -150,18 +159,24 @@ eventflux run app.sql --config config-prod.toml
 
 ### Running Tests
 
+Connector tests only compile with their feature enabled — run the full suite
+with `--features connectors-all` so nothing is silently skipped:
+
 ```bash
-# Run all tests
+# Run all tests (including connector code)
+cargo test --features connectors-all
+
+# Minimal-build tests (no connectors — guards the lightweight baseline)
 cargo test
 
 # Run with output visible
-cargo test -- --nocapture
+cargo test --features connectors-all -- --nocapture
 
 # Run specific test
-cargo test test_name
+cargo test --features connectors-all test_name
 
 # Run tests matching pattern
-cargo test pattern
+cargo test --features connectors-all pattern
 ```
 
 ### Performance Tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,7 +65,8 @@ RUN mkdir -p src/bin && \
     echo "pub fn lib() {}" > src/lib.rs
 
 # Build dependencies only (cached layer)
-RUN cargo build --release --locked --bin run_eventflux
+# Shipped images include every connector (connectors-all)
+RUN cargo build --release --locked --features connectors-all --bin run_eventflux
 
 # Remove dummy files
 RUN rm -rf src
@@ -79,7 +80,7 @@ COPY src/ src/
 RUN find src -type f -exec touch {} +
 
 # Build release binary with optimizations
-RUN cargo build --release --locked --bin run_eventflux && \
+RUN cargo build --release --locked --features connectors-all --bin run_eventflux && \
     strip /build/target/release/run_eventflux
 
 # Verify binary

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ docker run -v ./app.sql:/app.sql ghcr.io/eventflux-io/eventflux /app.sql
 # Or build from source (--recursive pulls in the vendored SQL parser submodule)
 git clone --recursive https://github.com/eventflux-io/eventflux.git
 cd eventflux
-cargo build --release
+cargo build --release --features connectors-all
 ./target/release/run_eventflux app.sql
 ```
 
@@ -38,6 +38,26 @@ Already cloned without `--recursive`? Fetch the submodule before building:
 
 ```bash
 git submodule update --init --recursive
+```
+
+### Connector feature flags
+
+The default build is fully minimal — core engine plus the built-in `timer`
+source and `log` sink, no external connectors. Each connector is a cargo
+feature named after its SQL extension name:
+
+| Feature | Connector | In default build? |
+|---------|-----------|-------------------|
+| `rabbitmq` | RabbitMQ source + sink | No |
+| `websocket` | WebSocket source + sink | No |
+| `connectors-all` | All of the above | No |
+
+Docker images are built with `connectors-all`, so they include everything.
+Building from source, pick what you need:
+
+```bash
+cargo build --release --features rabbitmq          # just RabbitMQ
+cargo build --release --features connectors-all    # everything
 ```
 
 ### Prerequisites (for building)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -159,16 +159,20 @@ All have state holder implementations for checkpointing.
 
 ### M7: Connectors (In Progress - 2026)
 
-| Connector  | Source      | Sink        | Format           |
-|------------|-------------|-------------|------------------|
-| Timer      | Done        | —           | —                |
-| Log        | —           | Done        | —                |
-| RabbitMQ   | Done        | Done        | JSON, CSV, bytes |
-| WebSocket  | Done        | Done        | JSON, CSV, bytes |
-| Kafka      | Not started | Not started | —                |
-| HTTP       | Not started | Not started | —                |
-| File       | Not started | Not started | —                |
-| TCP/Socket | Not started | Not started | —                |
+| Connector  | Source      | Sink        | Format           | Feature flag     |
+|------------|-------------|-------------|------------------|------------------|
+| Timer      | Done        | —           | —                | (always built)   |
+| Log        | —           | Done        | —                | (always built)   |
+| RabbitMQ   | Done        | Done        | JSON, CSV, bytes | `rabbitmq`       |
+| WebSocket  | Done        | Done        | JSON, CSV, bytes | `websocket`      |
+| Kafka      | Not started | Not started | —                | `kafka` (planned)|
+| HTTP       | Not started | Not started | —                | —                |
+| File       | Not started | Not started | —                | —                |
+| TCP/Socket | Not started | Not started | —                | —                |
+
+Connectors are cargo features named after the SQL extension name; the default
+build is minimal and `connectors-all` enables everything (release/Docker
+builds use it).
 
 **Data mapping layer**: JSON, CSV, and bytes source/sink mappers registered.
 

--- a/docs/writing_extensions.md
+++ b/docs/writing_extensions.md
@@ -133,6 +133,26 @@ blocking I/O (as the RabbitMQ and WebSocket sources do), and
 between iterations (as TimerSource does), so long intervals never delay
 shutdown.
 
+## Connector Feature Gating
+
+Every in-tree connector is gated behind a cargo feature **named exactly after
+its registered extension name** (the string used in SQL
+`WITH (extension = '...')`). The default build is fully minimal — no
+connectors — and release/Docker builds use `--features connectors-all`.
+
+When adding a new in-tree connector, touch exactly these points:
+
+| Point | Mechanism |
+|-------|-----------|
+| Dependency | `optional = true` in `[dependencies]`, `dep:` in the feature |
+| Feature | `[features]` entry named after the extension; add it to `connectors-all` |
+| Module declaration | `#[cfg(feature = "x")] pub mod x_source;` in `source/mod.rs` (same for the sink) |
+| Registration | `#[cfg(feature = "x")]` on the import and `add_source_factory`/`add_sink_factory` lines in `register_default_extensions()` |
+| Unavailable-extension hint | add the name to `GATED_OUT_EXTENSIONS` in `stream_initializer.rs` so builds without the feature report "rebuild with `--features x`" instead of "extension not found" |
+| Integration tests | `#![cfg(feature = "x")]` at the top of `tests/x_integration.rs` |
+| CI | add `cargo check --features x` to the per-connector gating check in `.github/workflows/rust.yml` |
+| Docs | feature-flags table in README.md; example files note the required feature |
+
 ## Dynamic Extensions
 
 Extensions can also be distributed as separate crates compiled into dynamic

--- a/examples/rabbitmq.eventflux
+++ b/examples/rabbitmq.eventflux
@@ -11,6 +11,11 @@
 -- PREREQUISITES
 -- ============================================================================
 --
+-- 0. Build EventFlux with the RabbitMQ connector enabled:
+--
+--    cargo build --release --features rabbitmq
+--    (Docker images include all connectors already)
+--
 -- 1. Start RabbitMQ with Docker:
 --
 --    docker run -d --name rabbitmq \

--- a/examples/rabbitmq_to_log.eventflux
+++ b/examples/rabbitmq_to_log.eventflux
@@ -9,6 +9,11 @@
 -- PREREQUISITES
 -- ============================================================================
 --
+-- 0. Build EventFlux with the RabbitMQ connector enabled:
+--
+--    cargo build --release --features rabbitmq
+--    (Docker images include all connectors already)
+--
 -- 1. Start RabbitMQ with Docker:
 --
 --    docker run -d --name rabbitmq \

--- a/justfile
+++ b/justfile
@@ -2,29 +2,39 @@ alias b  := build
 alias t  := test
 alias n  := nextest
 
+# Connector code is feature-gated (rabbitmq, websocket, ...); dev commands
+# default to connectors-all so nothing is silently left unbuilt/untested.
+# `check-minimal` guards the minimal (no-connector) baseline.
+
 build:
-  cargo build
+  cargo build --features connectors-all
 
 test: build
-  cargo test
+  cargo test --features connectors-all
 
 # Run a specific test by name
 tests TEST: build
-  cargo test {{TEST}}
+  cargo test --features connectors-all {{TEST}}
 
 nextest: build
-  cargo nextest run
+  cargo nextest run --features connectors-all
 
 # Run with output visible
 nextests TEST: build
-  cargo nextest run --nocapture -- {{TEST}}
+  cargo nextest run --features connectors-all --nocapture -- {{TEST}}
 
 server *ARGS:
-  cargo run --bin run_eventflux {{ARGS}}
+  cargo run --features connectors-all --bin run_eventflux {{ARGS}}
 
 # Code quality
 lint:
-  cargo clippy --all-targets -- -D warnings -A clippy::nursery
+  cargo clippy --all-targets --features connectors-all -- -D warnings -A clippy::nursery
+
+# Feature-gating honesty: minimal build and each connector alone must compile
+check-minimal:
+  cargo check --all-targets
+  cargo check --all-targets --features rabbitmq
+  cargo check --all-targets --features websocket
 
 fmt:
   cargo fmt --all
@@ -54,7 +64,7 @@ coverage:
   cargo llvm-cov --all-features --lcov --output-path lcov.info
 
 # All quality checks (run before PR)
-check-all: fmt sort taplo lint
+check-all: fmt sort taplo lint check-minimal
   cargo machete
   typos
 

--- a/src/core/config/eventflux_context.rs
+++ b/src/core/config/eventflux_context.rs
@@ -426,9 +426,13 @@ impl EventFluxContext {
             OrAttributeAggregatorFactory, StdDevAttributeAggregatorFactory,
             SumAttributeAggregatorFactory,
         };
+        #[cfg(feature = "rabbitmq")]
         use crate::core::stream::input::source::rabbitmq_source::RabbitMQSourceFactory;
+        #[cfg(feature = "websocket")]
         use crate::core::stream::input::source::websocket_source::WebSocketSourceFactory;
+        #[cfg(feature = "rabbitmq")]
         use crate::core::stream::output::sink::rabbitmq_sink::RabbitMQSinkFactory;
+        #[cfg(feature = "websocket")]
         use crate::core::stream::output::sink::websocket_sink::WebSocketSinkFactory;
         use crate::core::table::{CacheTableFactory, InMemoryTableFactory, JdbcTableFactory};
 
@@ -524,10 +528,14 @@ impl EventFluxContext {
         self.add_table_factory("jdbc".to_string(), Box::new(JdbcTableFactory));
         self.add_table_factory("cache".to_string(), Box::new(CacheTableFactory));
         self.add_source_factory("timer".to_string(), Box::new(TimerSourceFactory));
+        #[cfg(feature = "rabbitmq")]
         self.add_source_factory("rabbitmq".to_string(), Box::new(RabbitMQSourceFactory));
+        #[cfg(feature = "websocket")]
         self.add_source_factory("websocket".to_string(), Box::new(WebSocketSourceFactory));
         self.add_sink_factory("log".to_string(), Box::new(LogSinkFactory));
+        #[cfg(feature = "rabbitmq")]
         self.add_sink_factory("rabbitmq".to_string(), Box::new(RabbitMQSinkFactory));
+        #[cfg(feature = "websocket")]
         self.add_sink_factory("websocket".to_string(), Box::new(WebSocketSinkFactory));
 
         // Mapper factories for format = 'json' / 'csv' / 'bytes'

--- a/src/core/stream/input/source/mod.rs
+++ b/src/core/stream/input/source/mod.rs
@@ -15,8 +15,10 @@
  * limitations under the License.
  */
 
+#[cfg(feature = "rabbitmq")]
 pub mod rabbitmq_source;
 pub mod timer_source;
+#[cfg(feature = "websocket")]
 pub mod websocket_source;
 
 use crate::core::exception::EventFluxError;

--- a/src/core/stream/output/sink/mod.rs
+++ b/src/core/stream/output/sink/mod.rs
@@ -16,9 +16,11 @@
  */
 
 pub mod log_sink;
+#[cfg(feature = "rabbitmq")]
 pub mod rabbitmq_sink;
 pub mod sink_factory;
 pub mod sink_trait;
+#[cfg(feature = "websocket")]
 pub mod websocket_sink;
 
 use crate::core::event::event::Event;

--- a/src/core/stream/stream_initializer.rs
+++ b/src/core/stream/stream_initializer.rs
@@ -185,6 +185,31 @@ pub fn initialize_stream(
     }
 }
 
+/// Connectors that exist in the codebase but were excluded from this build
+/// by cargo features. The feature is always named after the extension (see
+/// the `[features]` section in Cargo.toml), so one entry per gated connector.
+const GATED_OUT_EXTENSIONS: &[&str] = &[
+    #[cfg(not(feature = "rabbitmq"))]
+    "rabbitmq",
+    #[cfg(not(feature = "websocket"))]
+    "websocket",
+];
+
+/// Error for a failed connector factory lookup.
+///
+/// If the extension is known but compiled out, the error tells the user how
+/// to rebuild instead of reporting a bare "extension not found".
+fn connector_lookup_error(kind: &str, extension: &str) -> EventFluxError {
+    if GATED_OUT_EXTENSIONS.contains(&extension) {
+        EventFluxError::configuration(format!(
+            "Extension '{extension}' is supported by EventFlux but was not included in this \
+             build. Rebuild with `--features {extension}` (or `--features connectors-all`)."
+        ))
+    } else {
+        EventFluxError::extension_not_found(kind, extension)
+    }
+}
+
 /// Initialize a source stream with factory lookup and validation
 fn initialize_source_stream(
     context: &EventFluxContext,
@@ -197,7 +222,7 @@ fn initialize_source_stream(
 
     let source_factory = context
         .get_source_factory(extension)
-        .ok_or_else(|| EventFluxError::extension_not_found("source", extension))?;
+        .ok_or_else(|| connector_lookup_error("source", extension))?;
 
     // 2. Validate format support (if format is specified)
     let mapper_factory = if let Some(format) = stream_config.format() {
@@ -304,7 +329,7 @@ fn initialize_sink_stream_internal(
 
     let sink_factory = context
         .get_sink_factory(extension)
-        .ok_or_else(|| EventFluxError::extension_not_found("sink", extension))?;
+        .ok_or_else(|| connector_lookup_error("sink", extension))?;
 
     // 2. Validate format support (if format is specified)
     let mapper_factory = if let Some(format) = stream_config.format() {
@@ -995,6 +1020,27 @@ mod tests {
     use crate::core::config::stream_config::{FlatConfig, PropertySource};
     use crate::core::extension::example_factories::{HttpSinkFactory, KafkaSourceFactory};
     use crate::core::extension::{CsvSinkMapperFactory, JsonSourceMapperFactory};
+
+    #[test]
+    fn test_connector_lookup_error_unknown_extension() {
+        // Names not in the gated-out table keep the plain not-found error
+        let err = connector_lookup_error("source", "no-such-connector");
+        let msg = err.to_string();
+        assert!(msg.contains("no-such-connector"), "got: {msg}");
+        assert!(!msg.contains("--features"), "got: {msg}");
+    }
+
+    // Only meaningful in builds where the connector is compiled out
+    // (the default minimal build) — with the feature on, the extension is
+    // registered and the lookup never fails.
+    #[cfg(not(feature = "rabbitmq"))]
+    #[test]
+    fn test_connector_lookup_error_gated_out_extension_hints_feature() {
+        let err = connector_lookup_error("source", "rabbitmq");
+        let msg = err.to_string();
+        assert!(msg.contains("--features rabbitmq"), "got: {msg}");
+        assert!(msg.contains("connectors-all"), "got: {msg}");
+    }
 
     #[test]
     fn test_initialize_source_stream_success() {

--- a/tests/rabbitmq_integration.rs
+++ b/tests/rabbitmq_integration.rs
@@ -17,8 +17,10 @@
 
 //! # RabbitMQ Integration Tests
 //!
+//! Requires building with the `rabbitmq` feature:
+//! `cargo test --features rabbitmq --test rabbitmq_integration -- --ignored`
+//!
 //! These tests require a running RabbitMQ broker and are marked with `#[ignore]`.
-//! Run with: `cargo test --test rabbitmq_integration -- --ignored`
 //!
 //! ## Setup
 //!
@@ -26,6 +28,8 @@
 //! ```bash
 //! docker run -d --name rabbitmq -p 5672:5672 -p 15672:15672 rabbitmq:3-management
 //! ```
+
+#![cfg(feature = "rabbitmq")]
 
 #[path = "common/mod.rs"]
 mod common;

--- a/website/docs/connectors/mappers.md
+++ b/website/docs/connectors/mappers.md
@@ -18,6 +18,14 @@ EventFlux provides three built-in mappers:
 | **CSV** | `format = 'csv'` | Yes | Yes | Log files, data exports |
 | **Bytes** | `format = 'bytes'` | Yes | Yes | Binary protocols (protobuf, msgpack), raw passthrough |
 
+### Sink mapping contract: one event = one message
+
+On the sink side, each event is mapped to its **own payload** and published as
+its **own transport message**. Even when a query emits several events at once
+(e.g. a batch window flush), the sink publishes one message per event — no
+events are ever merged into or dropped from a message. A mapping failure for
+one event is logged and does not affect the remaining events.
+
 ## JSON Mapper
 
 The JSON mapper is the most common choice for message queue integration. It handles automatic type conversion between JSON and EventFlux types.
@@ -271,7 +279,10 @@ CREATE STREAM RawMessages (
 
 ### Sink Mapper (Events → Bytes)
 
-The bytes sink mapper extracts raw bytes from the specified field and outputs them unchanged. **Only single-event batches are supported**—an error is returned if multiple events are received since binary data cannot be safely concatenated with separators:
+The bytes sink mapper extracts raw bytes from the specified field and outputs
+them unchanged. Because every event maps to its own message (see the
+[sink mapping contract](#sink-mapping-contract-one-event--one-message)),
+binary payloads are never concatenated:
 
 **Event Data:**
 ```

--- a/website/docs/connectors/overview.md
+++ b/website/docs/connectors/overview.md
@@ -45,10 +45,13 @@ The connector system consists of three main components:
 
 **Sinks** publish processed events to external systems. They handle:
 
-- Connection pooling
+- Connection management
 - Delivery guarantees
-- Batching and buffering
 - Format serialization via mappers
+
+**One event = one message**: each event is serialized and published as its own
+transport message (AMQP message, WebSocket frame, ...). A failure to serialize
+or publish one event never drops the other events in the same batch.
 
 ### Mappers
 
@@ -91,15 +94,39 @@ CREATE STREAM StreamName (
 );
 ```
 
+## Building with Connectors
+
+Connectors are **opt-in cargo features**, named exactly after their SQL
+extension name. The default build is fully minimal (core engine plus the
+built-in `timer` source and `log` sink):
+
+```bash
+cargo build --release --features rabbitmq          # just RabbitMQ
+cargo build --release --features websocket         # just WebSocket
+cargo build --release --features connectors-all    # everything
+```
+
+Docker images are built with `connectors-all` and include every connector.
+
+If a query references a connector that wasn't compiled in, EventFlux fails
+fast with an actionable error:
+
+```
+Extension 'rabbitmq' is supported by EventFlux but was not included in this
+build. Rebuild with `--features rabbitmq` (or `--features connectors-all`).
+```
+
 ## Available Connectors
 
-| Connector | Source | Sink | Status | Description |
-|-----------|--------|------|--------|-------------|
-| **RabbitMQ** | Yes | Yes | Production Ready | AMQP 0-9-1 message broker |
-| **WebSocket** | Yes | Yes | Production Ready | Real-time bidirectional streaming |
-| **Kafka** | Planned | Planned | Roadmap | Apache Kafka streaming |
-| **HTTP** | Planned | Planned | Roadmap | REST/Webhook endpoints |
-| **File** | Planned | Planned | Roadmap | File-based input/output |
+| Connector | Source | Sink | Feature flag | Status | Description |
+|-----------|--------|------|--------------|--------|-------------|
+| **Timer** | Yes | — | (always built) | Production Ready | Periodic tick source |
+| **Log** | — | Yes | (always built) | Production Ready | Logging sink for debugging |
+| **RabbitMQ** | Yes | Yes | `rabbitmq` | Production Ready | AMQP 0-9-1 message broker |
+| **WebSocket** | Yes | Yes | `websocket` | Production Ready | Real-time bidirectional streaming |
+| **Kafka** | Planned | Planned | `kafka` (planned) | Roadmap | Apache Kafka streaming |
+| **HTTP** | Planned | Planned | — | Roadmap | REST/Webhook endpoints |
+| **File** | Planned | Planned | — | Roadmap | File-based input/output |
 
 ## Available Mappers
 

--- a/website/docs/connectors/rabbitmq.md
+++ b/website/docs/connectors/rabbitmq.md
@@ -10,6 +10,16 @@ The RabbitMQ connector enables EventFlux to consume events from RabbitMQ queues 
 
 ## Prerequisites
 
+### Building with RabbitMQ Support
+
+The RabbitMQ connector is feature-gated. Build EventFlux with the `rabbitmq`
+feature (Docker images already include all connectors):
+
+```bash
+cargo build --release --features rabbitmq
+# or: cargo build --release --features connectors-all
+```
+
 ### Starting RabbitMQ
 
 The easiest way to run RabbitMQ is with Docker:
@@ -277,7 +287,7 @@ WHERE volume > 1000;
 
 3. **Run EventFlux:**
    ```bash
-   cargo run --bin run_eventflux your_query.eventflux
+   cargo run --features rabbitmq --bin run_eventflux your_query.eventflux
    ```
 
 4. **Publish test messages** via Management UI:

--- a/website/docs/connectors/websocket.md
+++ b/website/docs/connectors/websocket.md
@@ -16,6 +16,16 @@ WebSocket is ideal for:
 - **Bidirectional communication**: Chat applications, collaborative tools
 - **Low-latency messaging**: Gaming, trading systems
 
+## Prerequisites
+
+The WebSocket connector is feature-gated. Build EventFlux with the
+`websocket` feature (Docker images already include all connectors):
+
+```bash
+cargo build --release --features websocket
+# or: cargo build --release --features connectors-all
+```
+
 ## WebSocket Source
 
 The WebSocket source connects to a WebSocket endpoint and consumes incoming messages as events for processing.

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -25,23 +25,54 @@ cargo --version
 
 ## From Source
 
-Clone and build the repository:
+Clone and build the repository (`--recursive` pulls in the vendored SQL parser submodule):
 
 ```bash
-git clone https://github.com/eventflux-io/eventflux.git
+git clone --recursive https://github.com/eventflux-io/eventflux.git
 cd eventflux
-cargo build --release
+cargo build --release --features connectors-all
 ```
+
+### Connector Feature Flags
+
+The default build is **fully minimal** — the core engine plus the built-in
+`timer` source and `log` sink, with no external connectors. Each connector is
+a cargo feature named exactly after its SQL extension name:
+
+| Feature | Connector | In default build? |
+|---------|-----------|-------------------|
+| `rabbitmq` | RabbitMQ source + sink | No |
+| `websocket` | WebSocket source + sink | No |
+| `connectors-all` | All connectors | No |
+
+```bash
+cargo build --release                             # minimal: core engine only
+cargo build --release --features rabbitmq         # just RabbitMQ
+cargo build --release --features connectors-all   # everything
+```
+
+Docker images (`ghcr.io/eventflux-io/eventflux`) are built with
+`connectors-all`, so they include every connector out of the box.
+
+:::tip Helpful errors
+If a query references a connector that wasn't compiled in, EventFlux tells
+you exactly how to fix it:
+
+```
+Extension 'rabbitmq' is supported by EventFlux but was not included in this
+build. Rebuild with `--features rabbitmq` (or `--features connectors-all`).
+```
+:::
 
 ### Running Tests
 
 Verify your installation by running the test suite:
 
 ```bash
-cargo test
+cargo test --features connectors-all
 ```
 
-You should see **1,400+ passing tests**.
+You should see **3,000+ passing tests**.
 
 ### Build Artifacts
 
@@ -51,18 +82,19 @@ After building, you'll find:
 
 ## As a Dependency
 
-Add EventFlux to your `Cargo.toml`:
+Add EventFlux to your `Cargo.toml`. Enable the connector features your
+application needs (none are enabled by default):
 
 ```toml
 [dependencies]
-eventflux = { git = "https://github.com/eventflux-io/eventflux.git" }
+eventflux = { git = "https://github.com/eventflux-io/eventflux.git", features = ["connectors-all"] }
 ```
 
-Or with a specific revision:
+Or with a specific revision and only the connectors you use:
 
 ```toml
 [dependencies]
-eventflux = { git = "https://github.com/eventflux-io/eventflux.git", rev = "main" }
+eventflux = { git = "https://github.com/eventflux-io/eventflux.git", rev = "main", features = ["rabbitmq"] }
 ```
 
 ## Project Structure
@@ -107,15 +139,15 @@ Run it:
 cargo run
 ```
 
-## Optional Dependencies
+## Optional Features
 
-For specific features, you may need additional dependencies:
+Beyond connectors, EventFlux exposes additional opt-in cargo features:
 
-| Feature | Dependency | Purpose |
-|---------|------------|---------|
-| Redis State | `redis` | Distributed state backend |
-| Async Runtime | `tokio` | Async event processing |
-| Serialization | `serde` | Event serialization |
+| Feature | Purpose |
+|---------|---------|
+| `rabbitmq`, `websocket`, `connectors-all` | External connectors (see table above) |
+| `kubernetes`, `consul`, `etcd`, `vault`, `cloud-native` | Cloud-native integrations for distributed deployments |
+| `perf-tests` | Performance test suite |
 
 ## Troubleshooting
 

--- a/website/docs/getting-started/running.md
+++ b/website/docs/getting-started/running.md
@@ -15,6 +15,13 @@ Before running EventFlux applications, ensure you have:
 1. **Rust toolchain** (1.85+): Install from [rustup.rs](https://rustup.rs/)
 2. **RabbitMQ** (for connector examples): See [RabbitMQ setup](#rabbitmq-setup)
 
+:::info Connector feature flags
+Connectors are opt-in cargo features (the default build is minimal). Any
+command that runs a query using a connector needs the matching feature, e.g.
+`--features rabbitmq` or `--features connectors-all`. See
+[Installation → Connector Feature Flags](/docs/getting-started/installation#connector-feature-flags).
+:::
+
 ## Method 1: Command Line Interface (CLI)
 
 The simplest way to run EventFlux is using the built-in CLI binary.
@@ -22,11 +29,11 @@ The simplest way to run EventFlux is using the built-in CLI binary.
 ### Basic Usage
 
 ```bash
-# Run a query file
+# Run a query file (no connectors needed)
 cargo run --bin run_eventflux <path-to-query-file>
 
-# Example with the RabbitMQ to Log example
-cargo run --bin run_eventflux examples/rabbitmq_to_log.eventflux
+# Example with the RabbitMQ to Log example (needs the rabbitmq feature)
+cargo run --features rabbitmq --bin run_eventflux examples/rabbitmq_to_log.eventflux
 ```
 
 ### CLI Options
@@ -49,21 +56,21 @@ cargo run --bin run_eventflux -- --help
 cargo run --bin run_eventflux examples/simple_filter.eventflux
 
 # With file-based persistence (using --set)
-cargo run --bin run_eventflux examples/rabbitmq.eventflux \
+cargo run --features rabbitmq --bin run_eventflux examples/rabbitmq.eventflux \
   --set eventflux.persistence.type=file \
   --set eventflux.persistence.path=./snapshots
 
 # With SQLite persistence (using --set)
-cargo run --bin run_eventflux examples/rabbitmq.eventflux \
+cargo run --features rabbitmq --bin run_eventflux examples/rabbitmq.eventflux \
   --set eventflux.persistence.type=sqlite \
   --set eventflux.persistence.path=./eventflux.db
 
 # With custom configuration file
-cargo run --bin run_eventflux examples/rabbitmq.eventflux \
+cargo run --features rabbitmq --bin run_eventflux examples/rabbitmq.eventflux \
   --config ./config/eventflux.yaml
 
 # Combine config file with overrides
-cargo run --bin run_eventflux examples/rabbitmq.eventflux \
+cargo run --features rabbitmq --bin run_eventflux examples/rabbitmq.eventflux \
   --config ./config/base.yaml \
   --set eventflux.runtime.performance.thread_pool_size=16
 
@@ -98,8 +105,8 @@ The `--set` flag supports dot-notation paths to override any configuration value
 ### Release Build (Recommended for Production)
 
 ```bash
-# Build release binary
-cargo build --release
+# Build release binary (include the connectors your queries use)
+cargo build --release --features connectors-all
 
 # Run with release binary
 ./target/release/run_eventflux examples/rabbitmq_to_log.eventflux
@@ -558,8 +565,8 @@ sleep 30
 # Management UI: http://localhost:15672 (guest/guest)
 # Create queue named: event-queue
 
-# 4. Run EventFlux
-cargo run --bin run_eventflux examples/rabbitmq_to_log.eventflux
+# 4. Run EventFlux (rabbitmq connector is feature-gated)
+cargo run --features rabbitmq --bin run_eventflux examples/rabbitmq_to_log.eventflux
 
 # 5. In another terminal, publish a test message via Management UI
 # or use the rabbitmqadmin CLI:

--- a/website/docs/rust-api/custom-connectors.md
+++ b/website/docs/rust-api/custom-connectors.md
@@ -1,0 +1,191 @@
+---
+sidebar_position: 4
+title: Custom Connectors
+description: Write your own sources and sinks for EventFlux
+---
+
+# Custom Connectors
+
+EventFlux connectors are ordinary Rust types implementing the `Source` and
+`Sink` traits, registered through factories. This page covers the contracts a
+connector must honor and the helpers that make them easy to honor.
+
+The in-tree RabbitMQ connector
+(`src/core/stream/input/source/rabbitmq_source.rs` and
+`src/core/stream/output/sink/rabbitmq_sink.rs`) is a complete reference
+implementation of everything below.
+
+## Architecture
+
+```
+Source:  external system → bytes → SourceCallback → SourceMapper → Events → pipeline
+Sink:    pipeline → Events → per event: SinkMapper → bytes → Sink::publish() → external system
+```
+
+Connectors deal only in **bytes** — parsing and serialization are the mappers'
+job. This keeps transports and formats independently pluggable.
+
+## Writing a Source
+
+A source implements the `Source` trait:
+
+```rust
+pub trait Source: Debug + Send + Sync {
+    fn start(&mut self, callback: Arc<dyn SourceCallback>);
+    fn stop(&mut self);
+    fn clone_box(&self) -> Box<dyn Source>;
+    fn validate_connectivity(&self) -> Result<(), EventFluxError> { Ok(()) }
+    fn set_error_dlq_junction(&mut self, junction: Arc<Mutex<InputHandler>>) {}
+}
+```
+
+### The stop() contract — use SourceWorker
+
+`stop()` must be **synchronous**: when it returns, the worker thread has
+terminated and no callback can fire afterwards. Repeated calls must be no-ops.
+
+Don't hand-roll this with an `AtomicBool` and a discarded thread handle —
+embed a `SourceWorker`, which captures the lifecycle once:
+
+```rust
+use eventflux::core::stream::input::source::{Source, SourceCallback, SourceWorker};
+
+pub struct MySource {
+    config: MyConfig,
+    worker: SourceWorker,
+}
+
+impl MySource {
+    pub fn new(config: MyConfig) -> Self {
+        Self { config, worker: SourceWorker::new("MySource") }
+    }
+}
+
+impl Source for MySource {
+    fn start(&mut self, callback: Arc<dyn SourceCallback>) {
+        let config = self.config.clone();
+        self.worker.start(move |running| {
+            while running.load(Ordering::SeqCst) {
+                // read from the external system, then:
+                //     callback.on_data(&bytes)?
+                // Poll `running` at least every ~100ms so stop() is fast.
+            }
+        });
+    }
+
+    fn stop(&mut self) {
+        self.worker.stop(); // signals the flag + joins the thread (bounded)
+    }
+
+    fn clone_box(&self) -> Box<dyn Source> {
+        Box::new(Self {
+            config: self.config.clone(),
+            worker: self.worker.clone(), // clones as a fresh, unstarted worker
+        })
+    }
+}
+```
+
+`SourceWorker` guarantees:
+
+- **`stop()` joins the worker**, bounded by a 5s grace period
+  (`SOURCE_STOP_GRACE_PERIOD`) — a worker stuck in slow I/O is detached with a
+  warning instead of hanging shutdown
+- **Idempotent** — safe without `start()`, safe to call twice
+- **Drop-safe (RAII)** — a source dropped without being stopped still shuts
+  its worker down
+- **Clone-safe** — a clone starts unstarted; runtime state never leaks
+
+Your only obligation is inside the loop: **poll the `running` flag at least
+every ~100ms**. Use a poll/read timeout around blocking I/O, and
+`sleep_while_running(&running, interval)` instead of `thread::sleep` for waits
+between iterations, so long intervals never delay shutdown.
+
+The runtime stops all sources **in parallel** during application shutdown, so
+a correct `stop()` is all you need — total shutdown stays bounded by one grace
+period regardless of how many sources an app runs.
+
+### validate_connectivity()
+
+Called at application startup (fail-fast): verify the external system is
+reachable and configured resources exist, with a bounded timeout. If it
+returns an error, the application does not start.
+
+## Writing a Sink
+
+```rust
+pub trait Sink: Debug + Send + Sync {
+    fn publish(&self, payload: &[u8]) -> Result<(), EventFluxError>;
+    fn start(&self) {}
+    fn stop(&self) {}
+    fn clone_box(&self) -> Box<dyn Sink>;
+    fn validate_connectivity(&self) -> Result<(), EventFluxError> { Ok(()) }
+}
+```
+
+`publish()` receives **one pre-formatted payload per event** — the runtime
+maps each event through the sink mapper and calls `publish()` once per event
+(one event = one transport message). A sink that wants transport-level
+batching (e.g. batched HTTP POSTs) should buffer internally and flush in
+`stop()`.
+
+## Factories and Registration
+
+Factories carry the metadata the SQL layer validates against — supported
+formats, required and optional parameters — and build fully-initialized
+instances from the `WITH` clause properties:
+
+```rust
+impl SourceFactory for MySourceFactory {
+    fn name(&self) -> &'static str { "mysource" }        // WITH (extension = 'mysource')
+    fn supported_formats(&self) -> &[&str] { &["json", "csv", "bytes"] }
+    fn required_parameters(&self) -> &[&str] { &["mysource.host"] }
+    fn optional_parameters(&self) -> &[&str] { &["mysource.port"] }
+    fn create_initialized(
+        &self,
+        config: &HashMap<String, String>,
+    ) -> Result<Box<dyn Source>, EventFluxError> { /* parse + validate */ }
+    fn clone_box(&self) -> Box<dyn SourceFactory> { Box::new(self.clone()) }
+}
+```
+
+Register with the manager, and the connector becomes usable from SQL:
+
+```rust
+manager.context().add_source_factory("mysource".to_string(), Box::new(MySourceFactory));
+```
+
+```sql
+CREATE STREAM Input (value INT) WITH (
+    type = 'source',
+    extension = 'mysource',
+    format = 'json',
+    "mysource.host" = 'localhost'
+);
+```
+
+## Error Handling Integration
+
+Sources can integrate with EventFlux's error handling strategies
+(`error.strategy` = `drop` / `retry` / `dlq` / `fail`) via
+`SourceErrorContext`. The pattern — retry loop around `callback.on_data`,
+acknowledge only after success, DLQ fallback events from raw bytes — is shown
+end-to-end in the RabbitMQ source.
+
+## Contributing a Connector Upstream
+
+In-tree connectors are gated behind a cargo feature named after the extension
+(the default build is minimal; `connectors-all` enables everything). The
+complete per-connector gating checklist — dependency, feature, `#[cfg]`
+points, registration, the unavailable-extension error hint, tests, CI, docs —
+lives in
+[`docs/writing_extensions.md`](https://github.com/eventflux-io/eventflux/blob/main/docs/writing_extensions.md)
+in the repository.
+
+## Dynamic Extensions
+
+Connectors can also ship as separate crates compiled to dynamic libraries and
+loaded at runtime via `manager.set_extension(...)`, exporting registration
+callbacks like `register_sources` / `register_sinks`. See
+[`docs/writing_extensions.md`](https://github.com/eventflux-io/eventflux/blob/main/docs/writing_extensions.md)
+for the callback list and a minimal crate example.

--- a/website/docs/rust-api/getting-started.md
+++ b/website/docs/rust-api/getting-started.md
@@ -10,20 +10,25 @@ This guide shows you how to embed EventFlux in your Rust applications for progra
 
 ## Installation
 
-Add EventFlux to your `Cargo.toml`:
+Add EventFlux to your `Cargo.toml`. Connectors (RabbitMQ, WebSocket, ...) are
+opt-in cargo features — enable the ones your application uses:
 
 ```toml
 [dependencies]
-eventflux = { git = "https://github.com/eventflux-io/eventflux.git" }
+eventflux = { git = "https://github.com/eventflux-io/eventflux.git", features = ["connectors-all"] }
 ```
 
-Or install from source:
+Or install from source (`--recursive` pulls in the vendored SQL parser
+submodule):
 
 ```bash
-git clone https://github.com/eventflux-io/eventflux.git
+git clone --recursive https://github.com/eventflux-io/eventflux.git
 cd eventflux
-cargo build --release
+cargo build --release --features connectors-all
 ```
+
+See [Installation → Connector Feature Flags](/docs/getting-started/installation#connector-feature-flags)
+for the full feature list.
 
 ## Basic Usage
 

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -74,6 +74,7 @@ const sidebars = {
         'rust-api/getting-started',
         'rust-api/configuration',
         'rust-api/testing',
+        'rust-api/custom-connectors',
       ],
     },
   ],


### PR DESCRIPTION
## What

Introduces the generic connector feature-gating framework: every connector is a cargo feature **named exactly after its SQL extension name**, and the default build is fully minimal (core engine + built-in `timer`/`log` only).

```toml
rabbitmq = ["dep:lapin", "dep:urlencoding"]
websocket = ["dep:tokio-tungstenite"]
connectors-all = ["rabbitmq", "websocket"]
```

- `lapin`, `urlencoding`, `tokio-tungstenite` become optional; the unused direct `tungstenite` dependency is removed (only the `tokio_tungstenite::tungstenite` re-export was ever used)
- Module declarations, factory registrations, and `tests/rabbitmq_integration.rs` are `#[cfg]`-gated
- Release/Docker builds use `--features connectors-all`, so shipped artifacts include everything

## Helpful errors instead of bare "not found"

A build without a feature reports how to fix it, via a compile-time `GATED_OUT_EXTENSIONS` table in `stream_initializer`:

> Extension 'rabbitmq' is supported by EventFlux but was not included in this build. Rebuild with `--features rabbitmq` (or `--features connectors-all`).

Unknown names keep the existing extension-not-found error. Covered by tests in both build configurations.

## Nothing is silently skipped

Every check surface now builds with the gates enabled, so gated code cannot slip past lint/tests:

| Surface | Change |
|---|---|
| CI clippy / tests / doctests | `--features connectors-all` |
| CI minimal run | full test suite additionally runs on the minimal build (covers `cfg(not(feature))` code like the hint test) |
| CI gating honesty | `cargo check --all-targets` per connector alone — catches missing `#[cfg]`s and cross-feature leaks |
| pre-push git hook (clippy) | `--features connectors-all` |
| `justfile` | build/test/nextest/lint/server default to `connectors-all`; new `check-minimal` recipe wired into `check-all` |
| CONTRIBUTING.md | quality-check commands updated to match CI |

## Docs

README feature-flags table, DEV_GUIDE build/test commands, a per-connector gating checklist in `docs/writing_extensions.md` (the template Kafka follows next), ROADMAP connector table gains a feature-flag column, and the RabbitMQ example files note the required feature.

## Verification

- All 4 feature combinations compile with `--all-targets` (minimal, rabbitmq, websocket, connectors-all)
- Tests: 3,042 passed / 0 failed (`connectors-all`), 2,978 passed / 0 failed (minimal); doctests pass
- `just check-all` passes end-to-end; clippy clean under CI flags in both configurations

Part 3 (final) of the connector infrastructure work preceding the Kafka connector (Parts 1–2: #115, #116).