### PR TITLE
feat: add Kafka connector

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -84,6 +84,17 @@ jobs:
         ports:
           - 5672:5672
 
+      kafka:
+        # Single-node KRaft broker; default config advertises localhost:9092
+        image: apache/kafka:3.9.1
+        options: >-
+          --health-cmd "/opt/kafka/bin/kafka-broker-api-versions.sh --bootstrap-server localhost:9092"
+          --health-interval 10s
+          --health-timeout 10s
+          --health-retries 10
+        ports:
+          - 9092:9092
+
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
       with:
@@ -126,6 +137,7 @@ jobs:
       # Each connector alone (including test code) — catches missing #[cfg]s
       # and accidental cross-feature dependencies.
       run: |
+        cargo check --all-targets --features kafka
         cargo check --all-targets --features rabbitmq
         cargo check --all-targets --features websocket
 
@@ -155,8 +167,14 @@ jobs:
       # unavailable-extension hint) must pass.
       run: cargo nextest run --verbose
 
+    # Integration steps reuse the connectors-all build artifacts from the
+    # main test step — a per-connector feature set would recompile the lib.
+    # Single-connector compilation is already covered by the gating checks.
     - name: Run RabbitMQ integration tests
-      run: cargo nextest run --features rabbitmq --test rabbitmq_integration --run-ignored ignored-only --verbose
+      run: cargo nextest run --features connectors-all --test rabbitmq_integration --run-ignored ignored-only --verbose
+
+    - name: Run Kafka integration tests
+      run: cargo nextest run --features connectors-all --test kafka_integration --run-ignored ignored-only --verbose
 
     - name: Run doctests
       run: cargo test --doc --features connectors-all

--- a/.gitignore
+++ b/.gitignore
@@ -153,9 +153,6 @@ website/.cache-loader/
 website/.npm/
 research/
 
-# Feature development scratchpads (may contain proprietary references)
-feat/
-
 # LLM instruction files
 GEMINI.md
 CLAUDE.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,8 @@ cargo nextest run --features connectors-all        # or: cargo test --features c
 cargo nextest run                                  # minimal build tests (no connectors)
 cargo test --doc --features connectors-all
 cargo check --all-targets                          # minimal baseline compiles
-cargo check --all-targets --features rabbitmq      # each connector alone
+cargo check --all-targets --features kafka         # each connector alone
+cargo check --all-targets --features rabbitmq
 cargo check --all-targets --features websocket
 ```
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,6 +500,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.71.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
+dependencies = [
+ "bitflags 2.9.1",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.10.5",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex 1.3.0",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -583,13 +601,23 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.29"
+version = "1.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c1599538de2394445747c8cf7935946e3cc27e9625f889d979bfb2aaf569362"
+checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
 dependencies = [
+ "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex",
+ "shlex 2.0.1",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -650,6 +678,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
 name = "clap"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -688,6 +727,15 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "cms"
@@ -1256,6 +1304,7 @@ dependencies = [
  "prost 0.12.6",
  "rand 0.8.5",
  "rayon",
+ "rdkafka",
  "redis",
  "regex",
  "rusqlite",
@@ -1316,6 +1365,12 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fixedbitset"
@@ -1545,6 +1600,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "h2"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1556,7 +1617,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.10.0",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1598,6 +1659,12 @@ checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 dependencies = [
  "foldhash",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
@@ -1926,13 +1993,14 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.10.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.4",
+ "hashbrown 0.17.1",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2281,6 +2349,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "libz-sys"
+version = "1.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85bc9657773828b90eeb625adff10eeac83cc21bbfd8e23a03eaa8a33c9e28d9"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2499,6 +2579,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2567,6 +2669,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
+name = "openssl-src"
+version = "300.6.1+3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46eb8fb9fb3b61ce1c0f8a026c4c1a0714d3a9e138e7fbde78753ce2babc3846"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2574,6 +2685,7 @@ checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -2730,7 +2842,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.10.0",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -2933,6 +3045,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit 0.25.12+spec-1.1.0",
 ]
 
 [[package]]
@@ -3170,6 +3291,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "rdkafka"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7956f9ac12b5712e50372d9749a3102f4810a8d42481c5eae3748d36d585bcf"
+dependencies = [
+ "futures-channel",
+ "futures-util",
+ "libc",
+ "log",
+ "rdkafka-sys",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "slab",
+]
+
+[[package]]
+name = "rdkafka-sys"
+version = "4.10.0+2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e234cf318915c1059d4921ef7f75616b5219b10b46e9f3a511a15eb4b56a3f77"
+dependencies = [
+ "cmake",
+ "libc",
+ "libz-sys",
+ "num_enum",
+ "openssl-sys",
+ "pkg-config",
+ "zstd-sys",
+]
+
+[[package]]
 name = "reactor-trait"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3348,6 +3501,12 @@ name = "rustc-demangle"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rusticata-macros"
@@ -3721,7 +3880,7 @@ version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
- "indexmap 2.10.0",
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",
@@ -3756,7 +3915,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.10.0",
+ "indexmap 2.14.0",
  "itoa",
  "ryu",
  "serde",
@@ -3821,6 +3980,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -4238,8 +4403,8 @@ checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
  "serde_spanned",
- "toml_datetime",
- "toml_edit",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]
@@ -4252,17 +4417,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.10.0",
+ "indexmap 2.14.0",
  "serde",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 0.6.11",
  "toml_write",
- "winnow",
+ "winnow 0.7.13",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+dependencies = [
+ "indexmap 2.14.0",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "winnow 1.0.3",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -4721,7 +4916,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.10.0",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -4734,7 +4929,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.9.1",
  "hashbrown 0.15.4",
- "indexmap 2.10.0",
+ "indexmap 2.14.0",
  "semver",
 ]
 
@@ -5096,6 +5291,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winreg"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5148,7 +5352,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "indexmap 2.10.0",
+ "indexmap 2.14.0",
  "prettyplease 0.2.37",
  "syn 2.0.117",
  "wasm-metadata",
@@ -5179,7 +5383,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags 2.9.1",
- "indexmap 2.10.0",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -5198,7 +5402,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.10.0",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",
@@ -5376,6 +5580,7 @@ version = "2.0.15+zstd.1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237"
 dependencies = [
+ "bindgen",
  "cc",
  "pkg-config",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -949,6 +949,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "curl-sys"
+version = "0.4.90+curl-8.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97799a0d220bfb3361e0fe4936966ff8c4b24d65c3f06dfc70d7b680b44e7897"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "custom_dyn_ext"
 version = "0.1.0"
 dependencies = [
@@ -3314,6 +3329,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e234cf318915c1059d4921ef7f75616b5219b10b46e9f3a511a15eb4b56a3f77"
 dependencies = [
  "cmake",
+ "curl-sys",
  "libc",
  "libz-sys",
  "num_enum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,12 +67,15 @@ prost = "0.12"
 rand = "0.8"
 rayon = "1"
 # cmake-build compiles the vendored librdkafka (needs cmake + a C toolchain);
-# ssl-vendored statically links OpenSSL so SSL/SASL-SCRAM work everywhere;
+# ssl-vendored and curl-static statically link OpenSSL/libcurl so the build
+# is hermetic — no system dev packages needed (librdkafka's cmake otherwise
+# picks up a headerless system libcurl and fails, e.g. on ubuntu runners);
 # libz enables gzip and zstd enables zstd compression codecs (snappy and lz4
 # are bundled). Default features are off: they only add tokio async support,
 # which the sync BaseConsumer/ThreadedProducer connector does not use.
 rdkafka = { version = "0.39", default-features = false, features = [
     "cmake-build",
+    "curl-static",
     "libz",
     "ssl-vendored",
     "zstd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,9 +32,10 @@ cloud-native = ["kubernetes", "consul", "etcd", "vault"]
 # no connector ships in a plain `cargo build`. Release/Docker builds use
 # `--features connectors-all`. See docs/writing_extensions.md for the
 # per-connector gating checklist.
+kafka = ["dep:rdkafka"]
 rabbitmq = ["dep:lapin", "dep:urlencoding"]
 websocket = ["dep:tokio-tungstenite"]
-connectors-all = ["rabbitmq", "websocket"]
+connectors-all = ["kafka", "rabbitmq", "websocket"]
 
 [dependencies]
 async-trait = "0.1"
@@ -65,6 +66,17 @@ once_cell = "1"
 prost = "0.12"
 rand = "0.8"
 rayon = "1"
+# cmake-build compiles the vendored librdkafka (needs cmake + a C toolchain);
+# ssl-vendored statically links OpenSSL so SSL/SASL-SCRAM work everywhere;
+# libz enables gzip and zstd enables zstd compression codecs (snappy and lz4
+# are bundled). Default features are off: they only add tokio async support,
+# which the sync BaseConsumer/ThreadedProducer connector does not use.
+rdkafka = { version = "0.39", default-features = false, features = [
+    "cmake-build",
+    "libz",
+    "ssl-vendored",
+    "zstd",
+], optional = true }
 redis = { version = "0.27", features = ["aio", "tokio-comp", "connection-manager"] }
 regex = "1"
 rusqlite = { version = "0.29", features = ["bundled"] }

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ feature named after its SQL extension name:
 
 | Feature | Connector | In default build? |
 |---------|-----------|-------------------|
+| `kafka` | Kafka source + sink (needs cmake to build) | No |
 | `rabbitmq` | RabbitMQ source + sink | No |
 | `websocket` | WebSocket source + sink | No |
 | `connectors-all` | All of the above | No |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,7 @@
 # EventFlux Roadmap
 
-Last verified: 2026-06-14
+Last verified: 2026-07-10 (no `src/` changes since the prior 2026-06-14 verification — only CI/dependency
+bumps and docs have landed, so all feature-status claims below still hold)
 
 ---
 
@@ -163,9 +164,9 @@ All have state holder implementations for checkpointing.
 |------------|-------------|-------------|------------------|------------------|
 | Timer      | Done        | —           | —                | (always built)   |
 | Log        | —           | Done        | —                | (always built)   |
+| Kafka      | Done        | Done        | JSON, CSV, bytes | `kafka`          |
 | RabbitMQ   | Done        | Done        | JSON, CSV, bytes | `rabbitmq`       |
 | WebSocket  | Done        | Done        | JSON, CSV, bytes | `websocket`      |
-| Kafka      | Not started | Not started | —                | `kafka` (planned)|
 | HTTP       | Not started | Not started | —                | —                |
 | File       | Not started | Not started | —                | —                |
 | TCP/Socket | Not started | Not started | —                | —                |
@@ -332,14 +333,16 @@ registration over `inventory`/`linkme` crates for WASM compatibility.
 
 ## What's Next
 
-### Priority 1: Kafka Connector (Critical)
+### Priority 1: Kafka Connector — **DONE (2026-07)**
 
-The most requested connector for production viability.
+Implemented per `feat/kafka/README.md`: `kafka_source.rs` (BaseConsumer poll loop on `SourceWorker`,
+consumer groups, at-least-once via commit-after-delivery, `error.*` strategies, SASL/SSL) and
+`kafka_sink.rs` (ThreadedProducer, delivery reports, `kafka.delivery.sync`, backpressure on full
+queues). Feature-gated behind `kafka` (in `connectors-all`), `kafka.rdkafka.*` passthrough for
+librdkafka tuning, integration tests + CI broker service (apache/kafka:3.9.1), SQL example in
+`examples/kafka.eventflux`. Deferred: exactly-once transactions, per-event keys, Avro.
 
-- Kafka source: consumer groups, offset management, exactly-once semantics
-- Kafka sink: partitioning strategies, delivery guarantees
-- Configuration via SQL WITH clause
-- Dependency: `rdkafka` crate
+HTTP (Priority 2) is the next connector.
 
 ### Priority 2: HTTP Connector
 

--- a/examples/kafka.eventflux
+++ b/examples/kafka.eventflux
@@ -1,0 +1,89 @@
+-- ============================================================================
+-- EventFlux Kafka Source/Sink Example
+-- ============================================================================
+--
+-- This example demonstrates end-to-end stream processing with Kafka:
+--   1. Kafka Source: Consumes JSON events from a topic
+--   2. EventFlux Query: Filters by volume and adds price_category via CASE
+--   3. Kafka Sink: Publishes processed events to another topic
+--
+-- ============================================================================
+-- PREREQUISITES
+-- ============================================================================
+--
+-- 0. Build EventFlux with the Kafka connector enabled:
+--
+--    cargo build --release --features kafka
+--    (Docker images include all connectors already)
+--
+-- 1. Start a single-node Kafka broker with Docker:
+--
+--    docker run -d --name kafka -p 9092:9092 apache/kafka:3.9.1
+--
+-- 2. Create the topics (EventFlux validates they exist at startup):
+--
+--    docker exec kafka /opt/kafka/bin/kafka-topics.sh --create \
+--      --bootstrap-server localhost:9092 --topic trades-in
+--    docker exec kafka /opt/kafka/bin/kafka-topics.sh --create \
+--      --bootstrap-server localhost:9092 --topic trades-out
+--
+-- 3. Run this example:
+--
+--    cargo run --features kafka --bin run_eventflux examples/kafka.eventflux
+--
+-- 4. In another terminal, produce a test message:
+--
+--    docker exec -i kafka /opt/kafka/bin/kafka-console-producer.sh \
+--      --bootstrap-server localhost:9092 --topic trades-in
+--    {"symbol":"AAPL","price":150.25,"volume":1000}
+--
+-- 5. Watch the output topic:
+--
+--    docker exec -i kafka /opt/kafka/bin/kafka-console-consumer.sh \
+--      --bootstrap-server localhost:9092 --topic trades-out --from-beginning
+--
+-- ============================================================================
+
+CREATE STREAM TradeInput (
+    symbol STRING,
+    price DOUBLE,
+    volume INT
+) WITH (
+    type = 'source',
+    extension = 'kafka',
+    format = 'json',
+    "kafka.bootstrap.servers" = 'localhost:9092',
+    "kafka.topic" = 'trades-in',
+    "kafka.group.id" = 'eventflux-trades',
+    "kafka.auto.offset.reset" = 'earliest',
+    -- At-least-once: commit offsets only after pipeline delivery
+    "kafka.enable.auto.commit" = 'false'
+);
+
+CREATE STREAM TradeOutput (
+    symbol STRING,
+    price DOUBLE,
+    volume INT,
+    price_category STRING
+) WITH (
+    type = 'sink',
+    extension = 'kafka',
+    format = 'json',
+    "kafka.bootstrap.servers" = 'localhost:9092',
+    "kafka.topic" = 'trades-out',
+    "kafka.acks" = 'all',
+    "kafka.compression" = 'lz4'
+);
+
+INSERT INTO TradeOutput
+SELECT
+    symbol,
+    price,
+    volume,
+    CASE
+        WHEN price > 500 THEN 'HIGH'
+        WHEN price > 100 THEN 'MEDIUM'
+        ELSE 'LOW'
+    END AS price_category
+FROM TradeInput
+WHERE volume > 100;

--- a/examples/kafka.eventflux
+++ b/examples/kafka.eventflux
@@ -31,11 +31,12 @@
 --
 --    cargo run --features kafka --bin run_eventflux examples/kafka.eventflux
 --
--- 4. In another terminal, produce a test message:
+-- 4. In another terminal, produce a test message (pipe it into the
+--    console producer — it reads messages from stdin):
 --
---    docker exec -i kafka /opt/kafka/bin/kafka-console-producer.sh \
+--    echo '{"symbol":"AAPL","price":150.25,"volume":1000}' | \
+--      docker exec -i kafka /opt/kafka/bin/kafka-console-producer.sh \
 --      --bootstrap-server localhost:9092 --topic trades-in
---    {"symbol":"AAPL","price":150.25,"volume":1000}
 --
 -- 5. Watch the output topic:
 --

--- a/feat/connector-infra/README.md
+++ b/feat/connector-infra/README.md
@@ -1,0 +1,295 @@
+# Connector Infrastructure: Bug Fixes & Feature Gating Specification
+
+Status: **SPEC — APPROVED, ready for implementation**
+Prerequisite for: `feat/kafka/README.md` (Kafka connector)
+
+Review decisions (2026-07-10):
+- `SinkMapper::map_event` signature change approved — no backward-compatibility constraints at
+  this stage
+- Feature gating approved with a **fully minimal default set** (`default = []`)
+- CI Kafka broker: `apache/kafka:3.9.1`
+
+This document specifies fixes for correctness bugs in the connector base/adapter layer, and a
+generic feature-gating framework for connectors. Both were identified while reviewing the
+RabbitMQ connector as the template for Kafka; both must land before Kafka implementation starts.
+
+---
+
+## Part 1: Bug — Sink batch handling loses or corrupts events
+
+### Evidence
+
+`SinkCallbackAdapter::receive_events()` (`src/core/stream/output/sink/mod.rs:49`) maps an entire
+`&[Event]` batch into **one** payload and makes **one** `publish()` call:
+
+```rust
+fn receive_events(&self, events: &[Event]) {
+    let payload = match self.mapper.lock().unwrap().map(events) { ... };  // whole batch → 1 payload
+    if let Err(e) = self.sink.lock().unwrap().publish(&payload) { ... }   // 1 publish
+}
+```
+
+Multi-event batches genuinely occur: `callback_processor.rs:82` calls
+`receive_events(&events_vec)` with all events a query emitted in one processing pass (e.g. a
+batch window flush).
+
+Each sink mapper handles the batch differently — none correctly for record-oriented transports:
+
+| Mapper | Batch of N events becomes | Verdict |
+|--------|---------------------------|---------|
+| `JsonSinkMapper` (`json_mapper.rs:287`) | 1 message containing only `events[0]` — comment says "batching can be added later" | **Silent data loss of N−1 events** |
+| `CsvSinkMapper` (`csv_mapper.rs:355`) | 1 message containing N newline-joined rows | No loss, but 1 transport message ≠ 1 event; a JSON/CSV consumer of a queue/topic expects one record per message |
+| `BytesSinkMapper` (`bytes_mapper.rs:129`) | Hard error (`MappingFailed`) — refuses batches | Whole batch fails; the error text itself asks callers to "ensure events are sent individually" |
+| `PassthroughMapper` (`output/mapper.rs:67`) | 1 bincode blob of `Vec<Event>` | Internal binary format (LogSink pairing); acceptable but inconsistent |
+
+So today, publishing a 3-event batch through a RabbitMQ sink with `format='json'` silently
+delivers 1 message and discards 2 events. **Passing tests don't catch this because tests emit
+single events.**
+
+### Fix design
+
+**Chosen approach: per-event iteration in the adapter, per-event mapper contract.**
+
+1. `SinkCallbackAdapter::receive_events()` iterates the batch — one `map` + one `publish` per
+   event. One event = one transport message (Kafka record, AMQP message, WebSocket frame). This
+   matches every real message transport's data model.
+
+2. `SinkMapper` trait gets an honest, per-event signature:
+
+   ```rust
+   pub trait SinkMapper: Debug + Send + Sync {
+       /// Map ONE event to one transport payload.
+       fn map_event(&self, event: &Event) -> Result<Vec<u8>, EventFluxError>;
+       fn clone_box(&self) -> Box<dyn SinkMapper>;
+   }
+   ```
+
+   The `&[Event]` signature invited exactly the divergence in the table above. Per the project's
+   no-backward-compatibility philosophy, change the contract rather than documenting around it.
+
+3. Mapper updates (all four call sites):
+   - `JsonSinkMapper`: drop the `events[0]` selection — body already processes one event
+   - `CsvSinkMapper`: serialize one row; header handling moves to per-message (header + row per
+     message, or drop header support for stream sinks — decide at implementation; headers in a
+     message stream are unusual and CSV consumers of queues rarely want them repeated)
+   - `BytesSinkMapper`: remove the batch-rejection branch — the constraint is now structural
+   - `PassthroughMapper`: `bincode::serialize(&event)`; `LogSink` consumers updated accordingly
+
+4. Error handling per event: a mapper/publish failure for event *i* logs and continues with
+   event *i+1* (today one failure drops the whole batch). Failure counting hooks come later with
+   connector metrics.
+
+**Alternative considered — adapter iterates, keep `&[Event]` signature**: smaller diff, but
+leaves a trait contract nobody exercises with N>1, and the mapper divergence intact. Rejected;
+if a future sink genuinely wants transport-level batching (HTTP batch POST, file), that batching
+belongs in the sink (buffer + flush), not in the formatting layer.
+
+### Tests
+
+- Adapter: batch of 3 events through a recording mock sink → exactly 3 publishes, in order
+- Adapter: mapper failure on event 2 of 3 → events 1 and 3 still published
+- Each mapper: `map_event` output equivalence with current single-event output (regression)
+- Integration: RabbitMQ round-trip test extended to send a multi-event batch and assert N
+  messages arrive (extends `tests/rabbitmq_integration.rs`)
+
+---
+
+## Part 2: Bug — Source threads are never joined on stop()
+
+### Evidence
+
+All three sources spawn their worker thread and discard the `JoinHandle`:
+
+- `RabbitMQSource::stop()` (`rabbitmq_source.rs:721`) — sets `AtomicBool`, returns immediately
+- `WebSocketSource::stop()` (`websocket_source.rs:558`) — same
+- `TimerSource::stop()` (`timer_source.rs:296`) — same
+
+Consequences: `stop()` returns while the worker may still be mid-callback — events can arrive
+after shutdown began; app teardown can race connector cleanup (channel/connection close runs
+concurrently with runtime destruction); tests that stop-then-assert are inherently racy.
+
+### Fix design (revised at review: abstract, don't repeat)
+
+Rather than each source hand-rolling a `running: Arc<AtomicBool>` + `JoinHandle` pair (a pattern
+every future source would have to remember to copy correctly), the lifecycle is captured once in
+a **`SourceWorker`** struct in `source/mod.rs` that sources embed by composition:
+
+```rust
+pub struct SourceWorker {
+    name: &'static str,                 // for shutdown log messages
+    running: Arc<AtomicBool>,           // polled by the worker loop
+    handle: Option<JoinHandle<()>>,     // joined in stop()
+}
+
+impl SourceWorker {
+    pub fn new(name: &'static str) -> Self;
+    /// Sets the flag, spawns the thread; closure receives the running flag
+    pub fn start<F: FnOnce(Arc<AtomicBool>) + Send + 'static>(&mut self, body: F);
+    /// Signals + joins (bounded by SOURCE_STOP_GRACE_PERIOD = 5s). Idempotent.
+    pub fn stop(&mut self);
+}
+impl Drop for SourceWorker { /* stop() — RAII: dropped ⇒ shut down */ }
+impl Clone for SourceWorker { /* fresh, unstarted worker */ }
+```
+
+A source then holds `worker: SourceWorker`, spawns with `self.worker.start(|running| ...)`, and
+`Source::stop()` is one line: `self.worker.stop()`. The join cannot be forgotten because it
+lives inside the abstraction — and `Drop` covers even a source that is never stopped.
+
+- `join_with_timeout` (watcher thread + channel; std has no native timed join) stays available
+  but `SourceWorker` is the intended API. Kafka uses `SourceWorker` from day one.
+- Applies to: RabbitMQSource, WebSocketSource, TimerSource.
+- The `Source::stop()` trait doc states the contract (synchronous, idempotent, no callbacks
+  after return) and points to `SourceWorker`; `docs/writing_extensions.md` gains a
+  "Source Extensions" section documenting the pattern for new connector authors.
+
+### Tests
+
+- Per source: `start()` then `stop()` → worker observed terminated (flag set by worker's last
+  instruction; assert after `stop()` returns)
+- `stop()` without `start()` → no-op, no panic
+- Double `stop()` → idempotent
+
+---
+
+## Part 3: Generic connector feature gating
+
+### Verdict and rationale
+
+**Adopt per-connector cargo features.** It directly serves the project identity (lightweight
+single binary, minimal deps, zero external dependencies for core operation):
+
+- A core build should not pay for connectors it doesn't use — in binary size, compile time, or
+  build prerequisites
+- Kafka makes this acute: `rdkafka` compiles librdkafka via cmake + a C toolchain. Imposing that
+  on every `cargo build` (contributors, CI matrix, WASM-adjacent targets) is unacceptable
+- The project already has this precedent for infra integrations: `kubernetes`, `consul`, `etcd`,
+  `vault`, `cloud-native` umbrella — connectors follow the same pattern
+- Cost is a `#[cfg]` discipline and a CI check to prevent gating rot — both cheap and specified
+  below
+
+### Feature scheme
+
+```toml
+[features]
+default = []   # fully minimal — core engine only (Timer/Log baseline, no external connectors)
+
+# Connectors (one feature per connector, named exactly after the extension name)
+rabbitmq  = ["dep:lapin"]
+websocket = ["dep:tokio-tungstenite", "dep:tungstenite"]
+kafka     = ["dep:rdkafka"]
+# future: http = ["dep:reqwest"], file = [], ...
+
+# Umbrella
+connectors-all = ["rabbitmq", "websocket", "kafka"]
+```
+
+**Rules (documented in CLAUDE.md / IMPLEMENTATION_GUIDE.md when implemented):**
+
+1. **One feature per connector, named exactly after its registered extension name** (the string
+   used in SQL `WITH (extension = '...')`). This makes the SQL name ↔ feature name ↔ docs
+   mapping trivial.
+2. **Fully minimal default set: `default = []`** (decided at review). No connector ships in the
+   default build — every external connector is opt-in, regardless of whether it is pure Rust.
+   This maximizes the lightweight identity: fastest `cargo build`, smallest core binary, and one
+   uniform rule with no per-dependency judgment calls. It also matches the existing
+   `default = []` in Cargo.toml.
+3. **`connectors-all` umbrella** aggregates every connector. Release artifacts and Docker images
+   build with `--features connectors-all` so shipped binaries include everything.
+4. **Timer and Log stay ungated** — zero-dependency, used pervasively in tests and examples;
+   they are the "core operation" baseline.
+5. Existing unconditionally-compiled connectors (RabbitMQ, WebSocket) are **retrofitted** under
+   this scheme. Note the behavior change: a plain `cargo build` will no longer include them —
+   accepted at review (early stage, no backward-compatibility constraints). Anyone building from
+   source for messaging use cases passes `--features connectors-all` (documented in README).
+
+### Gating checklist (per connector)
+
+Every gated connector touches exactly these points — this is the template Kafka and all future
+connectors follow:
+
+| Point | Mechanism |
+|-------|-----------|
+| Dependency | `optional = true` + `dep:` in the feature |
+| Module declaration | `#[cfg(feature = "x")] pub mod x_source;` in `source/mod.rs` (same for sink) |
+| Re-exports | `#[cfg(feature = "x")]` on any `pub use` |
+| Registration | `#[cfg(feature = "x")]` on the `add_source_factory`/`add_sink_factory` lines in `register_default_extensions()` |
+| Integration tests | `#![cfg(feature = "x")]` at top of `tests/x_integration.rs` |
+| Unit tests referencing the connector | gate or relocate into the connector module |
+| Examples | header comment noting required feature |
+| cargo-machete metadata | add the optional dep to the ignored list if needed |
+
+### Unknown-extension error hint
+
+A binary built without a feature must fail helpfully, not with a bare `Unknown source type:
+kafka`. Add a compile-time table of known-but-not-compiled connectors:
+
+```rust
+/// Extensions that exist in the codebase but were excluded from this build.
+const UNAVAILABLE_EXTENSIONS: &[(&str, &str)] = &[
+    #[cfg(not(feature = "kafka"))]
+    ("kafka", "kafka"),
+    #[cfg(not(feature = "rabbitmq"))]
+    ("rabbitmq", "rabbitmq"),
+    #[cfg(not(feature = "websocket"))]
+    ("websocket", "websocket"),
+];
+```
+
+On failed factory lookup in `stream_initializer`, consult the table and emit:
+
+> Extension 'kafka' is supported by EventFlux but was not included in this build.
+> Rebuild with `--features kafka` (or `--features connectors-all`).
+
+Unknown names not in the table keep the current error (with the existing available-extensions
+listing).
+
+### CI strategy
+
+Additions to `.github/workflows/rust.yml`:
+
+1. **Main test job builds with `--features connectors-all`** — full coverage remains the norm
+   (requires cmake for rdkafka; preinstalled on `ubuntu-latest`)
+2. **Gating-honesty checks**: `cargo check` (minimal default build must compile and is the
+   lightweight baseline we advertise) plus `cargo check --features <connector>` for each
+   connector alone — catches missing `#[cfg]`s and accidental cross-feature dependencies
+   cheaply, without a full test matrix
+3. Docker publish workflow builds with `--features connectors-all`
+
+### Documentation requirements
+
+- **README.md**: "Building" section gains a feature-flags table (connector → feature → in
+  default? → extra prerequisites)
+- **Website** (`website/`): connector docs each state their feature flag and build command
+- **IMPLEMENTATION_GUIDE.md**: "Adding a Connector" gains the gating checklist above
+- **ROADMAP.md**: connector table gains a "Feature flag" column
+
+---
+
+## Out of scope (tracked, not in this spec)
+
+Noted during the same review; deliberately deferred to keep this spec shippable:
+
+| Item | Where it lives |
+|------|----------------|
+| `publish_event(&Event, payload)` keyed-publish interface + schema injection | `feat/kafka/README.md` Improvement 2 (driven by Kafka partition keys) |
+| Source supervision/restart policy on connection loss | ROADMAP P10 (production hardening) |
+| Shared tokio runtime for async connectors | Backlog — RabbitMQ/WebSocket cleanup, not needed by Kafka |
+| Connector metrics (records in/out/failed, lag) | ROADMAP P9 (observability); Kafka ships local counters meanwhile |
+| Shared `validate_connectivity` timeout helper | When a third network connector lands |
+| `from_properties` `Result<_, String>` → `EventFluxError` | Mechanical cleanup, anytime |
+
+---
+
+## Implementation order & PR breakdown
+
+| PR | Content | Risk |
+|----|---------|------|
+| 1 | Part 1: adapter iteration + `SinkMapper::map_event` migration + tests — **submitted: eventflux-io/eventflux#115** | Medium — touches 4 mappers, adapter, LogSink; behavior change for batched output is the point |
+| 2 | Part 2: `SourceWorker` lifecycle abstraction + tests (3 sources) — **submitted: eventflux-io/eventflux#116** | Low |
+| 3 | Part 3: feature scheme in Cargo.toml, retrofit rabbitmq/websocket, error hint, CI checks, docs — **submitted: eventflux-io/eventflux#117**. Review addition: ALL check surfaces (CI, pre-push hook, justfile, CONTRIBUTING) build with gates enabled so gated code is never silently skipped; CI runs the test suite in both minimal and connectors-all configurations | Low — mostly mechanical |
+
+Each PR: `cargo fmt`, `cargo clippy`, full `cargo test`, plus the RabbitMQ integration suite for
+PRs 1–2 (`cargo test --test rabbitmq_integration -- --ignored`, broker required).
+
+After PR 3 lands, Kafka implementation (`feat/kafka/README.md`) starts on a clean base.

--- a/feat/kafka/README.md
+++ b/feat/kafka/README.md
@@ -1,0 +1,474 @@
+# Kafka Connector Specification for EventFlux
+
+Status: **IMPLEMENTED (2026-07-12)** — source + sink + factories, registration, feature gating,
+integration tests, CI broker service, example, docs. Deferred items tracked below.
+Prerequisite (completed): **`feat/connector-infra/README.md`** — landed as eventflux-io/eventflux
+#115/#116/#117.
+
+Review decisions (2026-07-10): fully minimal default feature set (`default = []`, no connectors);
+`map_event` signature change approved; CI broker `apache/kafka:3.9.1`.
+
+This document specifies the Kafka source and sink implementations for EventFlux, following the
+patterns established by the RabbitMQ connector (`feat/rabbitmq/README.md`). Cross-cutting
+infrastructure fixes discovered during the same review are specified separately in
+`feat/connector-infra/README.md`; this spec assumes they are in place.
+
+## Overview
+
+EventFlux will provide native integration with Apache Kafka through:
+
+- **Kafka Source**: Consumes records from Kafka topics (consumer groups, offset management)
+- **Kafka Sink**: Produces records to Kafka topics (partitioning, delivery reports)
+
+Both implementations use the `rdkafka` crate (bindings to librdkafka), behind a `kafka` cargo
+feature.
+
+## Architecture
+
+```
+┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
+│   Kafka Topic   │────▶│    EventFlux    │────▶│   Kafka Topic   │
+│    (Source)     │     │    Pipeline     │     │     (Sink)      │
+└─────────────────┘     └─────────────────┘     └─────────────────┘
+```
+
+### Threading Model — no tokio runtime needed
+
+The RabbitMQ connector must bridge the sync `Source`/`Sink` traits to `lapin`'s async API, which
+forces `thread::spawn → tokio::runtime::Runtime → block_on` and the
+`Handle::try_current()/block_in_place` fallback chains seen throughout `rabbitmq_sink.rs`.
+
+Kafka avoids all of this. librdkafka runs its own background threads (network I/O, batching,
+reconnection), and `rdkafka` exposes synchronous APIs on top:
+
+| Component | rdkafka API | Model |
+|-----------|-------------|-------|
+| Source | `BaseConsumer<CustomContext>` | Dedicated thread, `consumer.poll(100ms)` loop — mirrors the existing 100ms `running`-flag check pattern |
+| Sink | `ThreadedProducer<DeliveryContext>` | `publish()` = non-blocking enqueue; librdkafka batches and delivers; delivery reports arrive via callback on the producer's poll thread |
+
+```
+Source:  thread::spawn → BaseConsumer::poll(100ms) loop → bytes → SourceCallback → SourceMapper → Events
+Sink:    Events → SinkMapper → bytes → ThreadedProducer::send() → librdkafka batching → Kafka
+```
+
+Benefits over the RabbitMQ approach:
+- No nested-runtime handling, no `block_in_place`, no stored `runtime`/`runtime_handle` fields
+- Automatic reconnection with exponential backoff (librdkafka built-in) — the RabbitMQ source
+  thread simply exits on connection errors; Kafka gets resilience for free
+- Producer-side batching (`linger.ms`, `batch.size`) without blocking the pipeline per message —
+  the RabbitMQ sink synchronously awaits a publisher confirm per publish, capping throughput at
+  ~1 message per broker RTT
+
+## Kafka Source
+
+Consumes records from one or more Kafka topics and delivers payload bytes to the EventFlux
+pipeline via `SourceCallback`.
+
+### Configuration
+
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| `kafka.bootstrap.servers` | Yes | - | Comma-separated broker list (`host1:9092,host2:9092`) |
+| `kafka.topic` | Yes | - | Topic(s) to consume, comma-separated for multiple |
+| `kafka.group.id` | No | `eventflux-<topic>` | Consumer group id. Default is deterministic so offsets survive restarts |
+| `kafka.auto.offset.reset` | No | `latest` | Where to start without committed offsets (`earliest`, `latest`) |
+| `kafka.enable.auto.commit` | No | `true` | `true`: librdkafka commits periodically (at-most-once-ish). `false`: commit after successful delivery to pipeline (at-least-once) |
+| `kafka.poll.timeout.ms` | No | `100` | Poll timeout; bounds shutdown latency |
+| `kafka.security.protocol` | No | `plaintext` | `plaintext`, `ssl`, `sasl_plaintext`, `sasl_ssl` |
+| `kafka.sasl.mechanism` | No | - | `PLAIN`, `SCRAM-SHA-256`, `SCRAM-SHA-512` |
+| `kafka.sasl.username` | No | - | SASL username |
+| `kafka.sasl.password` | No | - | SASL password (use `${ENV_VAR}` substitution; never logged) |
+| `kafka.ssl.ca.location` | No | - | CA certificate path |
+| `kafka.rdkafka.<prop>` | No | - | Escape hatch: passed verbatim to librdkafka (e.g. `kafka.rdkafka.fetch.min.bytes`). Same pattern as Flink's `properties.*` |
+| `error.strategy` | No | - | Error handling strategy (drop, retry, dlq, fail) |
+| `error.retry.max-attempts` | No | 3 | Max retry attempts |
+| `error.retry.initial-delay-ms` | No | 100 | Initial retry delay in ms |
+| `error.retry.max-delay-ms` | No | 10000 | Max retry delay in ms |
+| `error.retry.backoff-multiplier` | No | 2.0 | Backoff multiplier |
+| `error.dlq.stream` | No | - | DLQ stream name (required when strategy=dlq) |
+
+Reserved keys (`bootstrap.servers`, `group.id`, offset/commit settings) may not be overridden via
+`kafka.rdkafka.*` — config parsing rejects them with a clear error.
+
+### Consume loop semantics
+
+Mirrors the RabbitMQ source's retry/ack pattern, with Kafka commit semantics:
+
+```
+while running:
+    match consumer.poll(poll_timeout):
+        None            → continue (check running flag)
+        Some(Err(e))    → route through SourceErrorContext (retry/drop/dlq/fail)
+        Some(Ok(msg))   →
+            loop:                                   # retry loop, same as RabbitMQ
+                match callback.on_data(msg.payload()):
+                    Ok  → if !auto_commit: consumer.commit_message(msg, Async)
+                          reset error counter; break
+                    Err → action = error_ctx.handle_error_with_action(fallback_event, e)
+                          Retry → continue
+                          Drop | SendToDlq → if !auto_commit: commit (skip record); break
+                          Fail  → do NOT commit; stop source
+
+on shutdown: final commit (Sync) if !auto_commit, then consumer unsubscribe/close
+```
+
+- **At-least-once** (`kafka.enable.auto.commit=false`): a record's offset is committed only after
+  `on_data` succeeds (or the error strategy explicitly disposes of it via Drop/DLQ). Crash before
+  commit → redelivery on restart.
+- **DLQ fallback event**: raw payload wrapped as `AttributeValue::Bytes`, identical to RabbitMQ.
+- Records with empty/null payloads (tombstones) are skipped with a debug log in v1.
+- Consumer group rebalances are logged via a custom `ConsumerContext` (`pre_rebalance` /
+  `post_rebalance` hooks).
+
+### `KafkaSource` structure
+
+```rust
+pub struct KafkaSourceConfig { /* fields per config table; from_properties() parsing */ }
+
+pub struct KafkaSource {
+    config: KafkaSourceConfig,
+    worker: SourceWorker,        // lifecycle: spawn / signal / bounded join (connector-infra Part 2)
+    error_ctx: Option<SourceErrorContext>,
+    metrics: Arc<SourceMetrics>, // records_received, records_failed (AtomicU64)
+}
+
+impl Source for KafkaSource {
+    fn start(&mut self, callback: Arc<dyn SourceCallback>);  // worker.start(|running| poll loop)
+    fn stop(&mut self);          // worker.stop() — synchronous, joined, idempotent
+    fn clone_box(&self) -> Box<dyn Source>;
+    fn set_error_dlq_junction(&mut self, junction: Arc<Mutex<InputHandler>>);
+    fn validate_connectivity(&self) -> Result<(), EventFluxError>;
+}
+```
+
+`validate_connectivity()`: create a consumer, `fetch_metadata(Some(topic), 10s)` per configured
+topic; error if brokers unreachable or a topic does not exist. No queue-declare complications —
+topic auto-creation is a broker-side setting, so unlike RabbitMQ there is no client-side
+declare/passive-declare dance.
+
+### `KafkaSourceFactory`
+
+```rust
+impl SourceFactory for KafkaSourceFactory {
+    fn name(&self) -> &'static str { "kafka" }
+    fn supported_formats(&self) -> &[&str] { &["json", "csv", "bytes"] }
+    fn required_parameters(&self) -> &[&str] { &["kafka.bootstrap.servers", "kafka.topic"] }
+    fn optional_parameters(&self) -> &[&str] { /* per config table + error.* */ }
+    fn create_initialized(&self, config) -> Result<Box<dyn Source>, EventFluxError>;
+    fn clone_box(&self) -> Box<dyn SourceFactory>;
+}
+```
+
+Note: the existing placeholder stub in `example_factories.rs` claims `avro` support — there is no
+avro mapper in the registry, so the real factory advertises only formats that actually exist
+(json, csv, bytes). Avro + Schema Registry is deferred.
+
+## Kafka Sink
+
+Produces formatted event payloads to a Kafka topic.
+
+### Configuration
+
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| `kafka.bootstrap.servers` | Yes | - | Comma-separated broker list |
+| `kafka.topic` | Yes | - | Target topic |
+| `kafka.key` | No | - | Static record key (Phase 1). Per-event keys are Phase 2 (see Improvements) |
+| `kafka.acks` | No | `all` | `0`, `1`, `all` — durability vs latency |
+| `kafka.compression` | No | `none` | `none`, `gzip`, `snappy`, `lz4`, `zstd` |
+| `kafka.linger.ms` | No | `5` | Batching delay |
+| `kafka.batch.size` | No | librdkafka default | Max batch bytes |
+| `kafka.enable.idempotence` | No | `false` | Exactly-once producer semantics (no duplicates on retry) |
+| `kafka.message.timeout.ms` | No | `30000` | Total time to deliver a record before it's reported failed |
+| `kafka.delivery.sync` | No | `false` | `true`: `publish()` blocks until the delivery report for that record (strict, slow). `false`: async enqueue + background delivery reports |
+| `kafka.flush.timeout.ms` | No | `30000` | Max wait for in-flight records during `stop()` |
+| `kafka.queue.full.strategy` | No | `block` | When librdkafka's local queue is full: `block` (backpressure, bounded retry) or `error` (fail fast into pipeline error handling) |
+| `kafka.security.protocol` / `kafka.sasl.*` / `kafka.ssl.*` | No | - | Same as source |
+| `kafka.rdkafka.<prop>` | No | - | Escape hatch, same as source |
+
+### Publish semantics
+
+- **Default (async)**: `publish()` enqueues into librdkafka's local queue and returns. Delivery
+  reports arrive on the `ThreadedProducer` poll thread via a `ProducerContext::delivery()`
+  callback, which increments failure counters and logs errors. This is the standard model for
+  Kafka sinks (Flink/Kafka Connect) and keeps pipeline throughput decoupled from broker RTT.
+- **Sync mode** (`kafka.delivery.sync=true`): `publish()` waits for that record's delivery report;
+  errors propagate to the caller (`SinkCallbackAdapter` currently logs them). Use for
+  low-throughput, strict pipelines.
+- **`stop()`**: `producer.flush(flush_timeout)`; logs a warning with the count of undelivered
+  records if the timeout is exceeded, then logs lifetime counters (produced, failed).
+- `validate_connectivity()`: `fetch_metadata(Some(topic), 10s)`; error if brokers unreachable or
+  topic missing.
+
+### `KafkaSink` structure
+
+```rust
+pub struct KafkaSinkConfig { /* fields per config table; from_properties() parsing */ }
+
+pub struct KafkaSink {
+    config: KafkaSinkConfig,
+    producer: Arc<Mutex<Option<ThreadedProducer<DeliveryContext>>>>,  // created in start()
+    metrics: Arc<SinkMetrics>,  // records_produced, records_failed (AtomicU64)
+}
+
+impl Sink for KafkaSink {
+    fn publish(&self, payload: &[u8]) -> Result<(), EventFluxError>;
+    fn start(&self);   // builds ClientConfig, creates ThreadedProducer
+    fn stop(&self);    // flush(timeout), log stats, drop producer
+    fn clone_box(&self) -> Box<dyn Sink>;
+    fn validate_connectivity(&self) -> Result<(), EventFluxError>;
+}
+```
+
+`KafkaSinkFactory` mirrors `RabbitMQSinkFactory` (name `"kafka"`, formats json/csv/bytes,
+required `kafka.bootstrap.servers` + `kafka.topic`).
+
+## Delivery Guarantees
+
+| Configuration | Guarantee |
+|---------------|-----------|
+| Source: `enable.auto.commit=true` (default) | Approx. at-most-once (offsets may be committed before pipeline processing completes) |
+| Source: `enable.auto.commit=false` | At-least-once (commit after successful delivery) |
+| Sink: `acks=all` (default) + async delivery | At-least-once to Kafka; delivery failures logged/counted, not retried by EventFlux (librdkafka retries internally until `message.timeout.ms`) |
+| Sink: `+ enable.idempotence=true` | At-least-once without producer-side duplicates |
+| End-to-end exactly-once (Kafka transactions) | **Deferred** — requires integrating producer transactions with EventFlux checkpointing |
+
+## Format Support
+
+Same mapper infrastructure as RabbitMQ: `json`, `csv`, `bytes` for both source and sink.
+Record **keys, headers, and timestamps are not exposed to the pipeline in v1** (the
+`SourceCallback` interface carries payload bytes only) — see Improvements below.
+
+## SQL Usage Example
+
+```sql
+CREATE STREAM TradeInput (
+    symbol STRING,
+    price DOUBLE,
+    volume INT
+) WITH (
+    type = 'source',
+    extension = 'kafka',
+    format = 'json',
+    "kafka.bootstrap.servers" = 'localhost:9092',
+    "kafka.topic" = 'trades-in',
+    "kafka.group.id" = 'eventflux-trades',
+    "kafka.enable.auto.commit" = 'false'
+);
+
+CREATE STREAM TradeOutput (
+    symbol STRING,
+    price DOUBLE,
+    volume INT,
+    price_category STRING
+) WITH (
+    type = 'sink',
+    extension = 'kafka',
+    format = 'json',
+    "kafka.bootstrap.servers" = 'localhost:9092',
+    "kafka.topic" = 'trades-out',
+    "kafka.acks" = 'all',
+    "kafka.compression" = 'lz4'
+);
+```
+
+Example file: `examples/kafka.eventflux` (mirroring `examples/rabbitmq.eventflux`, with
+`docker run -p 9092:9092 apache/kafka:3.9.1` prerequisites).
+
+## Dependency & Feature Gating
+
+Kafka is the first connector to use the **generic connector feature-gating framework** specified
+in `feat/connector-infra/README.md` Part 3. Summary as applied to Kafka:
+
+```toml
+[features]
+kafka = ["dep:rdkafka"]                                   # named after the extension name
+connectors-all = ["rabbitmq", "websocket", "kafka"]       # umbrella includes kafka
+
+[dependencies]
+rdkafka = { version = "0.37", features = ["cmake-build", "ssl-vendored"], optional = true }
+```
+
+- **Not in `default`** — per the framework rule, the default set is fully minimal
+  (`default = []`); no connectors ship in default builds.
+- All gating points follow the framework's per-connector checklist (module decl, re-exports,
+  registration, integration tests, examples note, cargo-machete metadata).
+- A build without the feature reports the framework's helpful error:
+  "Extension 'kafka' ... rebuild with `--features kafka` (or `--features connectors-all`)".
+- Release/Docker builds use `--features connectors-all`, so shipped artifacts include Kafka.
+- `ssl-vendored` statically links OpenSSL → SSL/SASL-SCRAM work without system OpenSSL.
+  GSSAPI/Kerberos is excluded (heavy system deps; niche).
+- Version note: pin to the latest rdkafka at implementation time; verify MSRV 1.85 compatibility.
+
+## Error Handling
+
+Identical integration to RabbitMQ: `ErrorConfigBuilder` / `SourceErrorContext`, strategies
+drop / retry / dlq / fail, DLQ junction wired post-creation by `stream_initializer` via
+`set_error_dlq_junction()`. The source factory uses the topic name as the error-context stream
+identifier (RabbitMQ uses the queue name).
+
+Additional Kafka-specific handling:
+- librdkafka transient errors (broker down, timeouts) are retried internally; the source only
+  surfaces persistent errors to the error strategy.
+- Fatal consumer errors (e.g. unknown topic after metadata refresh, auth failure) map to
+  `EventFluxError::ConnectionUnavailable` / `configuration` respectively.
+
+## Testing Plan
+
+### Unit tests (no broker) — in-module, mirroring RabbitMQ
+
+- Config parsing: required/optional params, defaults, invalid values, reserved `kafka.rdkafka.*`
+  keys rejected, SASL config validation (mechanism requires protocol, etc.)
+- Factory metadata: name, formats, required/optional parameter lists
+- Factory create: missing params error, valid config succeeds, error.* config accepted
+- Clone semantics: cloned source/sink has config but no live state
+
+### Integration tests (broker required) — `tests/kafka_integration.rs`, `#[ignore]`-gated
+
+Following `tests/rabbitmq_integration.rs` structure:
+- Source: consume produced records end-to-end (JSON format)
+- Sink: publish and verify via a raw rdkafka consumer
+- Round-trip: sink → topic → source through an EventFlux app
+- Manual commit: verify offset advances only after successful processing; verify redelivery
+  after simulated failure with `error.strategy=retry`
+- `validate_connectivity`: unreachable broker fails fast (<15s), missing topic fails
+- Graceful shutdown: `stop()` flushes producer, joins consumer thread
+
+### CI
+
+Add a Kafka service container to `.github/workflows/rust.yml` (single-node KRaft):
+
+```yaml
+kafka:
+  image: apache/kafka:3.9.1
+  ports:
+    - 9092:9092
+  options: >-
+    --health-cmd "/opt/kafka/bin/kafka-broker-api-versions.sh --bootstrap-server localhost:9092"
+    --health-interval 10s
+    --health-timeout 10s
+    --health-retries 10
+```
+
+The main test job builds with `--features connectors-all` (per the connector-infra CI strategy);
+integration tests via `cargo nextest run --test kafka_integration --run-ignored ignored-only`
+(same pattern as RabbitMQ). cmake is preinstalled on `ubuntu-latest` runners.
+
+## Implementation Plan
+
+| Phase | Scope |
+|-------|-------|
+| 0 | **Prerequisite, separate PRs**: `feat/connector-infra/README.md` — sink batch fix, source thread join, feature-gating framework |
+| 1 | `kafka` cargo feature + `kafka_source.rs` (config, source, factory, unit tests) |
+| 2 | `kafka_sink.rs` (config, sink, factory, delivery context, unit tests) |
+| 3 | Registration in `EventFluxContext`, remove Kafka stub from `example_factories.rs`, update stub-based tests in `extension/mod.rs` |
+| 4 | Integration tests + CI service (apache/kafka:3.9.1, confirmed) + `examples/kafka.eventflux` |
+| 5 | Docs: this file updated to "Implemented", ROADMAP.md, website connector docs, README feature-flags table entry |
+| 6 (follow-up) | Keyed publish interface (Improvement 2 below), per-event keys via `kafka.key.field` |
+
+### Files
+
+| File | Description |
+|------|-------------|
+| `src/core/stream/input/source/kafka_source.rs` | Kafka source and factory |
+| `src/core/stream/output/sink/kafka_sink.rs` | Kafka sink and factory |
+| `tests/kafka_integration.rs` | Integration tests |
+| `examples/kafka.eventflux` | Example query file |
+
+## Technical Improvements (found reviewing connector infrastructure)
+
+Numbered for review; each is independent. Items 1, 3, and 8 are now **specified in
+`feat/connector-infra/README.md`** and land before Kafka; 2 is a Kafka follow-up phase; the
+rest are noted for the backlog.
+
+### 1. `SinkCallbackAdapter` silently drops batched events (bug) — MOVED to connector-infra spec
+
+Specified in `feat/connector-infra/README.md` Part 1 (with the full per-mapper behavior audit:
+JSON drops N−1 events, CSV concatenates rows into one message, Bytes hard-errors on batches,
+Passthrough bincodes the batch). Fix: per-event adapter iteration + per-event
+`SinkMapper::map_event` contract. Kafka's one-record-per-event semantics depend on this.
+
+### 2. `Sink::publish(&[u8])` carries no event context — no per-event Kafka keys/headers
+
+The sink sees opaque bytes, so it cannot extract a partition key or headers from the event.
+Backward-compatible extension:
+
+```rust
+fn publish_event(&self, _event: &Event, payload: &[u8]) -> Result<(), EventFluxError> {
+    self.publish(payload)   // default: ignore event context
+}
+```
+
+`SinkCallbackAdapter` calls `publish_event`; existing sinks are untouched. The Kafka sink
+overrides it to resolve `kafka.key.field` → record key. Requires the factory to know the field's
+position: have `stream_initializer` (which holds the `StreamDefinition`) inject schema metadata
+into the properties map (e.g. `_schema.fields=symbol:STRING,price:DOUBLE,...`) before
+`create_initialized()` — a generic mechanism any connector can use. Same path later enables
+Kafka headers and source-side key/timestamp exposure.
+
+### 3. Source `stop()` never joins the consumer thread — MOVED to connector-infra spec
+
+Specified in `feat/connector-infra/README.md` Part 2: all three existing sources (RabbitMQ,
+WebSocket, Timer) discard their `JoinHandle`; fix adds handle retention + a shared
+`join_with_timeout` helper. Kafka uses that helper from day one.
+
+### 4. No reconnect/supervision for source connection loss
+
+If the RabbitMQ broker connection drops, the source thread logs and exits — the stream is dead
+until app restart, with nothing above it noticing. librdkafka reconnects internally so Kafka is
+immune, but the framework-level gap remains: a supervision policy (restart with backoff, surface
+"source dead" state, health hook) belongs in the runtime, not in each connector. Ties into
+ROADMAP Priority 9/10 (observability, production hardening).
+
+### 5. One tokio runtime per connector instance
+
+Each RabbitMQ/WebSocket source thread creates its own `tokio::runtime::Runtime`, and each sink
+holds an owned runtime + handle fallback chain. N connectors → N runtimes and thread pools.
+Standard fix: one shared I/O runtime on `EventFluxContext` that async connectors get a `Handle`
+to. (Kafka needs none, but the RabbitMQ/WebSocket code would shrink substantially.)
+
+### 6. No connector metrics
+
+No counters exist for records received/produced/failed — invisible in production and needed by
+ROADMAP Priority 9. Kafka connector ships with `AtomicU64` counters (received, produced, failed,
+last-error timestamp) from day one, logged at `stop()`; wiring into a metrics endpoint comes with
+the observability milestone. Consumer lag is available via rdkafka's statistics callback when
+metrics land.
+
+### 7. `validate_connectivity()` boilerplate duplication
+
+Every connector re-implements "connect with 10s timeout, map to ConnectionUnavailable, cleanup".
+The 10s value is hardcoded. Worth a shared helper with a configurable timeout
+(`connect.timeout.ms`) once a third network connector exists — Kafka keeps its implementation
+self-contained but accepts the timeout property.
+
+### 8. Unregistered-extension errors don't mention feature flags — MOVED to connector-infra spec
+
+Specified in `feat/connector-infra/README.md` Part 3 (`UNAVAILABLE_EXTENSIONS` table +
+stream_initializer hint). A binary built without the feature reports the rebuild instruction
+instead of a bare `Unknown source type: kafka`.
+
+### 9. Config parsing returns `Result<_, String>`
+
+`*Config::from_properties()` returns `Result<Self, String>` mapped to
+`EventFluxError::configuration` at the factory boundary. Kafka follows the same pattern for
+consistency; unifying on `EventFluxError` end-to-end is a mechanical cleanup for later.
+
+### 10. Placeholder stub drift
+
+`example_factories.rs`'s `KafkaSourceFactory` advertises `avro` (no avro mapper exists) and uses
+`kafka.timeout` (real config uses librdkafka names). The stub and its tests in
+`extension/mod.rs` are replaced in Phase 3 — keeping placeholder stubs for implemented
+connectors invites exactly this drift.
+
+## Deferred (post-v1) — tracked as GitHub issues
+
+| Feature | Reason | Issue |
+|---------|--------|-------|
+| Exactly-once (Kafka transactions) | Needs checkpoint-coordinated commit protocol | eventflux-io/eventflux#125 |
+| Per-event keys / topic routing / headers | Needs `publish_event` + schema injection (Improvement 2) | eventflux-io/eventflux#126 |
+| Avro / Schema Registry | No avro mapper in registry yet | eventflux-io/eventflux#127 |
+| Consumer lag + connector metrics | Lands with observability milestone (statistics callback) | eventflux-io/eventflux#128 |
+| Regex topic subscription | Niche; `subscribe` with explicit list covers v1 | eventflux-io/eventflux#129 |
+| Shared-helper adoption in older sources | Kept out of the Kafka PR (single purpose) | eventflux-io/eventflux#130 |
+| Source supervision on connection loss | Runtime-level design needed | eventflux-io/eventflux#131 |

--- a/justfile
+++ b/justfile
@@ -33,6 +33,7 @@ lint:
 # Feature-gating honesty: minimal build and each connector alone must compile
 check-minimal:
   cargo check --all-targets
+  cargo check --all-targets --features kafka
   cargo check --all-targets --features rabbitmq
   cargo check --all-targets --features websocket
 

--- a/src/core/config/eventflux_context.rs
+++ b/src/core/config/eventflux_context.rs
@@ -426,10 +426,14 @@ impl EventFluxContext {
             OrAttributeAggregatorFactory, StdDevAttributeAggregatorFactory,
             SumAttributeAggregatorFactory,
         };
+        #[cfg(feature = "kafka")]
+        use crate::core::stream::input::source::kafka_source::KafkaSourceFactory;
         #[cfg(feature = "rabbitmq")]
         use crate::core::stream::input::source::rabbitmq_source::RabbitMQSourceFactory;
         #[cfg(feature = "websocket")]
         use crate::core::stream::input::source::websocket_source::WebSocketSourceFactory;
+        #[cfg(feature = "kafka")]
+        use crate::core::stream::output::sink::kafka_sink::KafkaSinkFactory;
         #[cfg(feature = "rabbitmq")]
         use crate::core::stream::output::sink::rabbitmq_sink::RabbitMQSinkFactory;
         #[cfg(feature = "websocket")]
@@ -528,11 +532,15 @@ impl EventFluxContext {
         self.add_table_factory("jdbc".to_string(), Box::new(JdbcTableFactory));
         self.add_table_factory("cache".to_string(), Box::new(CacheTableFactory));
         self.add_source_factory("timer".to_string(), Box::new(TimerSourceFactory));
+        #[cfg(feature = "kafka")]
+        self.add_source_factory("kafka".to_string(), Box::new(KafkaSourceFactory));
         #[cfg(feature = "rabbitmq")]
         self.add_source_factory("rabbitmq".to_string(), Box::new(RabbitMQSourceFactory));
         #[cfg(feature = "websocket")]
         self.add_source_factory("websocket".to_string(), Box::new(WebSocketSourceFactory));
         self.add_sink_factory("log".to_string(), Box::new(LogSinkFactory));
+        #[cfg(feature = "kafka")]
+        self.add_sink_factory("kafka".to_string(), Box::new(KafkaSinkFactory));
         #[cfg(feature = "rabbitmq")]
         self.add_sink_factory("rabbitmq".to_string(), Box::new(RabbitMQSinkFactory));
         #[cfg(feature = "websocket")]

--- a/src/core/error/source_support.rs
+++ b/src/core/error/source_support.rs
@@ -108,6 +108,32 @@ impl SourceErrorContext {
         Ok(Self::new(error_config, dlq_junction, stream_name))
     }
 
+    /// Build from a raw `WITH`-clause properties map (convenience method).
+    ///
+    /// Returns `Ok(None)` when no `error.*` properties are configured —
+    /// exactly the optional-context shape every source stores. Collapses the
+    /// ErrorConfigBuilder/FlatConfig boilerplate previously copy-pasted into
+    /// each connector's `from_properties`.
+    pub fn from_properties(
+        properties: &std::collections::HashMap<String, String>,
+        dlq_junction: Option<Arc<Mutex<InputHandler>>>,
+        stream_name: &str,
+    ) -> Result<Option<Self>, String> {
+        if !ErrorConfigBuilder::from_properties(properties).is_configured() {
+            return Ok(None);
+        }
+
+        use crate::core::config::PropertySource;
+        let mut flat_config = FlatConfig::new();
+        for (key, value) in properties {
+            if key.starts_with("error.") {
+                flat_config.set(key.clone(), value.clone(), PropertySource::SqlWith);
+            }
+        }
+
+        Self::from_config(&flat_config, dlq_junction, stream_name.to_string()).map(Some)
+    }
+
     /// Handle an error and return whether to continue processing
     ///
     /// This method applies the error handling strategy and performs any
@@ -244,6 +270,70 @@ impl ErrorConfigBuilder {
     /// Build ErrorConfig with default if not configured
     pub fn build_or_default(&self) -> Result<ErrorConfig, String> {
         Ok(self.build()?.unwrap_or_default())
+    }
+}
+
+/// Outcome of delivering one payload through the error-handling strategy
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeliveryVerdict {
+    /// The pipeline accepted the payload
+    Delivered,
+    /// The error strategy disposed of it (drop or DLQ) — the record counts
+    /// as consumed and may be acknowledged/committed
+    Disposed,
+    /// Unrecoverable (fail strategy) — stop the source; do NOT acknowledge
+    /// or commit, so the record is redelivered after restart
+    Fail,
+}
+
+/// Deliver one payload to the pipeline, applying the source's error strategy.
+///
+/// Encapsulates the retry state machine every source needs: retry until
+/// success or a non-retry action, build a DLQ fallback event from the raw
+/// bytes, reset the error counter on success. Transport-specific
+/// acknowledgement stays with the caller, keyed off the verdict:
+/// `Delivered`/`Disposed` → ack/commit, `Fail` → don't ack, stop the source.
+pub fn deliver_with_error_handling(
+    callback: &dyn crate::core::stream::input::source::SourceCallback,
+    payload: &[u8],
+    error_ctx: &mut Option<SourceErrorContext>,
+    source_tag: &str,
+) -> DeliveryVerdict {
+    loop {
+        match callback.on_data(payload) {
+            Ok(()) => {
+                if let Some(ctx) = error_ctx {
+                    ctx.reset_errors();
+                }
+                return DeliveryVerdict::Delivered;
+            }
+            Err(e) => {
+                let action = if let Some(ctx) = error_ctx {
+                    // Fallback event from raw bytes for DLQ support — only
+                    // built when a strategy exists to consume it
+                    let fallback_event = Event::new_with_data(
+                        std::time::SystemTime::now()
+                            .duration_since(std::time::UNIX_EPOCH)
+                            .map(|d| d.as_millis() as i64)
+                            .unwrap_or(0),
+                        vec![crate::core::event::value::AttributeValue::Bytes(
+                            payload.to_vec(),
+                        )],
+                    );
+                    ctx.handle_error_with_action(Some(&fallback_event), &e)
+                } else {
+                    log::error!("[{source_tag}] Callback error: {e}");
+                    ErrorAction::Drop
+                };
+
+                match action {
+                    // Delay already applied by handle_error_with_action
+                    ErrorAction::Retry { .. } => continue,
+                    ErrorAction::Drop | ErrorAction::SendToDlq => return DeliveryVerdict::Disposed,
+                    ErrorAction::Fail => return DeliveryVerdict::Fail,
+                }
+            }
+        }
     }
 }
 

--- a/src/core/extension/example_factories.rs
+++ b/src/core/extension/example_factories.rs
@@ -20,10 +20,11 @@
 //! This module contains placeholder factories for demonstration purposes:
 //!
 //! ## Placeholder Factories (NOT production-ready)
-//! - `KafkaSourceFactory` - Placeholder for future Kafka integration
+//! - `ExampleSourceFactory` - Fictional source demonstrating the factory pattern
 //! - `HttpSinkFactory` - Placeholder for future HTTP sink
 //!
 //! ## Production-Ready Factories (in proper modules)
+//! - `KafkaSourceFactory`/`KafkaSinkFactory` in `kafka_source.rs`/`kafka_sink.rs`
 //! - `RabbitMQSourceFactory` in `src/core/stream/input/source/rabbitmq_source.rs`
 //! - `RabbitMQSinkFactory` in `src/core/stream/output/sink/rabbitmq_sink.rs`
 //! - `TimerSourceFactory` in `src/core/extension/mod.rs`
@@ -41,30 +42,30 @@ use crate::core::stream::output::sink::Sink;
 use std::collections::HashMap;
 
 // ============================================================================
-// Kafka Source Factory (Placeholder)
+// Example Source Factory (Placeholder)
 // ============================================================================
 
-/// Kafka-specific validated configuration (INTERNAL to KafkaSourceFactory)
+/// Example validated configuration (INTERNAL to ExampleSourceFactory)
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
-struct KafkaSourceConfig {
+struct ExampleSourceConfig {
     bootstrap_servers: Vec<String>,
     topic: String,
     consumer_group: String,
     timeout_ms: u64,
 }
 
-impl KafkaSourceConfig {
+impl ExampleSourceConfig {
     /// Parse and validate raw config into typed config (PRIVATE helper)
     fn parse(raw_config: &HashMap<String, String>) -> Result<Self, EventFluxError> {
         // 1. Validate required parameters present
         let brokers_str = raw_config
-            .get("kafka.bootstrap.servers")
-            .ok_or_else(|| EventFluxError::missing_parameter("kafka.bootstrap.servers"))?;
+            .get("example.servers")
+            .ok_or_else(|| EventFluxError::missing_parameter("example.servers"))?;
 
         let topic = raw_config
-            .get("kafka.topic")
-            .ok_or_else(|| EventFluxError::missing_parameter("kafka.topic"))?;
+            .get("example.topic")
+            .ok_or_else(|| EventFluxError::missing_parameter("example.topic"))?;
 
         // 2. Parse comma-separated brokers list
         let bootstrap_servers: Vec<String> = brokers_str
@@ -75,20 +76,20 @@ impl KafkaSourceConfig {
 
         if bootstrap_servers.is_empty() {
             return Err(EventFluxError::configuration_with_key(
-                "kafka.bootstrap.servers cannot be empty",
-                "kafka.bootstrap.servers",
+                "example.servers cannot be empty",
+                "example.servers",
             ));
         }
 
         // 3. Parse optional integer
         let timeout_ms = raw_config
-            .get("kafka.timeout")
+            .get("example.timeout")
             .map(|s| s.parse::<u64>())
             .transpose()
             .map_err(|_| {
                 EventFluxError::invalid_parameter_with_details(
-                    "kafka.timeout must be a valid integer",
-                    "kafka.timeout",
+                    "example.timeout must be a valid integer",
+                    "example.timeout",
                     "positive integer (milliseconds)",
                 )
             })?
@@ -96,12 +97,12 @@ impl KafkaSourceConfig {
 
         // 4. Parse consumer group (with default)
         let consumer_group = raw_config
-            .get("kafka.consumer.group")
+            .get("example.consumer.group")
             .cloned()
             .unwrap_or_else(|| format!("eventflux-{}", topic));
 
         // 5. Return typed config
-        Ok(KafkaSourceConfig {
+        Ok(ExampleSourceConfig {
             bootstrap_servers,
             topic: topic.clone(),
             consumer_group,
@@ -110,46 +111,48 @@ impl KafkaSourceConfig {
     }
 }
 
-/// Placeholder Kafka Source (actual implementation would use rdkafka)
+/// Placeholder Source demonstrating the trait surface
 #[derive(Debug)]
-struct KafkaSource {
+struct ExampleSource {
     _topic: String,
     _bootstrap_servers: Vec<String>,
 }
 
-impl Source for KafkaSource {
+impl Source for ExampleSource {
     fn start(
         &mut self,
         _callback: std::sync::Arc<dyn crate::core::stream::input::source::SourceCallback>,
     ) {
         // Placeholder: actual implementation would:
-        // 1. Read bytes from Kafka
+        // 1. Read bytes from the external system
         // 2. Call callback.on_data(bytes)
         // 3. Callback handles parsing via SourceMapper
     }
 
     fn stop(&mut self) {
-        // Placeholder: actual implementation would stop Kafka consumer
+        // Placeholder: actual implementation would stop the worker
+        // (embed a SourceWorker — see docs/writing_extensions.md)
     }
 
     fn clone_box(&self) -> Box<dyn Source> {
-        Box::new(KafkaSource {
+        Box::new(ExampleSource {
             _topic: self._topic.clone(),
             _bootstrap_servers: self._bootstrap_servers.clone(),
         })
     }
 }
 
-/// Placeholder Kafka source factory.
+/// Placeholder source factory demonstrating metadata + validated creation.
 ///
-/// This is NOT production-ready. For a production implementation example,
-/// see `RabbitMQSourceFactory` in `rabbitmq_source.rs`.
+/// This is NOT production-ready. For production implementation examples,
+/// see `KafkaSourceFactory` in `kafka_source.rs` or `RabbitMQSourceFactory`
+/// in `rabbitmq_source.rs`.
 #[derive(Debug, Clone)]
-pub struct KafkaSourceFactory;
+pub struct ExampleSourceFactory;
 
-impl SourceFactory for KafkaSourceFactory {
+impl SourceFactory for ExampleSourceFactory {
     fn name(&self) -> &'static str {
-        "kafka"
+        "example"
     }
 
     fn supported_formats(&self) -> &[&str] {
@@ -157,11 +160,11 @@ impl SourceFactory for KafkaSourceFactory {
     }
 
     fn required_parameters(&self) -> &[&str] {
-        &["kafka.bootstrap.servers", "kafka.topic"]
+        &["example.servers", "example.topic"]
     }
 
     fn optional_parameters(&self) -> &[&str] {
-        &["kafka.consumer.group", "kafka.timeout"]
+        &["example.consumer.group", "example.timeout"]
     }
 
     fn create_initialized(
@@ -169,16 +172,15 @@ impl SourceFactory for KafkaSourceFactory {
         config: &HashMap<String, String>,
     ) -> Result<Box<dyn Source>, EventFluxError> {
         // 1. Parse and validate configuration
-        let parsed = KafkaSourceConfig::parse(config)?;
+        let parsed = ExampleSourceConfig::parse(config)?;
 
-        // 2. Create Kafka source (in real implementation, would create rdkafka consumer)
-        // This is a placeholder - actual implementation would:
-        // - Create rdkafka consumer with parsed config
+        // 2. Create the source. A real implementation would:
+        // - Create the client with parsed config
         // - Test connectivity (fail-fast)
         // - Return fully initialized Source
 
         // 3. Return fully initialized Source
-        Ok(Box::new(KafkaSource {
+        Ok(Box::new(ExampleSource {
             _topic: parsed.topic,
             _bootstrap_servers: parsed.bootstrap_servers,
         }))
@@ -324,15 +326,12 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_kafka_source_config_parse() {
+    fn test_example_source_config_parse() {
         let mut config = HashMap::new();
-        config.insert(
-            "kafka.bootstrap.servers".to_string(),
-            "localhost:9092".to_string(),
-        );
-        config.insert("kafka.topic".to_string(), "test-topic".to_string());
+        config.insert("example.servers".to_string(), "localhost:9092".to_string());
+        config.insert("example.topic".to_string(), "test-topic".to_string());
 
-        let parsed = KafkaSourceConfig::parse(&config).unwrap();
+        let parsed = ExampleSourceConfig::parse(&config).unwrap();
         assert_eq!(parsed.bootstrap_servers, vec!["localhost:9092"]);
         assert_eq!(parsed.topic, "test-topic");
         assert_eq!(parsed.consumer_group, "eventflux-test-topic");
@@ -340,9 +339,9 @@ mod tests {
     }
 
     #[test]
-    fn test_kafka_source_config_missing_required() {
+    fn test_example_source_config_missing_required() {
         let config = HashMap::new();
-        let result = KafkaSourceConfig::parse(&config);
+        let result = ExampleSourceConfig::parse(&config);
         assert!(result.is_err());
         assert!(matches!(
             result.unwrap_err(),
@@ -351,18 +350,18 @@ mod tests {
     }
 
     #[test]
-    fn test_kafka_source_config_empty_brokers() {
+    fn test_example_source_config_empty_brokers() {
         let mut config = HashMap::new();
-        config.insert("kafka.bootstrap.servers".to_string(), "".to_string());
-        config.insert("kafka.topic".to_string(), "test".to_string());
+        config.insert("example.servers".to_string(), "".to_string());
+        config.insert("example.topic".to_string(), "test".to_string());
 
-        let result = KafkaSourceConfig::parse(&config);
+        let result = ExampleSourceConfig::parse(&config);
         assert!(result.is_err());
     }
 
     #[test]
-    fn test_kafka_factory_supported_formats() {
-        let factory = KafkaSourceFactory;
+    fn test_example_factory_supported_formats() {
+        let factory = ExampleSourceFactory;
         assert!(factory.supported_formats().contains(&"json"));
         assert!(factory.supported_formats().contains(&"avro"));
         assert!(!factory.supported_formats().contains(&"xml"));
@@ -395,13 +394,10 @@ mod tests {
 
     #[test]
     fn test_factory_create_initialized() {
-        let factory = KafkaSourceFactory;
+        let factory = ExampleSourceFactory;
         let mut config = HashMap::new();
-        config.insert(
-            "kafka.bootstrap.servers".to_string(),
-            "localhost:9092".to_string(),
-        );
-        config.insert("kafka.topic".to_string(), "test".to_string());
+        config.insert("example.servers".to_string(), "localhost:9092".to_string());
+        config.insert("example.topic".to_string(), "test".to_string());
 
         let result = factory.create_initialized(&config);
         assert!(result.is_ok());
@@ -409,7 +405,7 @@ mod tests {
 
     #[test]
     fn test_factory_create_initialized_missing_params() {
-        let factory = KafkaSourceFactory;
+        let factory = ExampleSourceFactory;
         let config = HashMap::new();
 
         let result = factory.create_initialized(&config);

--- a/src/core/extension/mod.rs
+++ b/src/core/extension/mod.rs
@@ -641,7 +641,7 @@ pub const REGISTER_SINK_MAPPERS_FN: &[u8] = b"register_sink_mappers";
 mod tests {
     use super::*;
     use crate::core::config::eventflux_context::EventFluxContext;
-    use crate::core::extension::example_factories::{HttpSinkFactory, KafkaSourceFactory};
+    use crate::core::extension::example_factories::{ExampleSourceFactory, HttpSinkFactory};
 
     #[test]
     fn test_factory_registration() {
@@ -658,13 +658,13 @@ mod tests {
     }
 
     #[test]
-    fn test_kafka_source_factory_registration() {
+    fn test_example_source_factory_registration() {
         let context = EventFluxContext::new();
-        context.add_source_factory("kafka".to_string(), Box::new(KafkaSourceFactory));
+        context.add_source_factory("example".to_string(), Box::new(ExampleSourceFactory));
 
-        let factory = context.get_source_factory("kafka");
+        let factory = context.get_source_factory("example");
         assert!(factory.is_some());
-        assert_eq!(factory.unwrap().name(), "kafka");
+        assert_eq!(factory.unwrap().name(), "example");
     }
 
     #[test]
@@ -676,16 +676,16 @@ mod tests {
             "Timer should not support external formats (uses binary passthrough)"
         );
 
-        // Kafka supports external formats
-        let kafka_factory = KafkaSourceFactory;
-        assert!(kafka_factory.supported_formats().contains(&"json"));
-        assert!(kafka_factory.supported_formats().contains(&"avro"));
-        assert!(!kafka_factory.supported_formats().contains(&"xml"));
+        // The example stub advertises external formats
+        let example_factory = ExampleSourceFactory;
+        assert!(example_factory.supported_formats().contains(&"json"));
+        assert!(example_factory.supported_formats().contains(&"avro"));
+        assert!(!example_factory.supported_formats().contains(&"xml"));
     }
 
     #[test]
     fn test_create_initialized_missing_params() {
-        let factory = KafkaSourceFactory;
+        let factory = ExampleSourceFactory;
         let config = std::collections::HashMap::new();
 
         let result = factory.create_initialized(&config);
@@ -698,10 +698,10 @@ mod tests {
 
     #[test]
     fn test_create_initialized_invalid_config() {
-        let factory = KafkaSourceFactory;
+        let factory = ExampleSourceFactory;
         let mut config = std::collections::HashMap::new();
-        config.insert("kafka.bootstrap.servers".to_string(), "".to_string());
-        config.insert("kafka.topic".to_string(), "test".to_string());
+        config.insert("example.servers".to_string(), "".to_string());
+        config.insert("example.topic".to_string(), "test".to_string());
 
         let result = factory.create_initialized(&config);
         assert!(result.is_err());
@@ -713,13 +713,10 @@ mod tests {
 
     #[test]
     fn test_create_initialized_valid_config() {
-        let factory = KafkaSourceFactory;
+        let factory = ExampleSourceFactory;
         let mut config = std::collections::HashMap::new();
-        config.insert(
-            "kafka.bootstrap.servers".to_string(),
-            "localhost:9092".to_string(),
-        );
-        config.insert("kafka.topic".to_string(), "test-topic".to_string());
+        config.insert("example.servers".to_string(), "localhost:9092".to_string());
+        config.insert("example.topic".to_string(), "test-topic".to_string());
 
         let result = factory.create_initialized(&config);
         assert!(result.is_ok());
@@ -775,10 +772,10 @@ mod tests {
     #[test]
     fn test_factory_lookup_and_validation() {
         let context = EventFluxContext::new();
-        context.add_source_factory("kafka".to_string(), Box::new(KafkaSourceFactory));
+        context.add_source_factory("example".to_string(), Box::new(ExampleSourceFactory));
 
         // 1. Look up source factory by extension
-        let source_factory = context.get_source_factory("kafka");
+        let source_factory = context.get_source_factory("example");
         assert!(source_factory.is_some());
         let source_factory = source_factory.unwrap();
 
@@ -788,11 +785,8 @@ mod tests {
 
         // 3. Create fully initialized instances
         let mut source_config = std::collections::HashMap::new();
-        source_config.insert(
-            "kafka.bootstrap.servers".to_string(),
-            "localhost:9092".to_string(),
-        );
-        source_config.insert("kafka.topic".to_string(), "test".to_string());
+        source_config.insert("example.servers".to_string(), "localhost:9092".to_string());
+        source_config.insert("example.topic".to_string(), "test".to_string());
 
         let source = source_factory.create_initialized(&source_config);
         assert!(source.is_ok());
@@ -800,10 +794,10 @@ mod tests {
 
     #[test]
     fn test_unsupported_format_detection() {
-        let factory = KafkaSourceFactory;
+        let factory = ExampleSourceFactory;
         let format = "xml";
 
-        // Kafka doesn't support XML format
+        // The example stub doesn't support XML format
         assert!(!factory.supported_formats().contains(&format));
     }
 
@@ -817,15 +811,13 @@ mod tests {
 
     #[test]
     fn test_source_factory_parameters() {
-        let factory = KafkaSourceFactory;
-        assert!(factory
-            .required_parameters()
-            .contains(&"kafka.bootstrap.servers"));
-        assert!(factory.required_parameters().contains(&"kafka.topic"));
+        let factory = ExampleSourceFactory;
+        assert!(factory.required_parameters().contains(&"example.servers"));
+        assert!(factory.required_parameters().contains(&"example.topic"));
         assert!(factory
             .optional_parameters()
-            .contains(&"kafka.consumer.group"));
-        assert!(factory.optional_parameters().contains(&"kafka.timeout"));
+            .contains(&"example.consumer.group"));
+        assert!(factory.optional_parameters().contains(&"example.timeout"));
     }
 
     #[test]

--- a/src/core/stream/input/source/kafka_source.rs
+++ b/src/core/stream/input/source/kafka_source.rs
@@ -1,0 +1,769 @@
+/*
+ * Copyright 2025-2026 EventFlux.io
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! # Kafka Source
+//!
+//! Consumes records from Kafka topics and delivers their payloads to the
+//! EventFlux pipeline.
+//!
+//! ## Architecture
+//!
+//! Unlike the RabbitMQ/WebSocket sources, no tokio runtime is needed:
+//! librdkafka runs its own background threads (network I/O, reconnection),
+//! and the synchronous `BaseConsumer` poll loop maps directly onto the
+//! [`SourceWorker`] thread:
+//!
+//! ```text
+//! Kafka topic → BaseConsumer::poll(100ms) → bytes → SourceCallback → SourceMapper → Events
+//! ```
+//!
+//! ## Delivery semantics
+//!
+//! - `kafka.enable.auto.commit = true` (default): librdkafka stores and
+//!   commits offsets on its own — commits can precede processing
+//!   (approximately at-most-once).
+//! - `kafka.enable.auto.commit = false`: an offset enters the commit path
+//!   only after the pipeline accepted the record (or the error strategy
+//!   explicitly disposed of it via drop/DLQ) — at-least-once. Commits flush
+//!   every `auto.commit.interval.ms` (librdkafka default 5s, tunable via
+//!   `kafka.rdkafka.auto.commit.interval.ms`) plus synchronously on
+//!   rebalance and shutdown.
+//!
+//! ## Example Usage
+//!
+//! ```rust,ignore
+//! use std::collections::HashMap;
+//!
+//! let mut properties = HashMap::new();
+//! properties.insert("kafka.bootstrap.servers".to_string(), "localhost:9092".to_string());
+//! properties.insert("kafka.topic".to_string(), "events".to_string());
+//!
+//! let source = KafkaSource::from_properties(&properties, None, "KafkaStream")?;
+//! ```
+
+use super::{Source, SourceCallback, SourceWorker};
+use crate::core::error::source_support::{
+    deliver_with_error_handling, DeliveryVerdict, SourceErrorContext,
+};
+use crate::core::exception::EventFluxError;
+use crate::core::extension::SourceFactory;
+use crate::core::stream::input::input_handler::InputHandler;
+use crate::core::stream::kafka_common::{parse_or, validate_topics_exist, KafkaConnectionConfig};
+use rdkafka::client::ClientContext;
+use rdkafka::consumer::{BaseConsumer, Consumer, ConsumerContext, Rebalance};
+use rdkafka::message::Message;
+use std::collections::HashMap;
+use std::fmt::Debug;
+use std::sync::atomic::Ordering;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+/// librdkafka settings owned by first-class config fields — rejected when
+/// passed through the `kafka.rdkafka.*` escape hatch to avoid two sources of
+/// truth for the same knob.
+const RESERVED_RDKAFKA_KEYS: &[&str] = &[
+    "bootstrap.servers",
+    "group.id",
+    "enable.auto.commit",
+    "enable.auto.offset.store",
+    "auto.offset.reset",
+];
+
+/// Configuration for Kafka source
+#[derive(Debug, Clone)]
+pub struct KafkaSourceConfig {
+    /// Broker connection + security settings (shared with the sink)
+    pub connection: KafkaConnectionConfig,
+    /// Topics to consume (parsed from comma-separated `kafka.topic`)
+    pub topics: Vec<String>,
+    /// Consumer group id (default: `eventflux-<first-topic>`, deterministic
+    /// so committed offsets survive restarts)
+    pub group_id: String,
+    /// Where to start when no committed offset exists (`earliest`/`latest`)
+    pub auto_offset_reset: String,
+    /// true: librdkafka commits periodically (~at-most-once).
+    /// false: commit after successful pipeline delivery (at-least-once).
+    pub enable_auto_commit: bool,
+    /// Poll timeout; bounds shutdown latency (default 100ms)
+    pub poll_timeout_ms: u64,
+}
+
+impl KafkaSourceConfig {
+    /// Parse configuration from properties HashMap
+    pub fn from_properties(properties: &HashMap<String, String>) -> Result<Self, String> {
+        let connection = KafkaConnectionConfig::from_properties(properties, RESERVED_RDKAFKA_KEYS)?;
+
+        // Required: topic(s)
+        let topics: Vec<String> = properties
+            .get("kafka.topic")
+            .ok_or("Missing required property: kafka.topic")?
+            .split(',')
+            .map(|t| t.trim().to_string())
+            .filter(|t| !t.is_empty())
+            .collect();
+        if topics.is_empty() {
+            return Err("kafka.topic cannot be empty".to_string());
+        }
+
+        // Deterministic default group id keeps committed offsets across restarts
+        let group_id = properties
+            .get("kafka.group.id")
+            .cloned()
+            .unwrap_or_else(|| format!("eventflux-{}", topics[0]));
+
+        let auto_offset_reset = properties
+            .get("kafka.auto.offset.reset")
+            .cloned()
+            .unwrap_or_else(|| "latest".to_string());
+        if auto_offset_reset != "earliest" && auto_offset_reset != "latest" {
+            return Err(format!(
+                "Invalid kafka.auto.offset.reset '{auto_offset_reset}': expected 'earliest' or 'latest'"
+            ));
+        }
+
+        let enable_auto_commit = parse_or(properties, "kafka.enable.auto.commit", true)?;
+        let poll_timeout_ms = parse_or(properties, "kafka.poll.timeout.ms", 100)?;
+
+        Ok(Self {
+            connection,
+            topics,
+            group_id,
+            auto_offset_reset,
+            enable_auto_commit,
+            poll_timeout_ms,
+        })
+    }
+
+    /// Build the librdkafka client configuration
+    ///
+    /// Offset semantics follow the canonical librdkafka at-least-once
+    /// pattern: the internal auto-committer is ALWAYS on (it periodically
+    /// flushes the local offset store, commits on rebalance, and commits on
+    /// close). What `kafka.enable.auto.commit` really controls is what goes
+    /// INTO that store:
+    ///
+    /// - `true` (default): librdkafka auto-stores every polled offset —
+    ///   commits can precede processing (~at-most-once)
+    /// - `false`: auto-store is disabled and the consume loop stores an
+    ///   offset only AFTER the pipeline accepted the record — every commit,
+    ///   from any path, covers only processed records (at-least-once)
+    pub fn to_client_config(&self) -> rdkafka::config::ClientConfig {
+        let mut config = rdkafka::config::ClientConfig::new();
+        config
+            .set("group.id", &self.group_id)
+            .set("enable.auto.commit", "true")
+            .set(
+                "enable.auto.offset.store",
+                self.enable_auto_commit.to_string(),
+            )
+            .set("auto.offset.reset", &self.auto_offset_reset);
+        self.connection.apply_to(&mut config);
+        config
+    }
+}
+
+/// Consumer context that logs rebalance events and, in manual-commit mode,
+/// sync-commits pending offsets before partitions are revoked
+struct KafkaSourceContext {
+    /// true when `kafka.enable.auto.commit = false`
+    manual_commit: bool,
+}
+
+impl ClientContext for KafkaSourceContext {}
+
+impl ConsumerContext for KafkaSourceContext {
+    fn pre_rebalance(&self, consumer: &BaseConsumer<Self>, rebalance: &Rebalance<'_>) {
+        log::debug!("[KafkaSource] Pre-rebalance: {rebalance:?}");
+
+        // In manual-commit mode, flush pending async commits before losing
+        // the partitions — otherwise a commit that races the revoke is
+        // dropped and the records are redelivered (duplicate outputs).
+        if self.manual_commit && matches!(rebalance, Rebalance::Revoke(_)) {
+            if let Err(e) = consumer.commit_consumer_state(rdkafka::consumer::CommitMode::Sync) {
+                // "No offset stored" simply means nothing pending
+                log::debug!("[KafkaSource] Commit on revoke: {e}");
+            }
+        }
+    }
+
+    fn post_rebalance(&self, _consumer: &BaseConsumer<Self>, rebalance: &Rebalance<'_>) {
+        log::info!("[KafkaSource] Post-rebalance: {rebalance:?}");
+    }
+}
+
+/// Mark a record as processed in manual-commit mode.
+///
+/// The offset goes into librdkafka's local store; the internal committer
+/// (plus the revoke/shutdown sync commits) flushes it to the broker. Only
+/// offsets stored here are ever committed, which is what makes the
+/// at-least-once guarantee hold on every commit path. In auto-commit mode
+/// librdkafka stores offsets itself, so this is a no-op.
+fn store_processed_offset(
+    consumer: &BaseConsumer<KafkaSourceContext>,
+    msg: &rdkafka::message::BorrowedMessage<'_>,
+    auto_commit: bool,
+) {
+    if auto_commit {
+        return;
+    }
+    if let Err(e) = consumer.store_offset_from_message(msg) {
+        // Typically the partition was just revoked — the record will be
+        // redelivered to its new owner (at-least-once)
+        log::warn!("[KafkaSource] Failed to store offset: {e}");
+    }
+}
+
+/// Kafka source that consumes records from one or more topics
+///
+/// This implementation:
+/// - Uses the sync `BaseConsumer` poll loop on a [`SourceWorker`] thread —
+///   no tokio runtime needed; librdkafka handles I/O and reconnection
+/// - Supports at-least-once delivery via commit-after-success
+/// - Integrates with the `error.*` handling strategies
+#[derive(Debug)]
+pub struct KafkaSource {
+    /// Configuration
+    config: KafkaSourceConfig,
+    /// Worker thread lifecycle (spawn, signal, join on stop)
+    worker: SourceWorker,
+    /// Optional error handling context
+    error_ctx: Option<SourceErrorContext>,
+}
+
+impl KafkaSource {
+    /// Create a new Kafka source without error handling
+    pub fn new(config: KafkaSourceConfig) -> Self {
+        Self {
+            config,
+            worker: SourceWorker::new("KafkaSource"),
+            error_ctx: None,
+        }
+    }
+
+    /// Create a Kafka source from properties
+    ///
+    /// # Required Properties
+    /// - `kafka.bootstrap.servers`: Comma-separated broker list
+    /// - `kafka.topic`: Topic(s) to consume, comma-separated for multiple
+    ///
+    /// # Optional Properties
+    /// - `kafka.group.id`: Consumer group (default: `eventflux-<first-topic>`)
+    /// - `kafka.auto.offset.reset`: `earliest`/`latest` (default: `latest`)
+    /// - `kafka.enable.auto.commit`: default `true`; `false` = at-least-once
+    /// - `kafka.poll.timeout.ms`: Poll timeout (default: 100)
+    /// - `kafka.security.protocol`, `kafka.sasl.*`, `kafka.ssl.ca.location`
+    /// - `kafka.rdkafka.<prop>`: Verbatim librdkafka overrides
+    /// - `error.*`: Error handling properties (see SourceErrorContext)
+    pub fn from_properties(
+        properties: &HashMap<String, String>,
+        dlq_junction: Option<Arc<Mutex<InputHandler>>>,
+        stream_name: &str,
+    ) -> Result<Self, String> {
+        let config = KafkaSourceConfig::from_properties(properties)?;
+        let error_ctx = SourceErrorContext::from_properties(properties, dlq_junction, stream_name)?;
+
+        Ok(Self {
+            error_ctx,
+            ..Self::new(config)
+        })
+    }
+}
+
+impl Clone for KafkaSource {
+    fn clone(&self) -> Self {
+        Self {
+            config: self.config.clone(),
+            worker: self.worker.clone(), // Clones as a fresh, unstarted worker
+            error_ctx: None,             // Error context contains runtime state, not cloneable
+        }
+    }
+}
+
+impl Source for KafkaSource {
+    fn start(&mut self, callback: Arc<dyn SourceCallback>) {
+        let config = self.config.clone();
+        let mut error_ctx = self.error_ctx.take();
+
+        self.worker.start(move |running| {
+            // Setup failures (create/subscribe) are all reported the same way
+            let report_fatal = |error_ctx: &mut Option<SourceErrorContext>, err: EventFluxError| {
+                if let Some(ctx) = error_ctx {
+                    ctx.handle_error(None, &err);
+                } else {
+                    log::error!("[KafkaSource] {err}");
+                }
+            };
+
+            // Create consumer inside the worker thread
+            let context = KafkaSourceContext {
+                manual_commit: !config.enable_auto_commit,
+            };
+            let consumer: BaseConsumer<KafkaSourceContext> =
+                match config.to_client_config().create_with_context(context) {
+                    Ok(c) => c,
+                    Err(e) => {
+                        report_fatal(
+                            &mut error_ctx,
+                            EventFluxError::ConnectionUnavailable {
+                                message: format!("Failed to create Kafka consumer: {e}"),
+                                source: Some(Box::new(e)),
+                            },
+                        );
+                        return;
+                    }
+                };
+
+            let topic_refs: Vec<&str> = config.topics.iter().map(String::as_str).collect();
+            if let Err(e) = consumer.subscribe(&topic_refs) {
+                report_fatal(
+                    &mut error_ctx,
+                    EventFluxError::ConnectionUnavailable {
+                        message: format!("Failed to subscribe to {:?}: {e}", config.topics),
+                        source: Some(Box::new(e)),
+                    },
+                );
+                return;
+            }
+
+            log::info!(
+                "[KafkaSource] Consuming topics {:?} (group '{}')",
+                config.topics,
+                config.group_id
+            );
+
+            let poll_timeout = Duration::from_millis(config.poll_timeout_ms);
+            // Only the worker thread touches these — plain integers suffice
+            let mut records_received: u64 = 0;
+            let mut records_failed: u64 = 0;
+
+            'poll: while running.load(Ordering::SeqCst) {
+                match consumer.poll(poll_timeout) {
+                    None => continue, // Timeout — re-check running flag
+                    Some(Err(e)) => {
+                        // librdkafka retries transient broker errors internally;
+                        // errors surfacing here go through the error strategy.
+                        let err = EventFluxError::ConnectionUnavailable {
+                            message: format!("Kafka consumer error: {e}"),
+                            source: Some(Box::new(e)),
+                        };
+                        if let Some(ctx) = &mut error_ctx {
+                            if !ctx.handle_error(None, &err) {
+                                break;
+                            }
+                        } else {
+                            log::error!("[KafkaSource] {err}");
+                        }
+                    }
+                    Some(Ok(msg)) => {
+                        // Tombstones / empty payloads carry no event data,
+                        // but still count as consumed — store their offset
+                        // so commits advance past them.
+                        let Some(payload) = msg.payload().filter(|p| !p.is_empty()) else {
+                            log::debug!(
+                                "[KafkaSource] Skipping empty payload at {}:{}@{}",
+                                msg.topic(),
+                                msg.partition(),
+                                msg.offset()
+                            );
+                            store_processed_offset(&consumer, &msg, config.enable_auto_commit);
+                            continue;
+                        };
+
+                        records_received += 1;
+
+                        let verdict = deliver_with_error_handling(
+                            callback.as_ref(),
+                            payload,
+                            &mut error_ctx,
+                            "KafkaSource",
+                        );
+
+                        match verdict {
+                            DeliveryVerdict::Delivered | DeliveryVerdict::Disposed => {
+                                if verdict == DeliveryVerdict::Disposed {
+                                    records_failed += 1;
+                                }
+                                // Delivered, dropped, or routed to DLQ — the
+                                // record is consumed: store its offset so the
+                                // committer advances past it (at-least-once).
+                                store_processed_offset(&consumer, &msg, config.enable_auto_commit);
+                            }
+                            DeliveryVerdict::Fail => {
+                                // Do NOT store — no commit path can advance
+                                // past this record, so it is redelivered
+                                // after restart.
+                                records_failed += 1;
+                                log::error!("[KafkaSource] Unrecoverable error, stopping");
+                                break 'poll;
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Final synchronous commit of the stored (= processed) offsets so
+            // graceful restarts resume exactly where processing left off
+            if !config.enable_auto_commit {
+                if let Err(e) = consumer.commit_consumer_state(rdkafka::consumer::CommitMode::Sync)
+                {
+                    // "No offset stored" simply means nothing to commit
+                    log::debug!("[KafkaSource] Final commit: {e}");
+                }
+            }
+            consumer.unsubscribe();
+
+            log::info!(
+                "[KafkaSource] Stopped (received: {records_received}, failed: {records_failed})"
+            );
+        });
+    }
+
+    fn stop(&mut self) {
+        log::info!("[KafkaSource] Stopping...");
+        self.worker.stop();
+    }
+
+    fn clone_box(&self) -> Box<dyn Source> {
+        Box::new(self.clone())
+    }
+
+    fn set_error_dlq_junction(&mut self, junction: Arc<Mutex<InputHandler>>) {
+        if let Some(ref mut ctx) = self.error_ctx {
+            ctx.set_dlq_junction(junction);
+        }
+    }
+
+    fn validate_connectivity(&self) -> Result<(), EventFluxError> {
+        // The consumer client validates the exact config start() will use
+        let consumer: BaseConsumer = self.config.to_client_config().create().map_err(|e| {
+            EventFluxError::ConnectionUnavailable {
+                message: format!("Failed to create Kafka consumer: {e}"),
+                source: Some(Box::new(e)),
+            }
+        })?;
+
+        let topic_refs: Vec<&str> = self.config.topics.iter().map(String::as_str).collect();
+        validate_topics_exist(
+            consumer.client(),
+            &self.config.connection.bootstrap_servers,
+            &topic_refs,
+        )
+    }
+}
+
+// ============================================================================
+// Kafka Source Factory
+// ============================================================================
+
+/// Factory for creating Kafka source instances.
+///
+/// This factory is registered with EventFluxContext and used to create
+/// Kafka sources from SQL WITH clause configuration.
+#[derive(Debug, Clone)]
+pub struct KafkaSourceFactory;
+
+impl SourceFactory for KafkaSourceFactory {
+    fn name(&self) -> &'static str {
+        "kafka"
+    }
+
+    fn supported_formats(&self) -> &[&str] {
+        &["json", "csv", "bytes"]
+    }
+
+    fn required_parameters(&self) -> &[&str] {
+        &["kafka.bootstrap.servers", "kafka.topic"]
+    }
+
+    fn optional_parameters(&self) -> &[&str] {
+        &[
+            "kafka.group.id",
+            "kafka.auto.offset.reset",
+            "kafka.enable.auto.commit",
+            "kafka.poll.timeout.ms",
+            "kafka.security.protocol",
+            "kafka.sasl.mechanism",
+            "kafka.sasl.username",
+            "kafka.sasl.password",
+            "kafka.ssl.ca.location",
+            // kafka.rdkafka.<prop> passthrough is also accepted
+            // Error handling options
+            "error.strategy",
+            "error.retry.max-attempts",
+            "error.retry.initial-delay-ms",
+            "error.retry.max-delay-ms",
+            "error.retry.backoff-multiplier",
+            "error.dlq.stream",
+        ]
+    }
+
+    fn create_initialized(
+        &self,
+        config: &HashMap<String, String>,
+    ) -> Result<Box<dyn Source>, EventFluxError> {
+        // DLQ junction is None initially — stream_initializer calls
+        // set_error_dlq_junction() after creation. The first topic identifies
+        // the stream in error-context log messages.
+        let stream_name = config
+            .get("kafka.topic")
+            .and_then(|t| t.split(',').next())
+            .map(str::trim)
+            .filter(|t| !t.is_empty())
+            .unwrap_or("kafka-source")
+            .to_string();
+
+        let source = KafkaSource::from_properties(config, None, &stream_name)
+            .map_err(EventFluxError::configuration)?;
+
+        Ok(Box::new(source))
+    }
+
+    fn clone_box(&self) -> Box<dyn SourceFactory> {
+        Box::new(self.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base_props() -> HashMap<String, String> {
+        let mut props = HashMap::new();
+        props.insert(
+            "kafka.bootstrap.servers".to_string(),
+            "localhost:9092".to_string(),
+        );
+        props.insert("kafka.topic".to_string(), "events".to_string());
+        props
+    }
+
+    #[test]
+    fn test_config_from_properties_required_only() {
+        let config = KafkaSourceConfig::from_properties(&base_props()).unwrap();
+        assert_eq!(config.connection.bootstrap_servers, "localhost:9092");
+        assert_eq!(config.topics, vec!["events"]);
+        assert_eq!(config.group_id, "eventflux-events"); // deterministic default
+        assert_eq!(config.auto_offset_reset, "latest");
+        assert!(config.enable_auto_commit);
+        assert_eq!(config.poll_timeout_ms, 100);
+        assert!(config.connection.security_protocol.is_none());
+        assert!(config.connection.rdkafka_overrides.is_empty());
+    }
+
+    #[test]
+    fn test_config_from_properties_all_options() {
+        let mut props = base_props();
+        props.insert(
+            "kafka.bootstrap.servers".to_string(),
+            "b1:9092,b2:9092".to_string(),
+        );
+        props.insert("kafka.group.id".to_string(), "my-group".to_string());
+        props.insert(
+            "kafka.auto.offset.reset".to_string(),
+            "earliest".to_string(),
+        );
+        props.insert("kafka.enable.auto.commit".to_string(), "false".to_string());
+        props.insert("kafka.poll.timeout.ms".to_string(), "250".to_string());
+        props.insert(
+            "kafka.security.protocol".to_string(),
+            "sasl_ssl".to_string(),
+        );
+        props.insert("kafka.sasl.mechanism".to_string(), "PLAIN".to_string());
+        props.insert("kafka.sasl.username".to_string(), "user".to_string());
+        props.insert("kafka.sasl.password".to_string(), "secret".to_string());
+
+        let config = KafkaSourceConfig::from_properties(&props).unwrap();
+        assert_eq!(config.connection.bootstrap_servers, "b1:9092,b2:9092");
+        assert_eq!(config.group_id, "my-group");
+        assert_eq!(config.auto_offset_reset, "earliest");
+        assert!(!config.enable_auto_commit);
+        assert_eq!(config.poll_timeout_ms, 250);
+        assert_eq!(
+            config.connection.security_protocol,
+            Some("sasl_ssl".to_string())
+        );
+        assert_eq!(config.connection.sasl_username, Some("user".to_string()));
+    }
+
+    #[test]
+    fn test_config_multiple_topics() {
+        let mut props = base_props();
+        props.insert("kafka.topic".to_string(), "a, b ,c".to_string());
+
+        let config = KafkaSourceConfig::from_properties(&props).unwrap();
+        assert_eq!(config.topics, vec!["a", "b", "c"]);
+        assert_eq!(config.group_id, "eventflux-a"); // first topic
+    }
+
+    #[test]
+    fn test_config_missing_topic() {
+        let mut props = base_props();
+        props.remove("kafka.topic");
+
+        let result = KafkaSourceConfig::from_properties(&props);
+        assert!(result.unwrap_err().contains("kafka.topic"));
+    }
+
+    #[test]
+    fn test_config_invalid_offset_reset() {
+        let mut props = base_props();
+        props.insert(
+            "kafka.auto.offset.reset".to_string(),
+            "somewhere".to_string(),
+        );
+
+        let result = KafkaSourceConfig::from_properties(&props);
+        assert!(result.unwrap_err().contains("kafka.auto.offset.reset"));
+    }
+
+    #[test]
+    fn test_config_invalid_auto_commit() {
+        let mut props = base_props();
+        props.insert("kafka.enable.auto.commit".to_string(), "maybe".to_string());
+
+        let result = KafkaSourceConfig::from_properties(&props);
+        assert!(result.unwrap_err().contains("kafka.enable.auto.commit"));
+    }
+
+    #[test]
+    fn test_config_rdkafka_reserved_keys_rejected() {
+        // Consumer-owned settings must go through first-class options
+        for reserved in RESERVED_RDKAFKA_KEYS {
+            let mut props = base_props();
+            props.insert(format!("kafka.rdkafka.{reserved}"), "x".to_string());
+
+            let result = KafkaSourceConfig::from_properties(&props);
+            assert!(
+                result.unwrap_err().contains("reserved"),
+                "kafka.rdkafka.{reserved} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn test_client_config_translation_manual_commit() {
+        let mut props = base_props();
+        props.insert("kafka.enable.auto.commit".to_string(), "false".to_string());
+        props.insert(
+            "kafka.rdkafka.fetch.min.bytes".to_string(),
+            "1024".to_string(),
+        );
+
+        let config = KafkaSourceConfig::from_properties(&props).unwrap();
+        let client_config = config.to_client_config();
+        assert_eq!(
+            client_config.get("bootstrap.servers"),
+            Some("localhost:9092")
+        );
+        assert_eq!(client_config.get("group.id"), Some("eventflux-events"));
+        // Canonical at-least-once: the internal committer stays on, but only
+        // explicitly stored (= processed) offsets can be committed
+        assert_eq!(client_config.get("enable.auto.commit"), Some("true"));
+        assert_eq!(client_config.get("enable.auto.offset.store"), Some("false"));
+        assert_eq!(client_config.get("fetch.min.bytes"), Some("1024"));
+    }
+
+    #[test]
+    fn test_client_config_translation_auto_commit() {
+        // Default mode: librdkafka stores and commits on its own
+        let config = KafkaSourceConfig::from_properties(&base_props()).unwrap();
+        let client_config = config.to_client_config();
+        assert_eq!(client_config.get("enable.auto.commit"), Some("true"));
+        assert_eq!(client_config.get("enable.auto.offset.store"), Some("true"));
+    }
+
+    #[test]
+    fn test_source_from_properties() {
+        let source = KafkaSource::from_properties(&base_props(), None, "TestStream").unwrap();
+        assert_eq!(source.config.topics, vec!["events"]);
+        assert!(source.error_ctx.is_none());
+    }
+
+    #[test]
+    fn test_source_from_properties_with_error_handling() {
+        let mut props = base_props();
+        props.insert("error.strategy".to_string(), "drop".to_string());
+
+        let source = KafkaSource::from_properties(&props, None, "TestStream").unwrap();
+        assert!(source.error_ctx.is_some());
+    }
+
+    #[test]
+    fn test_source_clone_resets_runtime_state() {
+        let mut props = base_props();
+        props.insert("error.strategy".to_string(), "drop".to_string());
+
+        let source = KafkaSource::from_properties(&props, None, "TestStream").unwrap();
+        let cloned = source.clone();
+        assert_eq!(cloned.config.topics, vec!["events"]);
+        assert!(cloned.error_ctx.is_none()); // runtime state not cloned
+    }
+
+    // =========================================================================
+    // Factory Tests
+    // =========================================================================
+
+    #[test]
+    fn test_factory_metadata() {
+        let factory = KafkaSourceFactory;
+        assert_eq!(factory.name(), "kafka");
+        assert!(factory.supported_formats().contains(&"json"));
+        assert!(factory.supported_formats().contains(&"csv"));
+        assert!(factory.supported_formats().contains(&"bytes"));
+        assert!(!factory.supported_formats().contains(&"avro")); // no avro mapper exists
+        assert!(factory
+            .required_parameters()
+            .contains(&"kafka.bootstrap.servers"));
+        assert!(factory.required_parameters().contains(&"kafka.topic"));
+        assert!(factory.optional_parameters().contains(&"kafka.group.id"));
+    }
+
+    #[test]
+    fn test_factory_create() {
+        let factory = KafkaSourceFactory;
+        assert!(factory.create_initialized(&base_props()).is_ok());
+    }
+
+    #[test]
+    fn test_factory_missing_required() {
+        let factory = KafkaSourceFactory;
+        let mut config = base_props();
+        config.remove("kafka.bootstrap.servers");
+        assert!(factory.create_initialized(&config).is_err());
+
+        let mut config = base_props();
+        config.remove("kafka.topic");
+        assert!(factory.create_initialized(&config).is_err());
+    }
+
+    #[test]
+    fn test_factory_accepts_error_handling_config() {
+        let factory = KafkaSourceFactory;
+        let mut config = base_props();
+        config.insert("error.strategy".to_string(), "retry".to_string());
+        config.insert("error.retry.max-attempts".to_string(), "3".to_string());
+
+        assert!(factory.create_initialized(&config).is_ok());
+    }
+
+    #[test]
+    fn test_factory_clone() {
+        let factory = KafkaSourceFactory;
+        let cloned = factory.clone_box();
+        assert_eq!(cloned.name(), "kafka");
+    }
+}

--- a/src/core/stream/input/source/mod.rs
+++ b/src/core/stream/input/source/mod.rs
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+#[cfg(feature = "kafka")]
+pub mod kafka_source;
 #[cfg(feature = "rabbitmq")]
 pub mod rabbitmq_source;
 pub mod timer_source;

--- a/src/core/stream/kafka_common.rs
+++ b/src/core/stream/kafka_common.rs
@@ -1,0 +1,301 @@
+/*
+ * Copyright 2025-2026 EventFlux.io
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Configuration and validation shared by the Kafka source and sink.
+//!
+//! Broker connection, security (SASL/SSL), the `kafka.rdkafka.*` passthrough,
+//! and topic-existence validation are identical on both sides — this module
+//! keeps them in one place so they cannot drift.
+
+use crate::core::exception::EventFluxError;
+use rdkafka::client::{Client, ClientContext};
+use rdkafka::config::ClientConfig;
+use std::collections::HashMap;
+use std::fmt::Display;
+use std::str::FromStr;
+use std::time::Duration;
+
+/// Parse an optional property, falling back to `default` when absent.
+pub fn parse_or<T: FromStr>(
+    properties: &HashMap<String, String>,
+    key: &str,
+    default: T,
+) -> Result<T, String>
+where
+    T::Err: Display,
+{
+    match properties.get(key) {
+        Some(v) => v.parse().map_err(|e| format!("Invalid {key}: {e}")),
+        None => Ok(default),
+    }
+}
+
+/// Broker connection + security settings shared by source and sink configs
+#[derive(Debug, Clone)]
+pub struct KafkaConnectionConfig {
+    /// Comma-separated broker list (`host1:9092,host2:9092`)
+    pub bootstrap_servers: String,
+    /// `plaintext`, `ssl`, `sasl_plaintext`, `sasl_ssl`
+    pub security_protocol: Option<String>,
+    /// `PLAIN`, `SCRAM-SHA-256`, `SCRAM-SHA-512`
+    pub sasl_mechanism: Option<String>,
+    pub sasl_username: Option<String>,
+    pub sasl_password: Option<String>,
+    /// CA certificate path
+    pub ssl_ca_location: Option<String>,
+    /// Verbatim librdkafka overrides from `kafka.rdkafka.<prop>`
+    pub rdkafka_overrides: Vec<(String, String)>,
+}
+
+impl KafkaConnectionConfig {
+    /// Parse the connection/security properties.
+    ///
+    /// `reserved` lists librdkafka keys owned by the caller's first-class
+    /// options — passing them through `kafka.rdkafka.*` is rejected to avoid
+    /// two sources of truth for the same knob.
+    pub fn from_properties(
+        properties: &HashMap<String, String>,
+        reserved: &[&str],
+    ) -> Result<Self, String> {
+        let bootstrap_servers = properties
+            .get("kafka.bootstrap.servers")
+            .ok_or("Missing required property: kafka.bootstrap.servers")?
+            .clone();
+        if bootstrap_servers.trim().is_empty() {
+            return Err("kafka.bootstrap.servers cannot be empty".to_string());
+        }
+
+        let security_protocol = properties.get("kafka.security.protocol").cloned();
+        let sasl_mechanism = properties.get("kafka.sasl.mechanism").cloned();
+        let sasl_username = properties.get("kafka.sasl.username").cloned();
+        let sasl_password = properties.get("kafka.sasl.password").cloned();
+        let ssl_ca_location = properties.get("kafka.ssl.ca.location").cloned();
+
+        // SASL credentials only make sense with a SASL security protocol.
+        // librdkafka accepts protocol names case-insensitively (Kafka
+        // convention is uppercase SASL_SSL), so compare accordingly.
+        if (sasl_username.is_some() || sasl_password.is_some() || sasl_mechanism.is_some())
+            && !security_protocol
+                .as_deref()
+                .is_some_and(|p| p.to_ascii_lowercase().starts_with("sasl_"))
+        {
+            return Err(
+                "kafka.sasl.* settings require kafka.security.protocol to be \
+                 'sasl_plaintext' or 'sasl_ssl'"
+                    .to_string(),
+            );
+        }
+
+        let mut rdkafka_overrides = Vec::new();
+        for (key, value) in properties {
+            if let Some(prop) = key.strip_prefix("kafka.rdkafka.") {
+                if reserved.contains(&prop) {
+                    return Err(format!(
+                        "kafka.rdkafka.{prop} is reserved — use the first-class kafka.* option instead"
+                    ));
+                }
+                rdkafka_overrides.push((prop.to_string(), value.clone()));
+            }
+        }
+
+        Ok(Self {
+            bootstrap_servers,
+            security_protocol,
+            sasl_mechanism,
+            sasl_username,
+            sasl_password,
+            ssl_ca_location,
+            rdkafka_overrides,
+        })
+    }
+
+    /// Apply broker, security, and override settings to a client config
+    pub fn apply_to(&self, config: &mut ClientConfig) {
+        config.set("bootstrap.servers", &self.bootstrap_servers);
+
+        if let Some(v) = &self.security_protocol {
+            config.set("security.protocol", v);
+        }
+        if let Some(v) = &self.sasl_mechanism {
+            config.set("sasl.mechanism", v);
+        }
+        if let Some(v) = &self.sasl_username {
+            config.set("sasl.username", v);
+        }
+        if let Some(v) = &self.sasl_password {
+            config.set("sasl.password", v);
+        }
+        if let Some(v) = &self.ssl_ca_location {
+            config.set("ssl.ca.location", v);
+        }
+        for (key, value) in &self.rdkafka_overrides {
+            config.set(key, value);
+        }
+    }
+}
+
+/// Fail-fast topic validation used by both connectors at startup.
+///
+/// One metadata round-trip regardless of topic count: a single topic is
+/// fetched directly; multiple topics reuse one full-metadata response.
+pub fn validate_topics_exist<C: ClientContext>(
+    client: &Client<C>,
+    brokers: &str,
+    topics: &[&str],
+) -> Result<(), EventFluxError> {
+    let fetch_topic = if topics.len() == 1 {
+        Some(topics[0])
+    } else {
+        None
+    };
+    let metadata = client
+        .fetch_metadata(fetch_topic, Duration::from_secs(10))
+        .map_err(|e| EventFluxError::ConnectionUnavailable {
+            message: format!("Failed to reach Kafka brokers at '{brokers}': {e}"),
+            source: Some(Box::new(e)),
+        })?;
+
+    for topic in topics {
+        let exists = metadata
+            .topics()
+            .iter()
+            .any(|t| t.name() == *topic && t.error().is_none() && !t.partitions().is_empty());
+        if !exists {
+            return Err(EventFluxError::configuration(format!(
+                "Kafka topic '{topic}' does not exist (brokers: '{brokers}')"
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base_props() -> HashMap<String, String> {
+        let mut props = HashMap::new();
+        props.insert(
+            "kafka.bootstrap.servers".to_string(),
+            "localhost:9092".to_string(),
+        );
+        props
+    }
+
+    #[test]
+    fn test_parse_or_default_and_value() {
+        let mut props = HashMap::new();
+        assert_eq!(parse_or(&props, "k", 5u64).unwrap(), 5);
+
+        props.insert("k".to_string(), "9".to_string());
+        assert_eq!(parse_or(&props, "k", 5u64).unwrap(), 9);
+
+        props.insert("k".to_string(), "no".to_string());
+        assert!(parse_or(&props, "k", 5u64)
+            .unwrap_err()
+            .contains("Invalid k"));
+    }
+
+    #[test]
+    fn test_connection_missing_bootstrap_servers() {
+        let result = KafkaConnectionConfig::from_properties(&HashMap::new(), &[]);
+        assert!(result.unwrap_err().contains("kafka.bootstrap.servers"));
+    }
+
+    #[test]
+    fn test_connection_empty_bootstrap_servers() {
+        let mut props = HashMap::new();
+        props.insert("kafka.bootstrap.servers".to_string(), "  ".to_string());
+        let result = KafkaConnectionConfig::from_properties(&props, &[]);
+        assert!(result.unwrap_err().contains("cannot be empty"));
+    }
+
+    #[test]
+    fn test_connection_sasl_requires_sasl_protocol() {
+        let mut props = base_props();
+        props.insert("kafka.sasl.username".to_string(), "user".to_string());
+
+        let result = KafkaConnectionConfig::from_properties(&props, &[]);
+        assert!(result.unwrap_err().contains("kafka.security.protocol"));
+    }
+
+    #[test]
+    fn test_connection_sasl_accepted_with_sasl_protocol() {
+        let mut props = base_props();
+        props.insert(
+            "kafka.security.protocol".to_string(),
+            "sasl_ssl".to_string(),
+        );
+        props.insert("kafka.sasl.mechanism".to_string(), "PLAIN".to_string());
+        props.insert("kafka.sasl.username".to_string(), "user".to_string());
+        props.insert("kafka.sasl.password".to_string(), "secret".to_string());
+
+        let config = KafkaConnectionConfig::from_properties(&props, &[]).unwrap();
+        assert_eq!(config.security_protocol, Some("sasl_ssl".to_string()));
+        assert_eq!(config.sasl_mechanism, Some("PLAIN".to_string()));
+    }
+
+    #[test]
+    fn test_connection_sasl_protocol_case_insensitive() {
+        // Kafka convention is uppercase; librdkafka accepts both
+        let mut props = base_props();
+        props.insert(
+            "kafka.security.protocol".to_string(),
+            "SASL_SSL".to_string(),
+        );
+        props.insert("kafka.sasl.username".to_string(), "user".to_string());
+
+        assert!(KafkaConnectionConfig::from_properties(&props, &[]).is_ok());
+    }
+
+    #[test]
+    fn test_connection_rdkafka_passthrough_and_reserved() {
+        let mut props = base_props();
+        props.insert(
+            "kafka.rdkafka.fetch.min.bytes".to_string(),
+            "1024".to_string(),
+        );
+        let config = KafkaConnectionConfig::from_properties(&props, &["acks"]).unwrap();
+        assert_eq!(
+            config.rdkafka_overrides,
+            vec![("fetch.min.bytes".to_string(), "1024".to_string())]
+        );
+
+        props.insert("kafka.rdkafka.acks".to_string(), "0".to_string());
+        let result = KafkaConnectionConfig::from_properties(&props, &["acks"]);
+        assert!(result.unwrap_err().contains("reserved"));
+    }
+
+    #[test]
+    fn test_apply_to_sets_connection_keys() {
+        let mut props = base_props();
+        props.insert(
+            "kafka.rdkafka.fetch.min.bytes".to_string(),
+            "1024".to_string(),
+        );
+        let connection = KafkaConnectionConfig::from_properties(&props, &[]).unwrap();
+
+        let mut client_config = ClientConfig::new();
+        connection.apply_to(&mut client_config);
+        assert_eq!(
+            client_config.get("bootstrap.servers"),
+            Some("localhost:9092")
+        );
+        assert_eq!(client_config.get("fetch.min.bytes"), Some("1024"));
+    }
+}

--- a/src/core/stream/mod.rs
+++ b/src/core/stream/mod.rs
@@ -18,6 +18,8 @@
 pub mod handler;
 pub mod input;
 pub mod junction_factory;
+#[cfg(feature = "kafka")]
+pub mod kafka_common;
 pub mod mapper;
 pub mod output;
 pub mod stream_initializer;

--- a/src/core/stream/output/sink/kafka_sink.rs
+++ b/src/core/stream/output/sink/kafka_sink.rs
@@ -1,0 +1,754 @@
+/*
+ * Copyright 2025-2026 EventFlux.io
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! # Kafka Sink
+//!
+//! Produces formatted event payloads to a Kafka topic.
+//!
+//! ## Architecture
+//!
+//! ```text
+//! Events → per event: SinkMapper → bytes → KafkaSink::publish() → ThreadedProducer → Kafka
+//! ```
+//!
+//! No tokio runtime is needed: `ThreadedProducer` runs librdkafka's own
+//! background poll thread, which batches records (`linger.ms`, `batch.size`)
+//! and invokes the delivery callback per record.
+//!
+//! ## Delivery semantics
+//!
+//! - Default (async): `publish()` enqueues into librdkafka's local queue and
+//!   returns; delivery reports arrive on the producer poll thread and
+//!   failures are counted/logged. librdkafka retries internally until
+//!   `kafka.message.timeout.ms`.
+//! - `kafka.delivery.sync = true`: `publish()` flushes and returns an error
+//!   if the record's delivery report came back failed — strict per-message
+//!   confirmation at the cost of throughput.
+//!
+//! `stop()` flushes in-flight records (bounded by `kafka.flush.timeout.ms`)
+//! and logs lifetime counters.
+
+use super::sink_trait::Sink;
+use crate::core::exception::EventFluxError;
+use crate::core::extension::SinkFactory;
+use crate::core::stream::kafka_common::{parse_or, validate_topics_exist, KafkaConnectionConfig};
+use rdkafka::client::ClientContext;
+use rdkafka::error::KafkaError;
+use rdkafka::producer::{BaseRecord, Producer, ProducerContext, ThreadedProducer};
+use rdkafka::types::RDKafkaErrorCode;
+use std::collections::HashMap;
+use std::fmt::Debug;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+/// librdkafka settings owned by first-class config fields — rejected when
+/// passed through the `kafka.rdkafka.*` escape hatch.
+const RESERVED_RDKAFKA_KEYS: &[&str] = &[
+    "bootstrap.servers",
+    "acks",
+    "compression.type",
+    "linger.ms",
+    "batch.size",
+    "enable.idempotence",
+    "message.timeout.ms",
+];
+
+/// What `publish()` does when librdkafka's local queue is full
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QueueFullStrategy {
+    /// Backpressure: retry the enqueue until it succeeds or the flush
+    /// timeout elapses (default)
+    Block,
+    /// Fail fast: surface the error to the pipeline's error handling
+    Error,
+}
+
+/// Configuration for Kafka sink
+#[derive(Debug, Clone)]
+pub struct KafkaSinkConfig {
+    /// Broker connection + security settings (shared with the source)
+    pub connection: KafkaConnectionConfig,
+    /// Target topic
+    pub topic: String,
+    /// Static record key (optional; keyless records use the default
+    /// partitioner)
+    pub key: Option<String>,
+    /// Durability vs latency: `0`, `1`, `all` (default `all`)
+    pub acks: String,
+    /// `none`, `gzip`, `snappy`, `lz4`, `zstd` (default `none`)
+    pub compression: String,
+    /// Batching delay in ms (default 5)
+    pub linger_ms: u64,
+    /// Max batch bytes (librdkafka default when unset)
+    pub batch_size: Option<u64>,
+    /// Exactly-once producer semantics — no duplicates on retry
+    pub enable_idempotence: bool,
+    /// Total time to deliver a record before it is reported failed
+    pub message_timeout_ms: u64,
+    /// true: `publish()` flushes and surfaces delivery failures (strict, slow)
+    pub delivery_sync: bool,
+    /// Bounds every wait in the sink: the `stop()` flush, sync-mode flushes,
+    /// and queue-full enqueue backpressure (default 30000)
+    pub flush_timeout_ms: u64,
+    /// Behavior when librdkafka's local queue is full
+    pub queue_full_strategy: QueueFullStrategy,
+}
+
+impl KafkaSinkConfig {
+    /// Parse configuration from properties HashMap
+    pub fn from_properties(properties: &HashMap<String, String>) -> Result<Self, String> {
+        let connection = KafkaConnectionConfig::from_properties(properties, RESERVED_RDKAFKA_KEYS)?;
+
+        let topic = properties
+            .get("kafka.topic")
+            .ok_or("Missing required property: kafka.topic")?
+            .trim()
+            .to_string();
+        if topic.is_empty() {
+            return Err("kafka.topic cannot be empty".to_string());
+        }
+
+        let key = properties.get("kafka.key").cloned();
+
+        let acks = properties
+            .get("kafka.acks")
+            .cloned()
+            .unwrap_or_else(|| "all".to_string());
+        if !["0", "1", "all"].contains(&acks.as_str()) {
+            return Err(format!(
+                "Invalid kafka.acks '{acks}': expected '0', '1', or 'all'"
+            ));
+        }
+
+        let compression = properties
+            .get("kafka.compression")
+            .cloned()
+            .unwrap_or_else(|| "none".to_string());
+        if !["none", "gzip", "snappy", "lz4", "zstd"].contains(&compression.as_str()) {
+            return Err(format!(
+                "Invalid kafka.compression '{compression}': expected none, gzip, snappy, lz4, or zstd"
+            ));
+        }
+
+        let enable_idempotence = parse_or(properties, "kafka.enable.idempotence", false)?;
+        // Kafka rejects this combination at the protocol level — fail with a
+        // clear message at parse time instead of a librdkafka create error
+        if enable_idempotence && acks != "all" {
+            return Err(format!(
+                "kafka.enable.idempotence requires kafka.acks = 'all' (got '{acks}')"
+            ));
+        }
+
+        let queue_full_strategy = match properties
+            .get("kafka.queue.full.strategy")
+            .map(String::as_str)
+        {
+            None | Some("block") => QueueFullStrategy::Block,
+            Some("error") => QueueFullStrategy::Error,
+            Some(other) => {
+                return Err(format!(
+                    "Invalid kafka.queue.full.strategy '{other}': expected 'block' or 'error'"
+                ))
+            }
+        };
+
+        Ok(Self {
+            connection,
+            topic,
+            key,
+            acks,
+            compression,
+            linger_ms: parse_or(properties, "kafka.linger.ms", 5)?,
+            batch_size: match properties.get("kafka.batch.size") {
+                Some(v) => Some(
+                    v.parse()
+                        .map_err(|e| format!("Invalid kafka.batch.size: {e}"))?,
+                ),
+                None => None,
+            },
+            enable_idempotence,
+            message_timeout_ms: parse_or(properties, "kafka.message.timeout.ms", 30_000)?,
+            delivery_sync: parse_or(properties, "kafka.delivery.sync", false)?,
+            flush_timeout_ms: parse_or(properties, "kafka.flush.timeout.ms", 30_000)?,
+            queue_full_strategy,
+        })
+    }
+
+    /// Build the librdkafka client configuration
+    pub fn to_client_config(&self) -> rdkafka::config::ClientConfig {
+        let mut config = rdkafka::config::ClientConfig::new();
+        config
+            .set("acks", &self.acks)
+            .set("compression.type", &self.compression)
+            .set("linger.ms", self.linger_ms.to_string())
+            .set("enable.idempotence", self.enable_idempotence.to_string())
+            .set("message.timeout.ms", self.message_timeout_ms.to_string());
+
+        if let Some(v) = self.batch_size {
+            config.set("batch.size", v.to_string());
+        }
+        self.connection.apply_to(&mut config);
+        config
+    }
+}
+
+/// Counters updated by the delivery callback on the producer poll thread
+#[derive(Debug, Default)]
+struct SinkMetrics {
+    records_produced: AtomicU64,
+    records_failed: AtomicU64,
+}
+
+/// Producer context that receives per-record delivery reports
+struct DeliveryTracker {
+    metrics: Arc<SinkMetrics>,
+}
+
+impl ClientContext for DeliveryTracker {}
+
+impl ProducerContext for DeliveryTracker {
+    type DeliveryOpaque = ();
+
+    fn delivery(
+        &self,
+        delivery_result: &rdkafka::message::DeliveryResult<'_>,
+        _delivery_opaque: Self::DeliveryOpaque,
+    ) {
+        match delivery_result {
+            Ok(_) => {
+                self.metrics
+                    .records_produced
+                    .fetch_add(1, Ordering::Relaxed);
+            }
+            Err((e, msg)) => {
+                self.metrics.records_failed.fetch_add(1, Ordering::Relaxed);
+                use rdkafka::message::Message;
+                log::error!(
+                    "[KafkaSink] Delivery failed for record to '{}' ({} bytes): {e}",
+                    msg.topic(),
+                    msg.payload().map_or(0, <[u8]>::len),
+                );
+            }
+        }
+    }
+}
+
+type KafkaProducer = ThreadedProducer<DeliveryTracker>;
+
+/// Kafka sink that produces records to a topic
+///
+/// This implementation:
+/// - Uses `ThreadedProducer` — librdkafka batches and delivers in the
+///   background; `publish()` is a non-blocking enqueue by default
+/// - Reports delivery failures via callback counters (logged on `stop()`)
+/// - Supports strict per-record confirmation via `kafka.delivery.sync`
+pub struct KafkaSink {
+    /// Configuration
+    config: KafkaSinkConfig,
+    /// Producer (created in start()). The Arc lets publish() clone a handle
+    /// out and do all I/O outside the lock — the mutex only guards the
+    /// start()/stop() transitions of the Option.
+    producer: Mutex<Option<Arc<KafkaProducer>>>,
+    /// Produced/failed counters (shared with the delivery callback)
+    metrics: Arc<SinkMetrics>,
+}
+
+// Manual Debug impl: ThreadedProducer does not implement Debug
+impl Debug for KafkaSink {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("KafkaSink")
+            .field("config", &self.config)
+            .field(
+                "connected",
+                &self.producer.lock().map(|g| g.is_some()).unwrap_or(false),
+            )
+            .finish()
+    }
+}
+
+impl KafkaSink {
+    /// Create a new Kafka sink
+    pub fn new(config: KafkaSinkConfig) -> Self {
+        Self {
+            config,
+            producer: Mutex::new(None),
+            metrics: Arc::new(SinkMetrics::default()),
+        }
+    }
+
+    /// Create a Kafka sink from properties
+    pub fn from_properties(properties: &HashMap<String, String>) -> Result<Self, String> {
+        Ok(Self::new(KafkaSinkConfig::from_properties(properties)?))
+    }
+
+    fn make_record<'a>(&'a self, payload: &'a [u8]) -> BaseRecord<'a, str, [u8]> {
+        let record = BaseRecord::to(&self.config.topic).payload(payload);
+        match &self.config.key {
+            Some(key) => record.key(key.as_str()),
+            None => record,
+        }
+    }
+}
+
+impl Clone for KafkaSink {
+    fn clone(&self) -> Self {
+        // A clone starts unconnected; the producer is created on start()
+        Self {
+            config: self.config.clone(),
+            producer: Mutex::new(None),
+            metrics: Arc::new(SinkMetrics::default()),
+        }
+    }
+}
+
+impl Sink for KafkaSink {
+    fn start(&self) {
+        let context = DeliveryTracker {
+            metrics: Arc::clone(&self.metrics),
+        };
+        match self.config.to_client_config().create_with_context(context) {
+            Ok(producer) => {
+                *self.producer.lock().unwrap() = Some(Arc::new(producer));
+                log::info!(
+                    "[KafkaSink] Producing to topic '{}' (brokers: '{}')",
+                    self.config.topic,
+                    self.config.connection.bootstrap_servers
+                );
+            }
+            Err(e) => {
+                log::error!("[KafkaSink] Failed to create producer: {e}");
+            }
+        }
+    }
+
+    fn publish(&self, payload: &[u8]) -> Result<(), EventFluxError> {
+        // Clone the Arc and drop the guard immediately — all I/O below
+        // (queue-full retries, sync flush) happens outside the lock, so
+        // stop() and other callers never stall behind a slow publish.
+        let producer =
+            {
+                let guard = self.producer.lock().map_err(|_| {
+                    EventFluxError::app_runtime("Producer lock poisoned".to_string())
+                })?;
+                guard.as_ref().map(Arc::clone).ok_or_else(|| {
+                    EventFluxError::ConnectionUnavailable {
+                        message: "Kafka sink not started - call start() first".to_string(),
+                        source: None,
+                    }
+                })?
+            };
+
+        // Sync mode surfaces delivery failures via the failed-counter delta;
+        // publishes are serialized by the SinkCallbackAdapter, so the delta
+        // is attributable to this record.
+        let failed_before = self
+            .config
+            .delivery_sync
+            .then(|| self.metrics.records_failed.load(Ordering::Relaxed));
+
+        // Enqueue with bounded retry when the local queue is full (block
+        // strategy applies backpressure to the pipeline; error fails fast).
+        // The deadline clock only starts on the first QueueFull.
+        let mut deadline: Option<Instant> = None;
+        let mut record = self.make_record(payload);
+        loop {
+            match producer.send(record) {
+                Ok(()) => break,
+                Err((KafkaError::MessageProduction(RDKafkaErrorCode::QueueFull), returned))
+                    if self.config.queue_full_strategy == QueueFullStrategy::Block =>
+                {
+                    let deadline = *deadline.get_or_insert_with(|| {
+                        Instant::now() + Duration::from_millis(self.config.flush_timeout_ms)
+                    });
+                    if Instant::now() >= deadline {
+                        return Err(EventFluxError::app_runtime(
+                            "Kafka enqueue failed: local queue full past the flush timeout"
+                                .to_string(),
+                        ));
+                    }
+                    // Local queue full — give the poll thread time to drain
+                    std::thread::sleep(Duration::from_millis(10));
+                    record = returned;
+                }
+                Err((e, _)) => {
+                    return Err(EventFluxError::app_runtime(format!(
+                        "Kafka enqueue failed: {e}"
+                    )));
+                }
+            }
+        }
+
+        if let Some(failed_before) = failed_before {
+            // Strict mode: wait for the delivery report, then check it
+            producer
+                .flush(Duration::from_millis(self.config.flush_timeout_ms))
+                .map_err(|e| EventFluxError::app_runtime(format!("Kafka flush failed: {e}")))?;
+
+            if self.metrics.records_failed.load(Ordering::Relaxed) > failed_before {
+                return Err(EventFluxError::app_runtime(
+                    "Kafka delivery failed (see delivery report log for details)".to_string(),
+                ));
+            }
+        }
+
+        Ok(())
+    }
+
+    fn stop(&self) {
+        log::info!("[KafkaSink] Stopping...");
+        let producer = self.producer.lock().unwrap().take();
+        if let Some(producer) = producer {
+            let timeout = Duration::from_millis(self.config.flush_timeout_ms);
+            if let Err(e) = producer.flush(timeout) {
+                log::warn!(
+                    "[KafkaSink] Flush did not complete within {timeout:?}: {e} — \
+                     some records may be undelivered"
+                );
+            }
+        }
+        log::info!(
+            "[KafkaSink] Stopped (produced: {}, failed: {})",
+            self.metrics.records_produced.load(Ordering::Relaxed),
+            self.metrics.records_failed.load(Ordering::Relaxed)
+        );
+    }
+
+    fn clone_box(&self) -> Box<dyn Sink> {
+        Box::new(self.clone())
+    }
+
+    fn validate_connectivity(&self) -> Result<(), EventFluxError> {
+        use rdkafka::consumer::{BaseConsumer, Consumer};
+
+        // Probe with a consumer client built from the connection settings
+        // only: producer metadata requests AUTO-CREATE missing topics on
+        // permissive brokers (verified against apache/kafka defaults), which
+        // would false-pass this validation and mutate broker state. Consumer
+        // clients never auto-create, and the fabricated group id below never
+        // materializes on the broker — group state only exists after a
+        // subscribe/commit, neither of which happens here.
+        let mut probe = rdkafka::config::ClientConfig::new();
+        self.config.connection.apply_to(&mut probe);
+        probe.set("group.id", "eventflux-validate");
+
+        let consumer: BaseConsumer =
+            probe
+                .create()
+                .map_err(|e| EventFluxError::ConnectionUnavailable {
+                    message: format!("Failed to create Kafka client: {e}"),
+                    source: Some(Box::new(e)),
+                })?;
+
+        validate_topics_exist(
+            consumer.client(),
+            &self.config.connection.bootstrap_servers,
+            &[&self.config.topic],
+        )
+    }
+}
+
+// ============================================================================
+// Kafka Sink Factory
+// ============================================================================
+
+/// Factory for creating Kafka sink instances.
+///
+/// This factory is registered with EventFluxContext and used to create
+/// Kafka sinks from SQL WITH clause configuration.
+#[derive(Debug, Clone)]
+pub struct KafkaSinkFactory;
+
+impl SinkFactory for KafkaSinkFactory {
+    fn name(&self) -> &'static str {
+        "kafka"
+    }
+
+    fn supported_formats(&self) -> &[&str] {
+        &["json", "csv", "bytes"]
+    }
+
+    fn required_parameters(&self) -> &[&str] {
+        &["kafka.bootstrap.servers", "kafka.topic"]
+    }
+
+    fn optional_parameters(&self) -> &[&str] {
+        &[
+            "kafka.key",
+            "kafka.acks",
+            "kafka.compression",
+            "kafka.linger.ms",
+            "kafka.batch.size",
+            "kafka.enable.idempotence",
+            "kafka.message.timeout.ms",
+            "kafka.delivery.sync",
+            "kafka.flush.timeout.ms",
+            "kafka.queue.full.strategy",
+            "kafka.security.protocol",
+            "kafka.sasl.mechanism",
+            "kafka.sasl.username",
+            "kafka.sasl.password",
+            "kafka.ssl.ca.location",
+            // kafka.rdkafka.<prop> passthrough is also accepted
+        ]
+    }
+
+    fn create_initialized(
+        &self,
+        config: &HashMap<String, String>,
+    ) -> Result<Box<dyn Sink>, EventFluxError> {
+        let parsed =
+            KafkaSinkConfig::from_properties(config).map_err(EventFluxError::configuration)?;
+        Ok(Box::new(KafkaSink::new(parsed)))
+    }
+
+    fn clone_box(&self) -> Box<dyn SinkFactory> {
+        Box::new(self.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base_props() -> HashMap<String, String> {
+        let mut props = HashMap::new();
+        props.insert(
+            "kafka.bootstrap.servers".to_string(),
+            "localhost:9092".to_string(),
+        );
+        props.insert("kafka.topic".to_string(), "out-events".to_string());
+        props
+    }
+
+    #[test]
+    fn test_config_from_properties_required_only() {
+        let config = KafkaSinkConfig::from_properties(&base_props()).unwrap();
+        assert_eq!(config.connection.bootstrap_servers, "localhost:9092");
+        assert_eq!(config.topic, "out-events");
+        assert!(config.key.is_none());
+        assert_eq!(config.acks, "all"); // safest default
+        assert_eq!(config.compression, "none");
+        assert_eq!(config.linger_ms, 5);
+        assert!(config.batch_size.is_none());
+        assert!(!config.enable_idempotence);
+        assert_eq!(config.message_timeout_ms, 30_000);
+        assert!(!config.delivery_sync);
+        assert_eq!(config.flush_timeout_ms, 30_000);
+        assert_eq!(config.queue_full_strategy, QueueFullStrategy::Block);
+    }
+
+    #[test]
+    fn test_config_from_properties_all_options() {
+        let mut props = base_props();
+        props.insert("kafka.key".to_string(), "my-key".to_string());
+        // acks=all kept explicit: idempotence below requires it
+        props.insert("kafka.acks".to_string(), "all".to_string());
+        props.insert("kafka.compression".to_string(), "lz4".to_string());
+        props.insert("kafka.linger.ms".to_string(), "20".to_string());
+        props.insert("kafka.batch.size".to_string(), "65536".to_string());
+        props.insert("kafka.enable.idempotence".to_string(), "true".to_string());
+        props.insert("kafka.message.timeout.ms".to_string(), "5000".to_string());
+        props.insert("kafka.delivery.sync".to_string(), "true".to_string());
+        props.insert("kafka.flush.timeout.ms".to_string(), "10000".to_string());
+        props.insert("kafka.queue.full.strategy".to_string(), "error".to_string());
+
+        let config = KafkaSinkConfig::from_properties(&props).unwrap();
+        assert_eq!(config.key, Some("my-key".to_string()));
+        assert_eq!(config.acks, "all");
+        assert_eq!(config.compression, "lz4");
+        assert_eq!(config.linger_ms, 20);
+        assert_eq!(config.batch_size, Some(65536));
+        assert!(config.enable_idempotence);
+        assert_eq!(config.message_timeout_ms, 5000);
+        assert!(config.delivery_sync);
+        assert_eq!(config.flush_timeout_ms, 10000);
+        assert_eq!(config.queue_full_strategy, QueueFullStrategy::Error);
+    }
+
+    #[test]
+    fn test_config_acks_one_accepted_without_idempotence() {
+        let mut props = base_props();
+        props.insert("kafka.acks".to_string(), "1".to_string());
+        let config = KafkaSinkConfig::from_properties(&props).unwrap();
+        assert_eq!(config.acks, "1");
+    }
+
+    #[test]
+    fn test_config_missing_topic() {
+        let mut props = base_props();
+        props.remove("kafka.topic");
+        assert!(KafkaSinkConfig::from_properties(&props)
+            .unwrap_err()
+            .contains("kafka.topic"));
+    }
+
+    #[test]
+    fn test_config_invalid_acks() {
+        let mut props = base_props();
+        props.insert("kafka.acks".to_string(), "2".to_string());
+        assert!(KafkaSinkConfig::from_properties(&props)
+            .unwrap_err()
+            .contains("kafka.acks"));
+    }
+
+    #[test]
+    fn test_config_invalid_compression() {
+        let mut props = base_props();
+        props.insert("kafka.compression".to_string(), "brotli".to_string());
+        assert!(KafkaSinkConfig::from_properties(&props)
+            .unwrap_err()
+            .contains("kafka.compression"));
+    }
+
+    #[test]
+    fn test_config_idempotence_requires_acks_all() {
+        let mut props = base_props();
+        props.insert("kafka.enable.idempotence".to_string(), "true".to_string());
+        props.insert("kafka.acks".to_string(), "1".to_string());
+        assert!(KafkaSinkConfig::from_properties(&props)
+            .unwrap_err()
+            .contains("kafka.enable.idempotence"));
+    }
+
+    #[test]
+    fn test_all_compression_codecs_compiled_in() {
+        // Producer creation validates compression.type against the codecs
+        // librdkafka was BUILT with — this guards the Cargo feature set
+        // (libz for gzip, zstd feature for zstd; snappy/lz4 are bundled).
+        // No broker needed: creation is a local operation.
+        for codec in ["none", "gzip", "snappy", "lz4", "zstd"] {
+            let mut props = base_props();
+            props.insert("kafka.compression".to_string(), codec.to_string());
+            let sink = KafkaSink::from_properties(&props).unwrap();
+
+            let producer: Result<rdkafka::producer::BaseProducer, _> =
+                sink.config.to_client_config().create();
+            assert!(
+                producer.is_ok(),
+                "librdkafka must support compression codec '{codec}': {:?}",
+                producer.err()
+            );
+        }
+    }
+
+    #[test]
+    fn test_config_invalid_queue_full_strategy() {
+        let mut props = base_props();
+        props.insert("kafka.queue.full.strategy".to_string(), "drop".to_string());
+        assert!(KafkaSinkConfig::from_properties(&props)
+            .unwrap_err()
+            .contains("kafka.queue.full.strategy"));
+    }
+
+    #[test]
+    fn test_config_rdkafka_reserved_keys_rejected() {
+        // Producer-owned settings must go through first-class options
+        for reserved in RESERVED_RDKAFKA_KEYS {
+            let mut props = base_props();
+            props.insert(format!("kafka.rdkafka.{reserved}"), "x".to_string());
+            assert!(
+                KafkaSinkConfig::from_properties(&props)
+                    .unwrap_err()
+                    .contains("reserved"),
+                "kafka.rdkafka.{reserved} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn test_client_config_translation() {
+        let mut props = base_props();
+        props.insert("kafka.compression".to_string(), "zstd".to_string());
+        props.insert("kafka.rdkafka.max.in.flight".to_string(), "1".to_string());
+
+        let config = KafkaSinkConfig::from_properties(&props).unwrap();
+        let client_config = config.to_client_config();
+        assert_eq!(
+            client_config.get("bootstrap.servers"),
+            Some("localhost:9092")
+        );
+        assert_eq!(client_config.get("acks"), Some("all"));
+        assert_eq!(client_config.get("compression.type"), Some("zstd"));
+        assert_eq!(client_config.get("linger.ms"), Some("5"));
+        assert_eq!(client_config.get("max.in.flight"), Some("1"));
+    }
+
+    #[test]
+    fn test_publish_before_start_errors() {
+        let sink = KafkaSink::from_properties(&base_props()).unwrap();
+        let result = sink.publish(b"payload");
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("call start() first"));
+    }
+
+    #[test]
+    fn test_stop_without_start_is_noop() {
+        let sink = KafkaSink::from_properties(&base_props()).unwrap();
+        sink.stop(); // Must not panic — no producer was created
+        sink.stop(); // Idempotent
+    }
+
+    #[test]
+    fn test_sink_clone_resets_runtime_state() {
+        let sink = KafkaSink::from_properties(&base_props()).unwrap();
+        let cloned = sink.clone();
+        assert_eq!(cloned.config.topic, "out-events");
+        assert!(cloned.producer.lock().unwrap().is_none());
+    }
+
+    // =========================================================================
+    // Factory Tests
+    // =========================================================================
+
+    #[test]
+    fn test_factory_metadata() {
+        let factory = KafkaSinkFactory;
+        assert_eq!(factory.name(), "kafka");
+        assert!(factory.supported_formats().contains(&"json"));
+        assert!(factory.supported_formats().contains(&"csv"));
+        assert!(factory.supported_formats().contains(&"bytes"));
+        assert!(factory
+            .required_parameters()
+            .contains(&"kafka.bootstrap.servers"));
+        assert!(factory.required_parameters().contains(&"kafka.topic"));
+        assert!(factory.optional_parameters().contains(&"kafka.acks"));
+    }
+
+    #[test]
+    fn test_factory_create() {
+        let factory = KafkaSinkFactory;
+        assert!(factory.create_initialized(&base_props()).is_ok());
+    }
+
+    #[test]
+    fn test_factory_missing_required() {
+        let factory = KafkaSinkFactory;
+        let mut config = base_props();
+        config.remove("kafka.topic");
+        assert!(factory.create_initialized(&config).is_err());
+    }
+
+    #[test]
+    fn test_factory_clone() {
+        let factory = KafkaSinkFactory;
+        let cloned = factory.clone_box();
+        assert_eq!(cloned.name(), "kafka");
+    }
+}

--- a/src/core/stream/output/sink/mod.rs
+++ b/src/core/stream/output/sink/mod.rs
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+#[cfg(feature = "kafka")]
+pub mod kafka_sink;
 pub mod log_sink;
 #[cfg(feature = "rabbitmq")]
 pub mod rabbitmq_sink;

--- a/src/core/stream/stream_initializer.rs
+++ b/src/core/stream/stream_initializer.rs
@@ -189,6 +189,8 @@ pub fn initialize_stream(
 /// by cargo features. The feature is always named after the extension (see
 /// the `[features]` section in Cargo.toml), so one entry per gated connector.
 const GATED_OUT_EXTENSIONS: &[&str] = &[
+    #[cfg(not(feature = "kafka"))]
+    "kafka",
     #[cfg(not(feature = "rabbitmq"))]
     "rabbitmq",
     #[cfg(not(feature = "websocket"))]
@@ -1018,7 +1020,7 @@ impl QuerySourceExtractor for Query {
 mod tests {
     use super::*;
     use crate::core::config::stream_config::{FlatConfig, PropertySource};
-    use crate::core::extension::example_factories::{HttpSinkFactory, KafkaSourceFactory};
+    use crate::core::extension::example_factories::{ExampleSourceFactory, HttpSinkFactory};
     use crate::core::extension::{CsvSinkMapperFactory, JsonSourceMapperFactory};
 
     #[test]
@@ -1045,19 +1047,16 @@ mod tests {
     #[test]
     fn test_initialize_source_stream_success() {
         let context = EventFluxContext::new();
-        context.add_source_factory("kafka".to_string(), Box::new(KafkaSourceFactory));
+        context.add_source_factory("example".to_string(), Box::new(ExampleSourceFactory));
         context.add_source_mapper_factory("json".to_string(), Box::new(JsonSourceMapperFactory));
 
         let mut config = HashMap::new();
-        config.insert(
-            "kafka.bootstrap.servers".to_string(),
-            "localhost:9092".to_string(),
-        );
-        config.insert("kafka.topic".to_string(), "test-topic".to_string());
+        config.insert("example.servers".to_string(), "localhost:9092".to_string());
+        config.insert("example.topic".to_string(), "test-topic".to_string());
 
         let stream_config = StreamTypeConfig::new(
             StreamType::Source,
-            Some("kafka".to_string()),
+            Some("example".to_string()),
             Some("json".to_string()),
             config,
         )
@@ -1068,7 +1067,7 @@ mod tests {
 
         match result.unwrap() {
             InitializedStream::Source(source) => {
-                assert_eq!(source.extension, "kafka");
+                assert_eq!(source.extension, "example");
                 assert_eq!(source.format.as_deref(), Some("json"));
             }
             _ => panic!("Expected Source stream"),
@@ -1105,12 +1104,12 @@ mod tests {
     #[test]
     fn test_initialize_source_stream_unsupported_format() {
         let context = EventFluxContext::new();
-        context.add_source_factory("kafka".to_string(), Box::new(KafkaSourceFactory));
+        context.add_source_factory("example".to_string(), Box::new(ExampleSourceFactory));
 
         let stream_config = StreamTypeConfig::new(
             StreamType::Source,
-            Some("kafka".to_string()),
-            Some("xml".to_string()), // Kafka doesn't support XML
+            Some("example".to_string()),
+            Some("xml".to_string()), // The example stub doesn't support XML
             HashMap::new(),
         )
         .unwrap();
@@ -1121,7 +1120,7 @@ mod tests {
         match result.unwrap_err() {
             EventFluxError::Configuration { message, .. } => {
                 assert!(message.contains("xml"));
-                assert!(message.contains("kafka"));
+                assert!(message.contains("example"));
             }
             e => panic!(
                 "Expected Configuration error for unsupported format, got {:?}",
@@ -1133,19 +1132,16 @@ mod tests {
     #[test]
     fn test_initialize_source_stream_mapper_not_found() {
         let context = EventFluxContext::new();
-        context.add_source_factory("kafka".to_string(), Box::new(KafkaSourceFactory));
+        context.add_source_factory("example".to_string(), Box::new(ExampleSourceFactory));
         // Note: json/csv mappers are registered by default, use a non-existent format
 
         let mut config = HashMap::new();
-        config.insert(
-            "kafka.bootstrap.servers".to_string(),
-            "localhost:9092".to_string(),
-        );
-        config.insert("kafka.topic".to_string(), "test".to_string());
+        config.insert("example.servers".to_string(), "localhost:9092".to_string());
+        config.insert("example.topic".to_string(), "test".to_string());
 
         let stream_config = StreamTypeConfig::new(
             StreamType::Source,
-            Some("kafka".to_string()),
+            Some("example".to_string()),
             Some("avro".to_string()), // avro mapper not registered
             config,
         )
@@ -1217,15 +1213,15 @@ mod tests {
     #[test]
     fn test_initialize_source_stream_invalid_config() {
         let context = EventFluxContext::new();
-        context.add_source_factory("kafka".to_string(), Box::new(KafkaSourceFactory));
+        context.add_source_factory("example".to_string(), Box::new(ExampleSourceFactory));
         context.add_source_mapper_factory("json".to_string(), Box::new(JsonSourceMapperFactory));
 
-        // Missing required kafka.bootstrap.servers
+        // Missing required example.servers
         let config = HashMap::new();
 
         let stream_config = StreamTypeConfig::new(
             StreamType::Source,
-            Some("kafka".to_string()),
+            Some("example".to_string()),
             Some("json".to_string()),
             config,
         )
@@ -1238,7 +1234,7 @@ mod tests {
         match result.unwrap_err() {
             EventFluxError::InvalidParameter { parameter, .. } => {
                 if let Some(param) = parameter {
-                    assert!(param.contains("kafka.bootstrap.servers"));
+                    assert!(param.contains("example.servers"));
                 }
             }
             e => panic!(
@@ -1251,20 +1247,21 @@ mod tests {
     #[test]
     fn test_initialize_source_stream_missing_required_format() {
         let context = EventFluxContext::new();
-        context.add_source_factory("kafka".to_string(), Box::new(KafkaSourceFactory));
+        context.add_source_factory("example".to_string(), Box::new(ExampleSourceFactory));
         // Don't add mapper factory - we're testing the format requirement validation
 
         let mut config = HashMap::new();
-        config.insert(
-            "kafka.bootstrap.servers".to_string(),
-            "localhost:9092".to_string(),
-        );
-        config.insert("kafka.topic".to_string(), "test-topic".to_string());
+        config.insert("example.servers".to_string(), "localhost:9092".to_string());
+        config.insert("example.topic".to_string(), "test-topic".to_string());
 
-        // Kafka source WITHOUT format - should be rejected
-        let stream_config =
-            StreamTypeConfig::new(StreamType::Source, Some("kafka".to_string()), None, config)
-                .unwrap();
+        // Example source WITHOUT format - should be rejected
+        let stream_config = StreamTypeConfig::new(
+            StreamType::Source,
+            Some("example".to_string()),
+            None,
+            config,
+        )
+        .unwrap();
 
         let result = initialize_stream(&context, &stream_config);
         assert!(result.is_err());
@@ -1273,7 +1270,7 @@ mod tests {
         match result.unwrap_err() {
             EventFluxError::Configuration { message, .. } => {
                 assert!(message.contains("requires a format specification"));
-                assert!(message.contains("kafka"));
+                assert!(message.contains("example"));
                 assert!(message.contains("json"));
                 assert!(message.contains("data loss"));
             }

--- a/tests/kafka_integration.rs
+++ b/tests/kafka_integration.rs
@@ -74,6 +74,8 @@ fn sink_props(topic: &str) -> HashMap<String, String> {
     props.insert("kafka.topic".to_string(), topic.to_string());
     // Deterministic delivery for test assertions
     props.insert("kafka.delivery.sync".to_string(), "true".to_string());
+    // Exercise the static record-key path
+    props.insert("kafka.key".to_string(), "test-key".to_string());
     props
 }
 

--- a/tests/kafka_integration.rs
+++ b/tests/kafka_integration.rs
@@ -1,0 +1,332 @@
+/*
+ * Copyright 2025-2026 EventFlux.io
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! # Kafka Integration Tests
+//!
+//! Requires building with the `kafka` feature:
+//! `cargo test --features kafka --test kafka_integration -- --ignored`
+//!
+//! Tests marked `#[ignore]` require a running Kafka broker. Each test
+//! creates its own unique topic by producing to it first.
+//!
+//! ## Setup
+//!
+//! Start a single-node KRaft broker with Docker:
+//! ```bash
+//! docker run -d --name kafka -p 9092:9092 apache/kafka:3.9.1
+//! ```
+//!
+//! Override the broker address with the `KAFKA_BROKERS` env var.
+
+#![cfg(feature = "kafka")]
+
+use eventflux::core::exception::EventFluxError;
+use eventflux::core::stream::input::source::kafka_source::KafkaSource;
+use eventflux::core::stream::input::source::{Source, SourceCallback};
+use eventflux::core::stream::output::sink::kafka_sink::KafkaSink;
+use eventflux::core::stream::output::sink::Sink;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+fn broker() -> String {
+    std::env::var("KAFKA_BROKERS").unwrap_or_else(|_| "localhost:9092".to_string())
+}
+
+/// Unique per-run topic so tests never see each other's records
+fn unique_topic(prefix: &str) -> String {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    format!("{prefix}-{nanos}")
+}
+
+fn source_props(topic: &str, group: &str) -> HashMap<String, String> {
+    let mut props = HashMap::new();
+    props.insert("kafka.bootstrap.servers".to_string(), broker());
+    props.insert("kafka.topic".to_string(), topic.to_string());
+    props.insert("kafka.group.id".to_string(), group.to_string());
+    props.insert(
+        "kafka.auto.offset.reset".to_string(),
+        "earliest".to_string(),
+    );
+    props
+}
+
+fn sink_props(topic: &str) -> HashMap<String, String> {
+    let mut props = HashMap::new();
+    props.insert("kafka.bootstrap.servers".to_string(), broker());
+    props.insert("kafka.topic".to_string(), topic.to_string());
+    // Deterministic delivery for test assertions
+    props.insert("kafka.delivery.sync".to_string(), "true".to_string());
+    props
+}
+
+/// Callback that records every payload it receives
+#[derive(Debug, Clone)]
+struct CollectingCallback {
+    payloads: Arc<Mutex<Vec<Vec<u8>>>>,
+}
+
+impl CollectingCallback {
+    fn new() -> Self {
+        Self {
+            payloads: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn wait_for(&self, count: usize, timeout: Duration) -> Vec<Vec<u8>> {
+        let deadline = Instant::now() + timeout;
+        loop {
+            let payloads = self.payloads.lock().unwrap();
+            if payloads.len() >= count || Instant::now() >= deadline {
+                return payloads.clone();
+            }
+            drop(payloads);
+            std::thread::sleep(Duration::from_millis(50));
+        }
+    }
+}
+
+impl SourceCallback for CollectingCallback {
+    fn on_data(&self, data: &[u8]) -> Result<(), EventFluxError> {
+        self.payloads.lock().unwrap().push(data.to_vec());
+        Ok(())
+    }
+}
+
+// Factory metadata and config-validation coverage lives in the in-module
+// unit tests (kafka_source.rs / kafka_sink.rs); this file holds only the
+// broker-backed tests.
+
+// ============================================================================
+// Broker Tests (run with --ignored against a live broker)
+// ============================================================================
+
+#[test]
+#[ignore = "Requires Kafka broker - run with --ignored"]
+fn test_sink_to_source_round_trip() {
+    let topic = unique_topic("roundtrip");
+
+    // Produce three records (sync delivery; broker auto-creates the topic)
+    let sink = KafkaSink::from_properties(&sink_props(&topic)).unwrap();
+    sink.start();
+    sink.publish(b"one").unwrap();
+    sink.publish(b"two").unwrap();
+    sink.publish(b"three").unwrap();
+    sink.stop();
+
+    // Consume them from the beginning
+    let callback = CollectingCallback::new();
+    let mut source =
+        KafkaSource::from_properties(&source_props(&topic, &unique_topic("grp")), None, "Test")
+            .unwrap();
+    source.start(Arc::new(callback.clone()));
+
+    let payloads = callback.wait_for(3, Duration::from_secs(30));
+    source.stop();
+
+    assert_eq!(
+        payloads,
+        vec![b"one".to_vec(), b"two".to_vec(), b"three".to_vec()],
+        "all produced records must arrive in order"
+    );
+}
+
+#[test]
+#[ignore = "Requires Kafka broker - run with --ignored"]
+fn test_manual_commit_no_redelivery_across_restarts() {
+    let topic = unique_topic("commit");
+    let group = unique_topic("grp");
+
+    let sink = KafkaSink::from_properties(&sink_props(&topic)).unwrap();
+    sink.start();
+    sink.publish(b"first").unwrap();
+
+    // At-least-once mode: offset committed only after delivery
+    let mut props = source_props(&topic, &group);
+    props.insert("kafka.enable.auto.commit".to_string(), "false".to_string());
+
+    let callback = CollectingCallback::new();
+    let mut source = KafkaSource::from_properties(&props, None, "Test").unwrap();
+    source.start(Arc::new(callback.clone()));
+    let got = callback.wait_for(1, Duration::from_secs(30));
+    assert_eq!(got, vec![b"first".to_vec()]);
+    source.stop(); // final sync commit happens here
+
+    // Produce a second record, then resume with the SAME group:
+    // only the uncommitted record may arrive
+    sink.publish(b"second").unwrap();
+    sink.stop();
+
+    let callback2 = CollectingCallback::new();
+    let mut source2 = KafkaSource::from_properties(&props, None, "Test").unwrap();
+    source2.start(Arc::new(callback2.clone()));
+    let got2 = callback2.wait_for(1, Duration::from_secs(30));
+    source2.stop();
+
+    assert_eq!(
+        got2,
+        vec![b"second".to_vec()],
+        "committed offsets must survive restarts — 'first' must not be redelivered"
+    );
+}
+
+#[test]
+#[ignore = "Requires Kafka broker - run with --ignored"]
+fn test_validate_connectivity_existing_topic() {
+    let topic = unique_topic("validate");
+
+    // Create the topic by producing to it
+    let sink = KafkaSink::from_properties(&sink_props(&topic)).unwrap();
+    sink.start();
+    sink.publish(b"seed").unwrap();
+    sink.stop();
+
+    let source =
+        KafkaSource::from_properties(&source_props(&topic, &unique_topic("grp")), None, "Test")
+            .unwrap();
+    source.validate_connectivity().unwrap();
+
+    let sink = KafkaSink::from_properties(&sink_props(&topic)).unwrap();
+    sink.validate_connectivity().unwrap();
+}
+
+/// Callback that rejects every payload — used to exercise the fail strategy
+#[derive(Debug)]
+struct AlwaysFailCallback;
+
+impl SourceCallback for AlwaysFailCallback {
+    fn on_data(&self, _data: &[u8]) -> Result<(), EventFluxError> {
+        Err(EventFluxError::app_runtime("simulated failure".to_string()))
+    }
+}
+
+#[test]
+#[ignore = "Requires Kafka broker - run with --ignored"]
+fn test_fail_strategy_leaves_record_uncommitted() {
+    // The at-least-once contract for the `fail` strategy: the poisoned
+    // record's offset must NOT be committed by ANY path (including the
+    // shutdown/revoke commits), so it is redelivered after restart.
+    let topic = unique_topic("poison");
+    let group = unique_topic("grp");
+
+    let sink = KafkaSink::from_properties(&sink_props(&topic)).unwrap();
+    sink.start();
+    sink.publish(b"poison").unwrap();
+    sink.stop();
+
+    let mut props = source_props(&topic, &group);
+    props.insert("kafka.enable.auto.commit".to_string(), "false".to_string());
+    props.insert("error.strategy".to_string(), "fail".to_string());
+
+    // First source hits the poison record and stops without committing
+    let mut source = KafkaSource::from_properties(&props, None, "Test").unwrap();
+    source.start(Arc::new(AlwaysFailCallback));
+    std::thread::sleep(Duration::from_secs(10)); // let it consume + fail
+    source.stop();
+
+    // Restart with the SAME group: the record must be redelivered
+    let callback = CollectingCallback::new();
+    let mut source2 = KafkaSource::from_properties(&props, None, "Test").unwrap();
+    source2.start(Arc::new(callback.clone()));
+    let redelivered = callback.wait_for(1, Duration::from_secs(30));
+    source2.stop();
+
+    assert_eq!(
+        redelivered,
+        vec![b"poison".to_vec()],
+        "a failed record must be redelivered after restart — its offset must never be committed"
+    );
+}
+
+#[test]
+#[ignore = "Requires Kafka broker - run with --ignored"]
+fn test_validate_connectivity_missing_topic_fails() {
+    // Validation must fail on a topic that does not exist — and must not
+    // create it as a side effect (fail-fast, not create-on-probe)
+    let topic = unique_topic("missing");
+
+    let source =
+        KafkaSource::from_properties(&source_props(&topic, &unique_topic("grp")), None, "Test")
+            .unwrap();
+    assert!(
+        source.validate_connectivity().is_err(),
+        "source validation must fail for a missing topic"
+    );
+
+    let sink = KafkaSink::from_properties(&sink_props(&topic)).unwrap();
+    assert!(
+        sink.validate_connectivity().is_err(),
+        "sink validation must fail for a missing topic"
+    );
+
+    // Probing must not have created the topic: a second validation still fails
+    let sink = KafkaSink::from_properties(&sink_props(&topic)).unwrap();
+    assert!(
+        sink.validate_connectivity().is_err(),
+        "validation must not auto-create the topic it probes"
+    );
+}
+
+#[test]
+#[ignore = "Slow (waits out the 10s metadata timeout) - run with --ignored"]
+fn test_validate_connectivity_unreachable_broker_fails_fast() {
+    let mut props = source_props("any-topic", "any-group");
+    props.insert(
+        "kafka.bootstrap.servers".to_string(),
+        "127.0.0.1:1".to_string(),
+    );
+
+    let source = KafkaSource::from_properties(&props, None, "Test").unwrap();
+    let start = Instant::now();
+    let result = source.validate_connectivity();
+    assert!(result.is_err(), "unreachable broker must fail validation");
+    assert!(
+        start.elapsed() < Duration::from_secs(15),
+        "validation must fail fast (bounded by the 10s metadata timeout)"
+    );
+}
+
+#[test]
+#[ignore = "Requires Kafka broker - run with --ignored"]
+fn test_source_stop_joins_promptly() {
+    let topic = unique_topic("shutdown");
+
+    // Ensure the topic exists so the consumer settles into its poll loop
+    let sink = KafkaSink::from_properties(&sink_props(&topic)).unwrap();
+    sink.start();
+    sink.publish(b"seed").unwrap();
+    sink.stop();
+
+    let callback = CollectingCallback::new();
+    let mut source =
+        KafkaSource::from_properties(&source_props(&topic, &unique_topic("grp")), None, "Test")
+            .unwrap();
+    source.start(Arc::new(callback.clone()));
+    callback.wait_for(1, Duration::from_secs(30));
+
+    // The poll loop checks the running flag every ≤100ms — stop() must
+    // return well within the grace period
+    let start = Instant::now();
+    source.stop();
+    assert!(
+        start.elapsed() < Duration::from_secs(5),
+        "stop() must join the consumer thread promptly"
+    );
+}

--- a/website/docs/connectors/kafka.md
+++ b/website/docs/connectors/kafka.md
@@ -1,0 +1,170 @@
+---
+sidebar_position: 2
+title: Kafka Connector
+description: Consume from and produce to Apache Kafka topics
+---
+
+# Kafka Connector
+
+The Kafka connector enables EventFlux to consume records from Kafka topics and publish processed results back to Kafka. It supports JSON, CSV, and bytes formats, consumer groups with configurable offset semantics, and SASL/SSL security.
+
+Built on librdkafka (via the `rdkafka` crate), the connector inherits its battle-tested networking: automatic reconnection, internal retries, and producer-side batching all come from librdkafka's background threads — no extra runtime inside EventFlux.
+
+## Prerequisites
+
+### Building with Kafka Support
+
+The Kafka connector is feature-gated. Build EventFlux with the `kafka` feature (Docker images already include all connectors). Compiling librdkafka requires **cmake and a C toolchain**:
+
+```bash
+cargo build --release --features kafka
+# or: cargo build --release --features connectors-all
+```
+
+### Starting Kafka
+
+The easiest way to run a single-node broker is Docker (KRaft mode, no ZooKeeper):
+
+```bash
+docker run -d --name kafka -p 9092:9092 apache/kafka:3.9.1
+```
+
+### Creating Topics
+
+EventFlux validates at startup that configured topics exist (fail-fast):
+
+```bash
+docker exec kafka /opt/kafka/bin/kafka-topics.sh --create \
+  --bootstrap-server localhost:9092 --topic trades-in
+```
+
+## Kafka Source
+
+The Kafka source joins a consumer group and delivers record payloads into the pipeline.
+
+### SQL Syntax
+
+```sql
+CREATE STREAM TradeInput (
+    symbol STRING,
+    price DOUBLE,
+    volume INT
+) WITH (
+    type = 'source',
+    extension = 'kafka',
+    format = 'json',
+    "kafka.bootstrap.servers" = 'localhost:9092',
+    "kafka.topic" = 'trades-in',
+    "kafka.group.id" = 'eventflux-trades',
+    "kafka.enable.auto.commit" = 'false'
+);
+```
+
+### Source Configuration Options
+
+| Option | Required | Default | Description |
+|--------|----------|---------|-------------|
+| `kafka.bootstrap.servers` | Yes | - | Comma-separated broker list |
+| `kafka.topic` | Yes | - | Topic(s) to consume, comma-separated for multiple |
+| `kafka.group.id` | No | `eventflux-<topic>` | Consumer group id (deterministic default, so offsets survive restarts) |
+| `kafka.auto.offset.reset` | No | `latest` | Start position without committed offsets: `earliest` or `latest` |
+| `kafka.enable.auto.commit` | No | `true` | `false` = commit after pipeline delivery (**at-least-once**) |
+| `kafka.poll.timeout.ms` | No | `100` | Poll timeout; bounds shutdown latency |
+| `kafka.security.protocol` | No | `plaintext` | `plaintext`, `ssl`, `sasl_plaintext`, `sasl_ssl` |
+| `kafka.sasl.mechanism` | No | - | `PLAIN`, `SCRAM-SHA-256`, `SCRAM-SHA-512` |
+| `kafka.sasl.username` / `kafka.sasl.password` | No | - | SASL credentials |
+| `kafka.ssl.ca.location` | No | - | CA certificate path |
+| `kafka.rdkafka.<prop>` | No | - | Escape hatch: passed verbatim to librdkafka (e.g. `kafka.rdkafka.fetch.min.bytes`) |
+| `error.strategy` | No | - | Error handling: `drop`, `retry`, `dlq`, `fail` |
+
+### Delivery Semantics
+
+| Configuration | Guarantee |
+|---------------|-----------|
+| `kafka.enable.auto.commit = true` (default) | ~at-most-once: librdkafka commits periodically, possibly before processing completes |
+| `kafka.enable.auto.commit = false` | **at-least-once**: a record's offset is committed only after the pipeline accepted it (or the error strategy disposed of it via drop/DLQ). Crash before commit → redelivery on restart |
+
+With the `fail` error strategy, an unprocessable record is *not* committed, so it is redelivered after restart.
+
+Records with empty payloads (tombstones) are skipped.
+
+## Kafka Sink
+
+The Kafka sink publishes each event as its own record (one event = one message).
+
+### SQL Syntax
+
+```sql
+CREATE STREAM TradeOutput (
+    symbol STRING,
+    price DOUBLE,
+    price_category STRING
+) WITH (
+    type = 'sink',
+    extension = 'kafka',
+    format = 'json',
+    "kafka.bootstrap.servers" = 'localhost:9092',
+    "kafka.topic" = 'trades-out',
+    "kafka.acks" = 'all',
+    "kafka.compression" = 'lz4'
+);
+```
+
+### Sink Configuration Options
+
+| Option | Required | Default | Description |
+|--------|----------|---------|-------------|
+| `kafka.bootstrap.servers` | Yes | - | Comma-separated broker list |
+| `kafka.topic` | Yes | - | Target topic |
+| `kafka.key` | No | - | Static record key (keyless records use the default partitioner) |
+| `kafka.acks` | No | `all` | Durability vs latency: `0`, `1`, `all` |
+| `kafka.compression` | No | `none` | `none`, `gzip`, `snappy`, `lz4`, `zstd` |
+| `kafka.linger.ms` | No | `5` | Producer batching delay |
+| `kafka.batch.size` | No | librdkafka default | Max batch bytes |
+| `kafka.enable.idempotence` | No | `false` | No duplicates on producer retry |
+| `kafka.message.timeout.ms` | No | `30000` | Total time to deliver a record before it's reported failed |
+| `kafka.delivery.sync` | No | `false` | `true`: `publish()` waits for delivery confirmation per record (strict, slow) |
+| `kafka.flush.timeout.ms` | No | `30000` | Bounds the shutdown flush, sync-mode flushes, and queue-full backpressure |
+| `kafka.queue.full.strategy` | No | `block` | Local queue full: `block` (backpressure) or `error` (fail fast) |
+| `kafka.rdkafka.<prop>` | No | - | Escape hatch: passed verbatim to librdkafka |
+
+### Delivery Semantics
+
+- **Default (async)**: `publish()` enqueues into librdkafka's local queue; delivery happens in the background with internal retries until `kafka.message.timeout.ms`. Failures are counted and logged. This keeps pipeline throughput decoupled from broker round-trips.
+- **Sync** (`kafka.delivery.sync = true`): each publish waits for its delivery report — strict confirmation for low-throughput, high-assurance pipelines.
+- **Shutdown**: in-flight records are flushed (bounded by `kafka.flush.timeout.ms`); lifetime produced/failed counters are logged.
+- `kafka.acks = all` + `kafka.enable.idempotence = true` gives at-least-once without producer-side duplicates.
+
+## Complete End-to-End Example
+
+See [`examples/kafka.eventflux`](https://github.com/eventflux-io/eventflux/blob/main/examples/kafka.eventflux) for a runnable pipeline (Kafka → filter + CASE → Kafka), including broker setup and console producer/consumer commands for testing.
+
+## Error Handling
+
+The source integrates with EventFlux's error handling strategies:
+
+```sql
+"error.strategy" = 'retry',
+"error.retry.max-attempts" = '3',
+"error.retry.initial-delay-ms" = '100'
+```
+
+- `drop`: skip the failing record (offset committed)
+- `retry`: retry delivery with exponential backoff
+- `dlq`: route the raw payload to a dead-letter stream (offset committed)
+- `fail`: stop the source; the record is **not** committed and is redelivered after restart
+
+## Connection Validation
+
+Both source and sink validate at application startup that brokers are reachable and topics exist (10s timeout). The application does not start otherwise:
+
+```
+Configuration error: Kafka topic 'trades-in' does not exist (brokers: 'localhost:9092')
+```
+
+## Not Yet Supported
+
+- Exactly-once semantics (Kafka transactions) — needs checkpoint-coordinated commits
+- Per-event record keys / topic routing (static `kafka.key` only)
+- Kafka headers ↔ event metadata
+- Avro / Schema Registry (no Avro mapper yet)

--- a/website/docs/connectors/kafka.md
+++ b/website/docs/connectors/kafka.md
@@ -121,7 +121,7 @@ CREATE STREAM TradeOutput (
 | `kafka.compression` | No | `none` | `none`, `gzip`, `snappy`, `lz4`, `zstd` |
 | `kafka.linger.ms` | No | `5` | Producer batching delay |
 | `kafka.batch.size` | No | librdkafka default | Max batch bytes |
-| `kafka.enable.idempotence` | No | `false` | No duplicates on producer retry |
+| `kafka.enable.idempotence` | No | `false` | No duplicates on producer retry (requires `kafka.acks = 'all'`) |
 | `kafka.message.timeout.ms` | No | `30000` | Total time to deliver a record before it's reported failed |
 | `kafka.delivery.sync` | No | `false` | `true`: `publish()` waits for delivery confirmation per record (strict, slow) |
 | `kafka.flush.timeout.ms` | No | `30000` | Bounds the shutdown flush, sync-mode flushes, and queue-full backpressure |
@@ -141,18 +141,107 @@ See [`examples/kafka.eventflux`](https://github.com/eventflux-io/eventflux/blob/
 
 ## Error Handling
 
-The source integrates with EventFlux's error handling strategies:
+The source integrates with EventFlux's error handling strategies (`WITH`
+clause options on the source stream):
 
-```sql
-"error.strategy" = 'retry',
-"error.retry.max-attempts" = '3',
-"error.retry.initial-delay-ms" = '100'
-```
+| Option | Default | Description |
+|--------|---------|-------------|
+| `error.strategy` | `drop` | What to do when the pipeline rejects a record: `drop`, `retry`, `dlq`, `fail` |
+| `error.retry.max-attempts` | `3` | Max retries before falling back to drop |
+| `error.retry.initial-delay-ms` | `100` | First retry delay |
+| `error.retry.max-delay-ms` | `10000` | Retry delay ceiling |
+| `error.retry.backoff-multiplier` | `2.0` | Exponential backoff factor |
+| `error.dlq.stream` | - | Dead-letter stream name (required when strategy is `dlq`) |
+
+Strategy semantics and their offset interaction:
 
 - `drop`: skip the failing record (offset committed)
 - `retry`: retry delivery with exponential backoff
 - `dlq`: route the raw payload to a dead-letter stream (offset committed)
 - `fail`: stop the source; the record is **not** committed and is redelivered after restart
+
+## More Configuration Examples
+
+### At-least-once source with retry and a dead-letter queue
+
+```sql
+CREATE STREAM Orders (order_id STRING, amount DOUBLE) WITH (
+    type = 'source',
+    extension = 'kafka',
+    format = 'json',
+    "kafka.bootstrap.servers" = 'localhost:9092',
+    "kafka.topic" = 'orders',
+    "kafka.group.id" = 'eventflux-orders',
+    "kafka.auto.offset.reset" = 'earliest',
+    "kafka.enable.auto.commit" = 'false',      -- at-least-once
+    "error.strategy" = 'retry',
+    "error.retry.max-attempts" = '5',
+    "error.retry.initial-delay-ms" = '200',
+    "error.retry.max-delay-ms" = '5000',
+    "error.retry.backoff-multiplier" = '2.0'
+);
+```
+
+### Secured cluster (SASL/SSL)
+
+`kafka.sasl.*` options require a `sasl_*` security protocol. Use environment
+variable substitution for secrets rather than inlining them:
+
+```sql
+CREATE STREAM SecureInput (id STRING, value DOUBLE) WITH (
+    type = 'source',
+    extension = 'kafka',
+    format = 'json',
+    "kafka.bootstrap.servers" = 'broker1:9093,broker2:9093',
+    "kafka.topic" = 'secure-events',
+    "kafka.security.protocol" = 'sasl_ssl',
+    "kafka.sasl.mechanism" = 'SCRAM-SHA-256',
+    "kafka.sasl.username" = '${KAFKA_USERNAME}',
+    "kafka.sasl.password" = '${KAFKA_PASSWORD}',
+    "kafka.ssl.ca.location" = '/etc/ssl/certs/kafka-ca.pem'
+);
+```
+
+### High-throughput sink with idempotence and librdkafka tuning
+
+`kafka.enable.idempotence` requires `kafka.acks = 'all'`. Any librdkafka
+setting without a first-class option goes through the `kafka.rdkafka.*`
+passthrough:
+
+```sql
+CREATE STREAM MetricsOut (name STRING, value DOUBLE) WITH (
+    type = 'sink',
+    extension = 'kafka',
+    format = 'json',
+    "kafka.bootstrap.servers" = 'localhost:9092',
+    "kafka.topic" = 'metrics',
+    "kafka.acks" = 'all',
+    "kafka.enable.idempotence" = 'true',
+    "kafka.compression" = 'zstd',
+    "kafka.linger.ms" = '50',
+    "kafka.batch.size" = '131072',
+    "kafka.rdkafka.queue.buffering.max.messages" = '500000'
+);
+```
+
+### Strict per-record confirmation sink
+
+For low-throughput pipelines where every publish must be confirmed before
+the next event is processed:
+
+```sql
+CREATE STREAM AuditLog (user_id STRING, action STRING) WITH (
+    type = 'sink',
+    extension = 'kafka',
+    format = 'json',
+    "kafka.bootstrap.servers" = 'localhost:9092',
+    "kafka.topic" = 'audit-log',
+    "kafka.key" = 'audit',
+    "kafka.delivery.sync" = 'true',
+    "kafka.flush.timeout.ms" = '10000',
+    "kafka.queue.full.strategy" = 'error'
+);
+```
 
 ## Connection Validation
 

--- a/website/docs/connectors/overview.md
+++ b/website/docs/connectors/overview.md
@@ -101,6 +101,7 @@ extension name. The default build is fully minimal (core engine plus the
 built-in `timer` source and `log` sink):
 
 ```bash
+cargo build --release --features kafka             # just Kafka
 cargo build --release --features rabbitmq          # just RabbitMQ
 cargo build --release --features websocket         # just WebSocket
 cargo build --release --features connectors-all    # everything
@@ -122,9 +123,9 @@ build. Rebuild with `--features rabbitmq` (or `--features connectors-all`).
 |-----------|--------|------|--------------|--------|-------------|
 | **Timer** | Yes | — | (always built) | Production Ready | Periodic tick source |
 | **Log** | — | Yes | (always built) | Production Ready | Logging sink for debugging |
+| **Kafka** | Yes | Yes | `kafka` | Production Ready | Apache Kafka streaming |
 | **RabbitMQ** | Yes | Yes | `rabbitmq` | Production Ready | AMQP 0-9-1 message broker |
 | **WebSocket** | Yes | Yes | `websocket` | Production Ready | Real-time bidirectional streaming |
-| **Kafka** | Planned | Planned | `kafka` (planned) | Roadmap | Apache Kafka streaming |
 | **HTTP** | Planned | Planned | — | Roadmap | REST/Webhook endpoints |
 | **File** | Planned | Planned | — | Roadmap | File-based input/output |
 
@@ -217,6 +218,7 @@ manager.context().add_sink_factory(
 
 ## Next Steps
 
+- **[Kafka Connector](/docs/connectors/kafka)** - Consume from and produce to Apache Kafka topics
 - **[RabbitMQ Connector](/docs/connectors/rabbitmq)** - Connect to RabbitMQ message broker
 - **[WebSocket Connector](/docs/connectors/websocket)** - Connect to WebSocket endpoints for real-time streaming
 - **[Mappers Reference](/docs/connectors/mappers)** - JSON, CSV, and bytes format handling

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -41,6 +41,7 @@ a cargo feature named exactly after its SQL extension name:
 
 | Feature | Connector | In default build? |
 |---------|-----------|-------------------|
+| `kafka` | Kafka source + sink (needs cmake to build) | No |
 | `rabbitmq` | RabbitMQ source + sink | No |
 | `websocket` | WebSocket source + sink | No |
 | `connectors-all` | All connectors | No |

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -51,6 +51,7 @@ const sidebars = {
       collapsed: false,
       items: [
         'connectors/overview',
+        'connectors/kafka',
         'connectors/rabbitmq',
         'connectors/websocket',
         'connectors/mappers',


### PR DESCRIPTION
## What

Apache Kafka source and sink, feature-gated behind `kafka` (included in `connectors-all`), built on `rdkafka`/librdkafka. Roadmap Priority 1.

### Architecture — no tokio runtime

librdkafka runs its own background threads, so the sync APIs map directly onto the existing connector infrastructure: `BaseConsumer` poll loop on a `SourceWorker` thread (source), `ThreadedProducer` with delivery-report callbacks (sink). None of the nested-runtime bridging the async connectors need.

### Source
- Consumer groups, deterministic default group id (`eventflux-<topic>`), multi-topic, `earliest`/`latest` offset reset
- **At-least-once** (`kafka.enable.auto.commit=false`) via the canonical librdkafka pattern: auto-store disabled, offsets stored only after the pipeline accepted the record (or the error strategy disposed of it), internal committer + sync commits on rebalance/shutdown — every commit path covers only processed records. `fail`-strategy records are never committed and are redelivered after restart (proven by integration test)
- Full `error.*` strategy integration (drop/retry/dlq/fail) via the shared `deliver_with_error_handling` helper
- Fail-fast `validate_connectivity` (brokers reachable, topics exist — single metadata round-trip)

### Sink
- One event = one record; async enqueue with delivery reports; `kafka.delivery.sync` for strict per-record confirmation that surfaces delivery failures
- `acks` (default `all`), compression (gzip/snappy/lz4/zstd — all codecs compiled in and regression-tested), idempotence (validated against `acks` at parse time), bounded queue-full backpressure (`block`/`error`)
- Validation probes with a connection-only consumer client — producer metadata probes auto-create topics on permissive brokers (verified empirically), which would false-pass validation
- `publish()` never holds the producer lock across I/O (Arc handle cloned out)

### Shared infrastructure (used by both, reusable by future sources)
- `kafka_common.rs`: connection/SASL/SSL config, `kafka.rdkafka.*` passthrough with reserved-key protection, topic validation
- `SourceErrorContext::from_properties` and `deliver_with_error_handling`/`DeliveryVerdict` in `source_support.rs` — collapse boilerplate previously copy-pasted per connector (RabbitMQ/WebSocket can adopt in a follow-up)
- The old non-functional Kafka stub in `example_factories.rs` is renamed to `ExampleSourceFactory` (neutral `example.*` params) so it can't collide with or shadow the real connector

### Gating checklist (all points)
Cargo feature + optional dep, module decls, registration, `GATED_OUT_EXTENSIONS` hint, gated integration tests, CI per-connector check, justfile, docs.

### Tests & CI
- 43 unit tests (config parsing, factories, client-config translation, codec availability)
- 7 broker-backed integration tests: round-trip ordering, manual-commit offset persistence across restarts, fail-strategy redelivery, validation (existing/missing/unreachable, no topic auto-creation side effect), prompt shutdown join
- CI gains an `apache/kafka:3.9.1` (KRaft) service + integration step; integration steps now reuse `connectors-all` build artifacts
- Verified end-to-end locally: the SQL example pipeline against a real broker across multiple restarts — correct at-least-once resume, no duplicate outputs

### Docs
Website connector page + overview/installation tables + sidebar, README feature table, ROADMAP (Kafka → Done, feature-flag column), `examples/kafka.eventflux` with full broker setup instructions, CONTRIBUTING check commands.

### Deferred (documented)
Exactly-once transactions, per-event record keys/topic routing, Kafka headers, Avro/Schema Registry.