### PR TITLE
feat: add HTTP connector

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -137,6 +137,7 @@ jobs:
       # Each connector alone (including test code) — catches missing #[cfg]s
       # and accidental cross-feature dependencies.
       run: |
+        cargo check --all-targets --features http
         cargo check --all-targets --features kafka
         cargo check --all-targets --features rabbitmq
         cargo check --all-targets --features websocket

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,8 @@ cargo nextest run --features connectors-all        # or: cargo test --features c
 cargo nextest run                                  # minimal build tests (no connectors)
 cargo test --doc --features connectors-all
 cargo check --all-targets                          # minimal baseline compiles
-cargo check --all-targets --features kafka         # each connector alone
+cargo check --all-targets --features http          # each connector alone
+cargo check --all-targets --features kafka
 cargo check --all-targets --features rabbitmq
 cargo check --all-targets --features websocket
 ```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,6 +182,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
+name = "ascii"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
+
+[[package]]
 name = "asn1-rs"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -399,23 +405,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
 dependencies = [
  "async-trait",
- "axum-core",
+ "axum-core 0.3.4",
  "bitflags 1.3.2",
  "bytes",
  "futures-util",
  "http 0.2.12",
- "http-body",
- "hyper",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
  "itoa",
- "matchit",
+ "matchit 0.7.3",
  "memchr",
  "mime",
  "percent-encoding",
  "pin-project-lite",
  "rustversion",
  "serde",
- "sync_wrapper",
- "tower",
+ "sync_wrapper 0.1.2",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core 0.5.6",
+ "bytes",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.1.0",
+ "http-body-util",
+ "hyper 1.10.1",
+ "hyper-util",
+ "itoa",
+ "matchit 0.8.4",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
 ]
@@ -430,9 +464,27 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 0.2.12",
- "http-body",
+ "http-body 0.4.6",
  "mime",
  "rustversion",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.4.0",
+ "http-body 1.1.0",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper 1.0.2",
  "tower-layer",
  "tower-service",
 ]
@@ -508,7 +560,7 @@ dependencies = [
  "bitflags 2.9.1",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -639,6 +691,12 @@ dependencies = [
  "wasm-bindgen",
  "windows-link 0.2.1",
 ]
+
+[[package]]
+name = "chunked_transfer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
 
 [[package]]
 name = "ciborium"
@@ -830,6 +888,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "criterion"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -960,7 +1027,7 @@ dependencies = [
  "openssl-sys",
  "pkg-config",
  "vcpkg",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1290,6 +1357,7 @@ name = "eventflux"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "axum 0.8.9",
  "base64 0.22.1",
  "bincode",
  "chrono",
@@ -1332,13 +1400,15 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "thread_local",
+ "tiny_http",
  "tokio",
  "tokio-stream",
  "tokio-tungstenite",
  "toml",
  "tonic 0.11.0",
  "tonic-build 0.11.0",
- "tower",
+ "tower 0.4.13",
+ "ureq",
  "urlencoding",
  "uuid",
  "vault",
@@ -1398,6 +1468,16 @@ name = "flagset"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "flume"
@@ -1771,6 +1851,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-body"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
+dependencies = [
+ "bytes",
+ "http 1.4.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.4.0",
+ "http-body 1.1.0",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "http-range-header"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1800,7 +1903,7 @@ dependencies = [
  "futures-util",
  "h2",
  "http 0.2.12",
- "http-body",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -1813,6 +1916,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http 1.4.0",
+ "http-body 1.1.0",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1820,7 +1943,7 @@ checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
  "http 0.2.12",
- "hyper",
+ "hyper 0.14.32",
  "log",
  "rustls 0.21.12",
  "rustls-native-certs 0.6.3",
@@ -1834,7 +1957,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
- "hyper",
+ "hyper 0.14.32",
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
@@ -1847,10 +1970,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes",
- "hyper",
+ "hyper 0.14.32",
  "native-tls",
  "tokio",
  "tokio-native-tls",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "bytes",
+ "http 1.4.0",
+ "http-body 1.1.0",
+ "hyper 1.10.1",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -2212,8 +2350,8 @@ dependencies = [
  "futures",
  "home",
  "http 0.2.12",
- "http-body",
- "hyper",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
  "hyper-rustls",
  "hyper-timeout",
  "jsonpath-rust",
@@ -2230,7 +2368,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-util",
- "tower",
+ "tower 0.4.13",
  "tower-http",
  "tracing",
 ]
@@ -2441,6 +2579,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2465,6 +2609,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -3457,8 +3602,8 @@ dependencies = [
  "futures-util",
  "h2",
  "http 0.2.12",
- "http-body",
- "hyper",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -3472,7 +3617,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 0.1.2",
  "system-configuration",
  "tokio",
  "tokio-native-tls",
@@ -3605,6 +3750,7 @@ version = "0.23.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -4013,6 +4159,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
+
+[[package]]
 name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4145,6 +4297,12 @@ name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "synstructure"
@@ -4281,6 +4439,18 @@ checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny_http"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389915df6413a2e74fb181895f933386023c71110878cd0825588928e64cdc82"
+dependencies = [
+ "ascii",
+ "chunked_transfer",
+ "httpdate",
+ "log",
 ]
 
 [[package]]
@@ -4490,15 +4660,15 @@ checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
 dependencies = [
  "async-stream",
  "async-trait",
- "axum",
+ "axum 0.6.20",
  "base64 0.21.7",
  "bytes",
  "futures-core",
  "futures-util",
  "h2",
  "http 0.2.12",
- "http-body",
- "hyper",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
@@ -4507,7 +4677,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.24.1",
  "tokio-stream",
- "tower",
+ "tower 0.4.13",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -4521,13 +4691,13 @@ checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
 dependencies = [
  "async-stream",
  "async-trait",
- "axum",
+ "axum 0.6.20",
  "base64 0.21.7",
  "bytes",
  "h2",
  "http 0.2.12",
- "http-body",
- "hyper",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
@@ -4537,7 +4707,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.25.0",
  "tokio-stream",
- "tower",
+ "tower 0.4.13",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -4590,6 +4760,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "tower-http"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4601,7 +4786,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http 0.2.12",
- "http-body",
+ "http-body 0.4.6",
  "http-range-header",
  "mime",
  "pin-project-lite",
@@ -4716,6 +4901,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64 0.22.1",
+ "flate2",
+ "log",
+ "percent-encoding",
+ "rustls 0.23.35",
+ "rustls-pki-types",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64 0.22.1",
+ "http 1.4.0",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4737,6 +4951,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -4957,6 +5177,15 @@ checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,13 +32,21 @@ cloud-native = ["kubernetes", "consul", "etcd", "vault"]
 # no connector ships in a plain `cargo build`. Release/Docker builds use
 # `--features connectors-all`. See docs/writing_extensions.md for the
 # per-connector gating checklist.
+http = ["dep:axum", "dep:ureq"]
 kafka = ["dep:rdkafka"]
 rabbitmq = ["dep:lapin", "dep:urlencoding"]
 websocket = ["dep:tokio-tungstenite"]
-connectors-all = ["kafka", "rabbitmq", "websocket"]
+connectors-all = ["http", "kafka", "rabbitmq", "websocket"]
 
 [dependencies]
 async-trait = "0.1"
+# Webhook listener for the HTTP connector (concurrent handlers on the
+# already-present tokio runtime). Default features add extractors/tracing
+# glue the connector doesn't use.
+axum = { version = "0.8", default-features = false, features = [
+    "http1",
+    "tokio",
+], optional = true }
 base64 = { version = "0.22", optional = true }
 bincode = "1.3"
 chrono = { version = "0.4", features = ["serde"] }
@@ -99,6 +107,9 @@ tokio-tungstenite = { version = "0.24", features = ["native-tls"], optional = tr
 toml = "0.8"
 tonic = { version = "0.11", features = ["tls"] }
 tower = "0.4"
+# Blocking HTTP client for the HTTP connector's sink and polling source;
+# rustls keeps the build hermetic (no system TLS)
+ureq = { version = "3.3", optional = true }
 urlencoding = { version = "2.1", optional = true }
 uuid = { version = "1", features = ["v4"] }
 vault = { version = "10.1", optional = true }
@@ -112,7 +123,10 @@ criterion = { version = "0.5", features = ["html_reports"] }
 custom_dyn_ext = { path = "tests/custom_dyn_ext" }
 serial_test = "3.5"
 tempfile = "3"
+# Canned-response servers and direct client for HTTP connector tests
+tiny_http = "0.12"
 tokio = { version = "1", features = ["full", "test-util"] }
+ureq = "3.3"
 
 [lints.clippy]
 pedantic = { level = "deny", priority = -1 }

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ feature named after its SQL extension name:
 
 | Feature | Connector | In default build? |
 |---------|-----------|-------------------|
+| `http` | HTTP source (polling + webhook) + sink | No |
 | `kafka` | Kafka source + sink (needs cmake to build) | No |
 | `rabbitmq` | RabbitMQ source + sink | No |
 | `websocket` | WebSocket source + sink | No |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -165,10 +165,10 @@ All have state holder implementations for checkpointing.
 |------------|-------------|-------------|------------------|------------------|
 | Timer      | Done        | —           | —                | (always built)   |
 | Log        | —           | Done        | —                | (always built)   |
+| HTTP       | Done        | Done        | JSON, CSV, bytes | `http`           |
 | Kafka      | Done        | Done        | JSON, CSV, bytes | `kafka`          |
 | RabbitMQ   | Done        | Done        | JSON, CSV, bytes | `rabbitmq`       |
 | WebSocket  | Done        | Done        | JSON, CSV, bytes | `websocket`      |
-| HTTP       | Not started | Not started | —                | —                |
 | File       | Not started | Not started | —                | —                |
 | TCP/Socket | Not started | Not started | —                | —                |
 
@@ -355,10 +355,16 @@ shared-helper adoption, source supervision).
 
 HTTP (Priority 2) is the next connector.
 
-### Priority 2: HTTP Connector
+### Priority 2: HTTP Connector — **DONE (2026-07)**
 
-- HTTP source: REST polling, webhook listener
-- HTTP sink: webhooks, batch requests, retry with exponential backoff
+Implemented per `feat/http/README.md` (design: #133): dual-mode source (REST polling on an
+interruptible interval; concurrent axum webhook listener with auth/limits) and a webhook sink
+with exponential-backoff retry (transport errors and 408/429/5xx only). Blocking `ureq`
+client + async axum server — best tool per side. Feature-gated behind `http`; integration
+tests are self-hosting (no CI service needed). Deferred: request/response mode (#134),
+batched requests, connector-managed conditional GET, OAuth.
+
+File connector (Priority 3) is the next connector.
 
 ### Priority 3: File Connector
 

--- a/docs/writing_extensions.md
+++ b/docs/writing_extensions.md
@@ -57,6 +57,20 @@ A source extension implements the `Source` trait and provides a `SourceFactory`
 (see the RabbitMQ connector in `src/core/stream/input/source/rabbitmq_source.rs`
 for a complete reference implementation).
 
+### Reserved injected properties
+
+Property keys beginning with an underscore are **reserved for the engine** —
+never define your own. `stream_initializer` injects them into the map passed
+to `create_initialized()`:
+
+| Key | Value |
+|-----|-------|
+| `_format` | The stream's declared `format` (e.g. `json`), when one is set |
+
+Connectors may read these to derive format-dependent settings — the HTTP sink
+derives its default Content-Type from `_format` (see
+`connector_util::INJECTED_FORMAT_KEY`).
+
 ### Worker thread lifecycle: use `SourceWorker`
 
 `Source::stop()` has a hard contract: **it must be synchronous**. When `stop()`
@@ -139,6 +153,10 @@ Every in-tree connector is gated behind a cargo feature **named exactly after
 its registered extension name** (the string used in SQL
 `WITH (extension = '...')`). The default build is fully minimal — no
 connectors — and release/Docker builds use `--features connectors-all`.
+
+A feature may own a *family* of related extensions (e.g. a future
+`http-response` sink under the `http` feature) — the SQL extension names stay
+distinct, but they gate together.
 
 When adding a new in-tree connector, touch exactly these points:
 

--- a/examples/http.eventflux
+++ b/examples/http.eventflux
@@ -1,0 +1,78 @@
+-- ============================================================================
+-- EventFlux HTTP Source/Sink Example
+-- ============================================================================
+--
+-- This example demonstrates end-to-end stream processing over HTTP:
+--   1. HTTP Source (webhook): receives JSON alerts via POST
+--   2. EventFlux Query: keeps only CRITICAL alerts
+--   3. HTTP Sink: forwards them to an escalation webhook
+--
+-- Everything is testable with curl alone — no external infrastructure.
+--
+-- ============================================================================
+-- PREREQUISITES
+-- ============================================================================
+--
+-- 0. Build EventFlux with the HTTP connector enabled:
+--
+--    cargo build --release --features http
+--    (Docker images include all connectors already)
+--
+-- 1. Start a receiver for the sink output (in another terminal):
+--
+--    while true; do echo -e 'HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r' \
+--      | nc -l 9090; echo; done
+--
+-- 2. Run this example:
+--
+--    cargo run --features http --bin run_eventflux examples/http.eventflux
+--
+-- 3. Send test alerts (pipe the JSON via --data):
+--
+--    curl -s -X POST http://localhost:8081/alerts \
+--      -H 'X-Webhook-Token: dev-token' \
+--      -d '{"service":"payments","level":"CRITICAL","message":"db down"}'
+--
+--    curl -s -X POST http://localhost:8081/alerts \
+--      -H 'X-Webhook-Token: dev-token' \
+--      -d '{"service":"web","level":"INFO","message":"deploy ok"}'
+--
+--    The CRITICAL alert appears at the receiver from step 1; the INFO alert
+--    is filtered out by the query.
+--
+-- ============================================================================
+
+CREATE STREAM Alerts (
+    service STRING,
+    level STRING,
+    message STRING
+) WITH (
+    type = 'source',
+    extension = 'http',
+    format = 'json',
+    "http.mode" = 'webhook',
+    "http.host" = '0.0.0.0',
+    "http.port" = '8081',
+    "http.path" = '/alerts',
+    "http.auth.header" = 'X-Webhook-Token',
+    "http.auth.token" = 'dev-token'
+);
+
+CREATE STREAM Escalations (
+    service STRING,
+    message STRING
+) WITH (
+    type = 'sink',
+    extension = 'http',
+    format = 'json',
+    "http.url" = 'http://localhost:9090/escalate',
+    "http.retry.max-attempts" = '3',
+    -- The nc receiver can't answer a HEAD probe reliably; skip the
+    -- startup reachability check for this demo
+    "http.validation.method" = 'none'
+);
+
+INSERT INTO Escalations
+SELECT service, message
+FROM Alerts
+WHERE level = 'CRITICAL';

--- a/feat/http/README.md
+++ b/feat/http/README.md
@@ -1,0 +1,357 @@
+# HTTP Connector Specification for EventFlux
+
+Status: **IMPLEMENTED (2026-07-16)** — dual-mode source + sink, factories, gating,
+self-hosting integration tests, example, docs. Deferred items in the table below;
+request/response mode tracked as eventflux-io/eventflux#134.
+Design issue: eventflux-io/eventflux#133 · ROADMAP Priority 2
+
+This document specifies the HTTP source (REST polling + webhook listener) and HTTP sink
+(webhooks with retry), following the patterns established by the Kafka connector
+(`feat/kafka/README.md`, #118) and the connector infrastructure (#115–#117).
+
+## Overview
+
+- **HTTP Source, poll mode**: periodically GETs a URL and feeds each response body into the
+  pipeline
+- **HTTP Source, webhook mode**: runs a lightweight HTTP listener; each accepted POST body
+  becomes a payload
+- **HTTP Sink**: POSTs each event's formatted payload to a URL, with exponential-backoff retry
+
+## Architecture — best tool per side
+
+Client-side work (sink, polling) is simple sequential I/O → a blocking client keeps it
+trivially correct. Server-side work (webhook listener) genuinely benefits from async →
+a production-grade server with built-in concurrency, chosen deliberately for the future
+(middleware, HTTP/2, TLS, and the request/response mode sketched below all slot in without
+re-architecting):
+
+| Component | Crate | Model |
+|-----------|-------|-------|
+| Sink + polling source client | `ureq` 3 (rustls) | Blocking requests with per-request timeout |
+| Webhook listener | `axum` (hyper/tower, on the already-present tokio) | Concurrent async handlers |
+
+```
+Poll source:    SourceWorker thread → ureq GET every interval → body bytes → SourceCallback → mapper
+Webhook source: SourceWorker thread → tokio runtime → axum server (concurrent handlers)
+                  → per request: spawn_blocking → SourceCallback → mapper
+Sink:           per event: mapper → bytes → ureq request (+ bounded retry) → endpoint
+```
+
+- `ureq` with **rustls** keeps the build hermetic (no system TLS), consistent with the
+  `ssl-vendored`/`curl-static` decisions in the Kafka build; tokio is already an
+  unconditional core dependency, so axum adds no runtime that wasn't there
+- The webhook worker follows the RabbitMQ/WebSocket source pattern: `SourceWorker` thread
+  owns a tokio runtime; shutdown is axum's `with_graceful_shutdown`, driven by a small async
+  poll of the worker's running flag (≤100ms) — in-flight requests complete, `stop()` stays
+  synchronous
+- Handlers deliver payloads via `tokio::task::spawn_blocking` (junction publish can block on
+  backpressure; runtime workers must not); the shared `error_ctx` is mutex-wrapped since
+  handlers run concurrently
+- `tiny-http` was considered and rejected: fine for a toy listener, but concurrency,
+  limits, and everything on the future list would have to be hand-rolled onto it
+
+## Feature Gating
+
+Per the checklist in `docs/writing_extensions.md`:
+
+```toml
+[features]
+http = ["dep:ureq", "dep:axum"]
+connectors-all = ["http", "kafka", "rabbitmq", "websocket"]
+```
+
+Both crates are pure Rust — no native toolchain requirement — but stay out of the default
+build per the fully-minimal rule. All gating points apply (module decls, registration,
+`GATED_OUT_EXTENSIONS`, CI per-connector check, justfile, docs).
+
+## HTTP Source
+
+One extension (`extension = 'http'`), two explicit modes.
+
+### Common configuration
+
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| `http.mode` | Yes | - | `poll` or `webhook` |
+| `error.*` | No | - | Standard error-handling strategies (drop/retry/dlq/fail) via the shared helpers |
+
+### Poll mode
+
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| `http.url` | Yes | - | URL to poll (http/https) |
+| `http.poll.interval.ms` | No | `5000` | Time between polls (interruptible via `sleep_while_running`) |
+| `http.method` | No | `GET` | `GET` or `POST` (some APIs poll via POST) |
+| `http.headers.<Name>` | No | - | Request headers, e.g. `"http.headers.Authorization" = 'Bearer ${TOKEN}'` |
+| `http.timeout.ms` | No | `30000` | Per-request timeout (connect + response) |
+
+**Poll loop semantics:**
+
+- 2xx with a non-empty body → one payload delivered through
+  `deliver_with_error_handling` (verdict semantics identical to Kafka: `Fail` stops the source)
+- 2xx with an empty body / `204` → skipped (debug log)
+- `304` → skipped (supports endpoints that implement conditional responses; conditional
+  *request* headers are the user's business via `http.headers.*` in v1)
+- Non-2xx / transport error → routed through the error strategy as `ConnectionUnavailable`
+  (retry strategy gives polling backoff for free)
+- Each poll is independent — there is no offset concept; deduplication is the endpoint's or
+  the query's concern (documented)
+
+### Webhook mode
+
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| `http.port` | Yes | - | Port to listen on |
+| `http.host` | No | `0.0.0.0` | Bind address |
+| `http.path` | No | `/` | Request path to accept |
+| `http.auth.header` | No | - | Header name to require (e.g. `Authorization`, `X-Webhook-Token`) |
+| `http.auth.token` | No | - | Exact value required in `http.auth.header` (both must be set together) |
+| `http.max.concurrent.requests` | No | `256` | Concurrency cap (tower `ConcurrencyLimitLayer`); excess requests queue |
+| `http.max.body.bytes` | No | `1048576` | Payload size cap (axum `DefaultBodyLimit`); oversized → `413` |
+
+**Request handling (concurrent — axum handlers run in parallel up to the concurrency cap):**
+
+| Request | Response |
+|---------|----------|
+| POST on `http.path`, auth OK, payload delivered or disposed (drop/DLQ) | `200` |
+| POST with empty body | `200` (accepted, skipped) |
+| Auth header missing/mismatched | `401` |
+| Wrong path | `404` |
+| Non-POST method | `405` |
+| Body over `http.max.body.bytes` | `413` |
+| Delivery verdict `Fail` | `500`, then the source shuts down gracefully (fail-fast strategy) |
+| Listener shutting down (stop or after a failure) | `503` |
+
+Concurrency note: handlers run in parallel but deliveries are funneled over a bounded
+mpsc channel to a single delivery thread that owns the error context — no lock to
+contend on, and a full queue backpressures handlers naturally. Events enter the junction
+in channel order; HTTP webhooks carry no ordering guarantee anyway (unlike Kafka
+partitions).
+
+### `HttpSource` structure
+
+```rust
+pub enum HttpSourceMode { Poll(PollConfig), Webhook(WebhookConfig) }
+
+pub struct HttpSource {
+    mode: HttpSourceMode,
+    worker: SourceWorker,
+    error_ctx: Option<SourceErrorContext>,
+}
+```
+
+`validate_connectivity()`:
+
+- **poll**: probe `http.url` — any HTTP response (including 4xx) proves reachability;
+  connect failure/timeout fails the app start
+- **webhook**: bind `host:port` and drop the listener — fails fast on port conflicts and
+  permission errors
+
+### `HttpSourceFactory`
+
+`name() = "http"`, formats `json`/`csv`/`bytes`(*)
+required `["http.mode"]` (mode-specific requirements validated in `from_properties`),
+optional: the union of both mode tables + `error.*`.
+
+(*) format applies to the payload bytes; webhook senders set whatever Content-Type they
+like — the mapper, not the transport, interprets the bytes (consistent with all connectors).
+
+## HTTP Sink
+
+One event = one HTTP request (per the #115 contract). Transport-level batching is deferred —
+it belongs in sink-side buffering, not the mapper.
+
+### Configuration
+
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| `http.url` | Yes | - | Endpoint to send to |
+| `http.method` | No | `POST` | `POST`, `PUT`, or `PATCH` |
+| `http.headers.<Name>` | No | - | Request headers (auth goes here; use `${ENV_VAR}` for secrets) |
+| `http.content.type` | No | derived | Defaults from the stream format: json → `application/json`, csv → `text/csv`, bytes → `application/octet-stream`. A verbatim `http.headers.Content-Type` wins instead; setting both is rejected |
+| `http.timeout.ms` | No | `30000` | Per-request timeout |
+| `http.retry.max-attempts` | No | `3` | Retries after the first attempt (`0` disables) |
+| `http.retry.initial-delay-ms` | No | `100` | First retry delay |
+| `http.retry.max-delay-ms` | No | `10000` | Retry delay ceiling |
+| `http.retry.backoff-multiplier` | No | `2.0` | Exponential factor |
+| `http.validation.method` | No | `HEAD` | Startup reachability probe: `HEAD`, `GET`, `OPTIONS`, or `none` to skip |
+
+### Publish semantics
+
+- Success = any **2xx** response; the response body is discarded (request/response patterns
+  are deferred)
+- **Retryable**: transport errors (connect/timeout) and `408`, `429`, `5xx` — retried with
+  exponential backoff up to `http.retry.max-attempts`, then the error is returned to the
+  pipeline (the adapter logs it; the event is not silently lost — per-event isolation from
+  #115 keeps the rest of the batch flowing)
+- **Not retryable**: other `4xx` (the request itself is wrong — retrying can't fix it)
+- Retries happen inside `publish()` (blocking) — backpressure by design, mirroring the
+  Kafka sink's queue-full blocking
+
+`validate_connectivity()` sends the configured probe method; any HTTP response (including
+`405 Method Not Allowed`, common for webhook endpoints probed with HEAD) proves
+reachability. `http.validation.method = 'none'` opts out for endpoints that can't tolerate
+probes.
+
+### `HttpSinkFactory`
+
+Replaces the placeholder in `example_factories.rs` (the second and last placeholder there;
+the module keeps `ExampleSourceFactory` as its teaching fixture — update the module docs and
+any placeholder-based tests, as done for the Kafka stub in #118).
+
+## SQL Usage Examples
+
+```sql
+-- Webhook in, webhook out
+CREATE STREAM Alerts (service STRING, level STRING, message STRING) WITH (
+    type = 'source',
+    extension = 'http',
+    format = 'json',
+    "http.mode" = 'webhook',
+    "http.port" = '8081',
+    "http.path" = '/alerts',
+    "http.auth.header" = 'X-Webhook-Token',
+    "http.auth.token" = '${WEBHOOK_TOKEN}'
+);
+
+CREATE STREAM Escalations (service STRING, message STRING) WITH (
+    type = 'sink',
+    extension = 'http',
+    format = 'json',
+    "http.url" = 'https://hooks.example.com/escalate',
+    "http.headers.Authorization" = 'Bearer ${HOOK_TOKEN}',
+    "http.retry.max-attempts" = '5'
+);
+
+INSERT INTO Escalations
+SELECT service, message FROM Alerts WHERE level = 'CRITICAL';
+
+-- REST polling
+CREATE STREAM Prices (symbol STRING, price DOUBLE) WITH (
+    type = 'source',
+    extension = 'http',
+    format = 'json',
+    "http.mode" = 'poll',
+    "http.url" = 'https://api.example.com/v1/price?symbol=AAPL',
+    "http.poll.interval.ms" = '2000',
+    "http.headers.X-Api-Key" = '${API_KEY}'
+);
+```
+
+Example file: `examples/http.eventflux` (webhook → filter → webhook sink; testable with
+`curl` alone — no external infrastructure).
+
+## Testing Plan — no external services needed
+
+This connector is self-hosting for tests, so unlike Kafka/RabbitMQ the integration tests are
+**not `#[ignore]`d** — they run in every `--features http` test invocation:
+
+- **Unit tests** (in-module): config parsing for both modes and the sink (required/optional,
+  invalid values, auth pair validation, header prefix parsing, content-type derivation,
+  retry parameter validation)
+- **Integration tests** (`tests/http_integration.rs`, in-process servers):
+  - Round trip through public API: HTTP sink → webhook source (the connector receives its
+    own output)
+  - Poll source against an in-process `tiny_http` responder (dev-dependency): 2xx body
+    delivered, empty/304 skipped, 5xx routed to error strategy
+  - Webhook responses: 401 on bad token, 404 wrong path, 405 wrong method, 413 oversized,
+    200 on success
+  - Sink retry: responder fails twice then succeeds → delivered after backoff; 4xx → no
+    retry; max-attempts exhausted → error
+  - `validate_connectivity`: reachable/unreachable/`none` for the sink; port-conflict
+    failure for the webhook source
+  - Shutdown: both modes stop promptly (poll mid-interval via `sleep_while_running`,
+    listener via axum graceful shutdown); a slow in-flight webhook request completes
+    before the worker exits
+  - Concurrency: N parallel webhook POSTs all delivered (none dropped, none serialized
+    behind each other beyond the configured cap)
+- **CI**: no new service container; the per-connector gating check gains
+  `cargo check --all-targets --features http`
+
+`tiny_http` is added as a (non-optional) dev-dependency for test responders — pure Rust,
+compiles in seconds, acceptable in the minimal test build.
+
+## Implementation Plan
+
+| Phase | Scope |
+|-------|-------|
+| 1 | `http` cargo feature + `http_common.rs` if warranted (headers/timeout/retry parsing shared by source and sink) |
+| 2 | `http_source.rs` — poll + webhook modes, factory, unit tests |
+| 3 | `http_sink.rs` — client, retry, factory, unit tests; replace the placeholder in `example_factories.rs` |
+| 4 | Registration, gating points, integration tests, `examples/http.eventflux` |
+| 5 | Docs: website connector page + tables, README feature row, ROADMAP P2 → Done, this spec → IMPLEMENTED |
+
+## Future: request/response mode (design sketch, not in v1)
+
+The webhook mode is fire-and-forget: `200` acknowledges *acceptance*, not the query result.
+A synchronous request-reply mode — client POSTs, the event flows through the query, and the
+**correlated output event is returned as the HTTP response** — would turn EventFlux into a
+decision service (fraud scoring, routing, enrichment APIs). Siddhi shipped exactly this as
+its `http-request`/`http-response` source–sink pair, so the shape is proven:
+
+- `http.mode = 'request'` source: for each request, generate a correlation id, inject it as
+  a **declared attribute** of the stream (e.g. the first column), park the request on a
+  `oneshot` channel in a registry keyed by `http.source.id` + correlation id
+- A paired `http-response` **sink** (separate extension name) configured with the same
+  `http.source.id` and `http.correlation.field`: on publish, it looks up the parked request
+  and completes it with the payload as the response body
+- `http.request.timeout.ms`: parked requests that never see a correlated output (e.g. the
+  query's WHERE filtered the event out) respond `504`
+- **Separation of concerns survives**: no `Source`/`Sink` trait changes — the coupling is
+  contained in a shared registry (in `EventFluxContext`, like other cross-component
+  registries) plus an explicit, user-visible schema convention for the correlation field.
+  The correlation id rides through the query as ordinary data, which also makes the 1:1
+  constraint honest: windows/aggregations that break per-event correspondence simply time
+  the request out, and the docs say so
+- axum makes the "hold thousands of requests open" part natural (async handlers awaiting
+  oneshot channels) — this is a primary reason the listener is axum and not a minimal
+  blocking server
+
+Not in v1 because it deserves its own spec/PR: registry lifecycle, timeout sweeping, and
+backpressure under parked-request load each need design attention. Tracked as a follow-up
+issue.
+
+## Forward-Compatibility Notes (decided at spec review)
+
+Config keys and extension names are public API — these rules exist so future features are
+additive, never breaking:
+
+1. **Source metadata is one interface evolution, shared with Kafka.** Request/response
+   correlation injection (#134) and transport-metadata exposure (Kafka key/headers/timestamp,
+   HTTP request headers/path — the source-side twin of #126) need the same capability:
+   metadata flowing alongside the payload through `SourceCallback`. Whichever lands first
+   introduces the single shared shape (payload + transport-metadata map, adapter-side mapping
+   into declared attributes); the other consumes it. HTTP v1 requires nothing here.
+2. **`http.auth.*` means inbound verification only** (webhook callers proving themselves).
+   Outbound credentials are `http.headers.*` today and `http.oauth.*` when OAuth lands —
+   the prefix never switches direction.
+3. **Extension families under one feature**: #134 adds an `http-response` sink under the
+   same `http` cargo feature. The gating rule ("feature named after the extension") gains a
+   footnote: a feature may own a family of related extensions.
+4. **One port per webhook source (v1)**: two sources on the same port fail at validation
+   (bind check). A future shared-listener registry (port → composed router) is an internal
+   change — `http.host`/`http.port`/`http.path` keys are stable under it.
+5. **`ureq` is HTTP/1.1 only** (client side). An HTTP/2 client need is met by swapping the
+   client internally; no config key encodes the protocol.
+6. **Counters parity**: source (requests/polls received, failed) and sink (requests sent,
+   failed) keep the same local-counter shape as Kafka, logged at stop, so the observability
+   work (#128) finds a uniform surface.
+7. **Reserved injected properties** (added during implementation): keys with a leading
+   underscore in the factory properties map are engine-reserved. `stream_initializer`
+   injects `_format` (the stream's declared format) for every source/sink factory — the
+   HTTP sink derives its default Content-Type from it, and any future connector may read
+   it. Documented in `docs/writing_extensions.md`; this is a config-time metadata channel
+   that the future transport-metadata interface (note 1) should be designed alongside.
+
+## Deferred (post-v1)
+
+| Feature | Reason |
+|---------|--------|
+| Request/response mode | Design sketch above; own spec + PR |
+| Batched sink requests (N events per POST) | Needs sink-side buffering design; #115 contract keeps mapper per-event |
+| Pagination / conditional GET (ETag/If-Modified-Since managed by the connector) | Stateful polling; v1 passes conditional headers through untouched |
+| OAuth 2.0 flows / token refresh | Static headers + env vars cover v1 |
+| TLS for the webhook listener | Reverse proxy for v1; axum + rustls acceptor is the natural in-process path later |
+| Listener client-read timeouts (slowloris hardening) | Reverse proxy enforces client timeouts for v1 |
+| Redirect following on the client side | Deliberately disabled — following a 301/302 rewrites POST to a body-less GET (silent payload loss); 3xx is a permanent error |
+| Per-event dynamic URLs | Needs per-event sink context — eventflux-io/eventflux#126 |

--- a/justfile
+++ b/justfile
@@ -33,6 +33,7 @@ lint:
 # Feature-gating honesty: minimal build and each connector alone must compile
 check-minimal:
   cargo check --all-targets
+  cargo check --all-targets --features http
   cargo check --all-targets --features kafka
   cargo check --all-targets --features rabbitmq
   cargo check --all-targets --features websocket

--- a/src/core/config/eventflux_context.rs
+++ b/src/core/config/eventflux_context.rs
@@ -426,12 +426,16 @@ impl EventFluxContext {
             OrAttributeAggregatorFactory, StdDevAttributeAggregatorFactory,
             SumAttributeAggregatorFactory,
         };
+        #[cfg(feature = "http")]
+        use crate::core::stream::input::source::http_source::HttpSourceFactory;
         #[cfg(feature = "kafka")]
         use crate::core::stream::input::source::kafka_source::KafkaSourceFactory;
         #[cfg(feature = "rabbitmq")]
         use crate::core::stream::input::source::rabbitmq_source::RabbitMQSourceFactory;
         #[cfg(feature = "websocket")]
         use crate::core::stream::input::source::websocket_source::WebSocketSourceFactory;
+        #[cfg(feature = "http")]
+        use crate::core::stream::output::sink::http_sink::HttpSinkFactory;
         #[cfg(feature = "kafka")]
         use crate::core::stream::output::sink::kafka_sink::KafkaSinkFactory;
         #[cfg(feature = "rabbitmq")]
@@ -532,6 +536,8 @@ impl EventFluxContext {
         self.add_table_factory("jdbc".to_string(), Box::new(JdbcTableFactory));
         self.add_table_factory("cache".to_string(), Box::new(CacheTableFactory));
         self.add_source_factory("timer".to_string(), Box::new(TimerSourceFactory));
+        #[cfg(feature = "http")]
+        self.add_source_factory("http".to_string(), Box::new(HttpSourceFactory));
         #[cfg(feature = "kafka")]
         self.add_source_factory("kafka".to_string(), Box::new(KafkaSourceFactory));
         #[cfg(feature = "rabbitmq")]
@@ -539,6 +545,8 @@ impl EventFluxContext {
         #[cfg(feature = "websocket")]
         self.add_source_factory("websocket".to_string(), Box::new(WebSocketSourceFactory));
         self.add_sink_factory("log".to_string(), Box::new(LogSinkFactory));
+        #[cfg(feature = "http")]
+        self.add_sink_factory("http".to_string(), Box::new(HttpSinkFactory));
         #[cfg(feature = "kafka")]
         self.add_sink_factory("kafka".to_string(), Box::new(KafkaSinkFactory));
         #[cfg(feature = "rabbitmq")]

--- a/src/core/error/retry.rs
+++ b/src/core/error/retry.rs
@@ -231,21 +231,28 @@ pub fn exponential_backoff(
     initial_delay: Duration,
     max_delay: Duration,
 ) -> Duration {
+    exponential_backoff_with_multiplier(attempt, initial_delay, max_delay, 2.0)
+}
+
+/// Exponential backoff with a configurable growth factor (`multiplier >= 1`),
+/// capped at `max_delay`; overflow saturates at the cap. `attempt` is
+/// 1-based; attempt 0 returns zero.
+pub fn exponential_backoff_with_multiplier(
+    attempt: usize,
+    initial_delay: Duration,
+    max_delay: Duration,
+    multiplier: f64,
+) -> Duration {
     if attempt == 0 {
         return Duration::ZERO;
     }
 
-    // Calculate 2^(attempt-1) using checked operations to prevent overflow
-    let multiplier = 2u64.saturating_pow((attempt - 1) as u32);
-    let delay_ms = (initial_delay.as_millis() as u64).saturating_mul(multiplier);
+    let max_ms = max_delay.as_millis() as u64 as f64;
+    let factor = multiplier.powi((attempt - 1) as i32);
+    // Clamp in f64 space before the cast so overflow saturates at the cap
+    let delay_ms = (initial_delay.as_millis() as u64 as f64 * factor).min(max_ms);
 
-    let delay = Duration::from_millis(delay_ms);
-
-    if delay > max_delay {
-        max_delay
-    } else {
-        delay
-    }
+    Duration::from_millis(delay_ms as u64)
 }
 
 /// Calculate linear backoff delay for a retry attempt

--- a/src/core/extension/example_factories.rs
+++ b/src/core/extension/example_factories.rs
@@ -21,7 +21,7 @@
 //!
 //! ## Placeholder Factories (NOT production-ready)
 //! - `ExampleSourceFactory` - Fictional source demonstrating the factory pattern
-//! - `HttpSinkFactory` - Placeholder for future HTTP sink
+//! - `ExampleSinkFactory` - Fictional sink demonstrating the factory pattern
 //!
 //! ## Production-Ready Factories (in proper modules)
 //! - `KafkaSourceFactory`/`KafkaSinkFactory` in `kafka_source.rs`/`kafka_sink.rs`
@@ -192,47 +192,47 @@ impl SourceFactory for ExampleSourceFactory {
 }
 
 // ============================================================================
-// HTTP Sink Factory (Placeholder)
+// Example Sink Factory (Placeholder)
 // ============================================================================
 
-/// HTTP-specific validated configuration
+/// Example validated sink configuration
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
-struct HttpSinkConfig {
+struct ExampleSinkConfig {
     url: String,
     method: String,
     headers: HashMap<String, String>,
     timeout_secs: u64,
 }
 
-impl HttpSinkConfig {
+impl ExampleSinkConfig {
     fn parse(raw_config: &HashMap<String, String>) -> Result<Self, EventFluxError> {
         let url = raw_config
-            .get("http.url")
-            .ok_or_else(|| EventFluxError::missing_parameter("http.url"))?;
+            .get("example.url")
+            .ok_or_else(|| EventFluxError::missing_parameter("example.url"))?;
 
         let method = raw_config
-            .get("http.method")
+            .get("example.method")
             .cloned()
             .unwrap_or_else(|| "POST".to_string());
 
-        // Validate HTTP method
+        // Validate the method against an allowlist
         if !["GET", "POST", "PUT", "DELETE", "PATCH"].contains(&method.to_uppercase().as_str()) {
             return Err(EventFluxError::invalid_parameter_with_details(
-                format!("Invalid HTTP method: {}", method),
-                "http.method",
+                format!("Invalid example.method: {}", method),
+                "example.method",
                 "one of: GET, POST, PUT, DELETE, PATCH",
             ));
         }
 
         let timeout_secs = raw_config
-            .get("http.timeout")
+            .get("example.timeout")
             .map(|s| s.parse::<u64>())
             .transpose()
             .map_err(|_| {
                 EventFluxError::invalid_parameter_with_details(
-                    "http.timeout must be a valid integer",
-                    "http.timeout",
+                    "example.timeout must be a valid integer",
+                    "example.timeout",
                     "positive integer (seconds)",
                 )
             })?
@@ -241,7 +241,7 @@ impl HttpSinkConfig {
         // Parse headers (simple implementation)
         let headers = HashMap::new(); // Placeholder for header parsing
 
-        Ok(HttpSinkConfig {
+        Ok(ExampleSinkConfig {
             url: url.clone(),
             method: method.to_uppercase(),
             headers,
@@ -250,43 +250,40 @@ impl HttpSinkConfig {
     }
 }
 
-/// Placeholder HTTP Sink
+/// Placeholder Sink demonstrating the trait surface
 #[derive(Debug)]
-struct HttpSink {
+struct ExampleSink {
     _url: String,
     _method: String,
 }
 
-impl Sink for HttpSink {
+impl Sink for ExampleSink {
     fn publish(&self, _payload: &[u8]) -> Result<(), EventFluxError> {
-        // Placeholder: actual implementation would send HTTP request
-        // Example:
-        // let client = reqwest::blocking::Client::new();
-        // client.post(&self._url)
-        //     .body(payload.to_vec())
-        //     .header("Content-Type", "application/json")
-        //     .send()?;
+        // Placeholder: actual implementation would send the payload to the
+        // external system — see `HttpSinkFactory` in `http_sink.rs` for a
+        // production example
         Ok(())
     }
 
     fn clone_box(&self) -> Box<dyn Sink> {
-        Box::new(HttpSink {
+        Box::new(ExampleSink {
             _url: self._url.clone(),
             _method: self._method.clone(),
         })
     }
 }
 
-/// Placeholder HTTP sink factory.
+/// Placeholder sink factory demonstrating metadata + validated creation.
 ///
-/// This is NOT production-ready. For a production implementation example,
-/// see `RabbitMQSinkFactory` in `rabbitmq_sink.rs`.
+/// This is NOT production-ready. For production implementation examples,
+/// see `HttpSinkFactory` in `http_sink.rs` or `RabbitMQSinkFactory` in
+/// `rabbitmq_sink.rs`.
 #[derive(Debug, Clone)]
-pub struct HttpSinkFactory;
+pub struct ExampleSinkFactory;
 
-impl SinkFactory for HttpSinkFactory {
+impl SinkFactory for ExampleSinkFactory {
     fn name(&self) -> &'static str {
-        "http"
+        "example"
     }
 
     fn supported_formats(&self) -> &[&str] {
@@ -294,20 +291,20 @@ impl SinkFactory for HttpSinkFactory {
     }
 
     fn required_parameters(&self) -> &[&str] {
-        &["http.url"]
+        &["example.url"]
     }
 
     fn optional_parameters(&self) -> &[&str] {
-        &["http.method", "http.headers", "http.timeout"]
+        &["example.method", "example.headers", "example.timeout"]
     }
 
     fn create_initialized(
         &self,
         config: &HashMap<String, String>,
     ) -> Result<Box<dyn Sink>, EventFluxError> {
-        let parsed = HttpSinkConfig::parse(config)?;
+        let parsed = ExampleSinkConfig::parse(config)?;
 
-        Ok(Box::new(HttpSink {
+        Ok(Box::new(ExampleSink {
             _url: parsed.url,
             _method: parsed.method,
         }))
@@ -368,27 +365,30 @@ mod tests {
     }
 
     #[test]
-    fn test_http_sink_config_parse() {
+    fn test_example_sink_config_parse() {
         let mut config = HashMap::new();
         config.insert(
-            "http.url".to_string(),
+            "example.url".to_string(),
             "http://localhost:8080/api".to_string(),
         );
-        config.insert("http.method".to_string(), "POST".to_string());
+        config.insert("example.method".to_string(), "POST".to_string());
 
-        let parsed = HttpSinkConfig::parse(&config).unwrap();
+        let parsed = ExampleSinkConfig::parse(&config).unwrap();
         assert_eq!(parsed.url, "http://localhost:8080/api");
         assert_eq!(parsed.method, "POST");
         assert_eq!(parsed.timeout_secs, 30);
     }
 
     #[test]
-    fn test_http_sink_config_invalid_method() {
+    fn test_example_sink_config_invalid_method() {
         let mut config = HashMap::new();
-        config.insert("http.url".to_string(), "http://localhost:8080".to_string());
-        config.insert("http.method".to_string(), "INVALID".to_string());
+        config.insert(
+            "example.url".to_string(),
+            "http://localhost:8080".to_string(),
+        );
+        config.insert("example.method".to_string(), "INVALID".to_string());
 
-        let result = HttpSinkConfig::parse(&config);
+        let result = ExampleSinkConfig::parse(&config);
         assert!(result.is_err());
     }
 

--- a/src/core/extension/mod.rs
+++ b/src/core/extension/mod.rs
@@ -641,7 +641,7 @@ pub const REGISTER_SINK_MAPPERS_FN: &[u8] = b"register_sink_mappers";
 mod tests {
     use super::*;
     use crate::core::config::eventflux_context::EventFluxContext;
-    use crate::core::extension::example_factories::{ExampleSourceFactory, HttpSinkFactory};
+    use crate::core::extension::example_factories::{ExampleSinkFactory, ExampleSourceFactory};
 
     #[test]
     fn test_factory_registration() {
@@ -743,25 +743,25 @@ mod tests {
     }
 
     #[test]
-    fn test_http_sink_factory_format_support() {
-        let factory = HttpSinkFactory;
+    fn test_example_sink_factory_format_support() {
+        let factory = ExampleSinkFactory;
         assert!(factory.supported_formats().contains(&"json"));
         assert!(factory.supported_formats().contains(&"xml"));
         assert!(!factory.supported_formats().contains(&"avro"));
     }
 
     #[test]
-    fn test_http_sink_factory_required_params() {
-        let factory = HttpSinkFactory;
-        assert_eq!(factory.required_parameters(), &["http.url"]);
+    fn test_example_sink_factory_required_params() {
+        let factory = ExampleSinkFactory;
+        assert_eq!(factory.required_parameters(), &["example.url"]);
     }
 
     #[test]
-    fn test_http_sink_factory_create() {
-        let factory = HttpSinkFactory;
+    fn test_example_sink_factory_create() {
+        let factory = ExampleSinkFactory;
         let mut config = std::collections::HashMap::new();
         config.insert(
-            "http.url".to_string(),
+            "example.url".to_string(),
             "http://localhost:8080/events".to_string(),
         );
 

--- a/src/core/stream/connector_util.rs
+++ b/src/core/stream/connector_util.rs
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2025-2026 EventFlux.io
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Small helpers shared by connector configuration parsers.
+
+use std::collections::HashMap;
+use std::fmt::Display;
+use std::str::FromStr;
+
+/// Key injected by `stream_initializer` into the properties map passed to
+/// source/sink factories, carrying the stream's `format` (e.g. "json").
+/// The leading underscore marks it as reserved/injected — factories must not
+/// accept it from user configuration under another meaning.
+pub const INJECTED_FORMAT_KEY: &str = "_format";
+
+/// Parse an optional property, falling back to `default` when absent.
+pub fn parse_or<T: FromStr>(
+    properties: &HashMap<String, String>,
+    key: &str,
+    default: T,
+) -> Result<T, String>
+where
+    T::Err: Display,
+{
+    match properties.get(key) {
+        Some(v) => v.parse().map_err(|e| format!("Invalid {key}: {e}")),
+        None => Ok(default),
+    }
+}
+
+/// Collect `<prefix><Name>` properties into `(Name, value)` pairs — the
+/// header-map convention used by the WebSocket and HTTP connectors
+/// (e.g. `http.headers.Authorization`).
+pub fn parse_prefixed(properties: &HashMap<String, String>, prefix: &str) -> Vec<(String, String)> {
+    let mut out: Vec<(String, String)> = properties
+        .iter()
+        .filter_map(|(k, v)| {
+            k.strip_prefix(prefix)
+                .filter(|name| !name.is_empty())
+                .map(|name| (name.to_string(), v.clone()))
+        })
+        .collect();
+    // HashMap iteration order is arbitrary — sort for deterministic behavior
+    out.sort();
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_or_default_value_and_error() {
+        let mut props = HashMap::new();
+        assert_eq!(parse_or(&props, "k", 5u64).unwrap(), 5);
+
+        props.insert("k".to_string(), "9".to_string());
+        assert_eq!(parse_or(&props, "k", 5u64).unwrap(), 9);
+
+        props.insert("k".to_string(), "no".to_string());
+        assert!(parse_or(&props, "k", 5u64)
+            .unwrap_err()
+            .contains("Invalid k"));
+    }
+
+    #[test]
+    fn test_parse_prefixed() {
+        let mut props = HashMap::new();
+        props.insert("http.headers.B-Second".to_string(), "2".to_string());
+        props.insert("http.headers.A-First".to_string(), "1".to_string());
+        props.insert("http.url".to_string(), "x".to_string());
+        props.insert("http.headers.".to_string(), "empty-name".to_string());
+
+        let headers = parse_prefixed(&props, "http.headers.");
+        assert_eq!(
+            headers,
+            vec![
+                ("A-First".to_string(), "1".to_string()),
+                ("B-Second".to_string(), "2".to_string()),
+            ]
+        );
+    }
+}

--- a/src/core/stream/http_common.rs
+++ b/src/core/stream/http_common.rs
@@ -1,0 +1,243 @@
+/*
+ * Copyright 2025-2026 EventFlux.io
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Configuration and client helpers shared by the HTTP source and sink.
+
+use crate::core::exception::EventFluxError;
+use crate::core::stream::connector_util::{parse_or, parse_prefixed};
+use std::collections::HashMap;
+use std::time::Duration;
+
+/// Request headers from `http.headers.<Name>` properties.
+///
+/// Secrets belong in environment variables:
+/// `"http.headers.Authorization" = 'Bearer ${TOKEN}'`.
+pub fn parse_headers(properties: &HashMap<String, String>) -> Vec<(String, String)> {
+    parse_prefixed(properties, "http.headers.")
+}
+
+/// Validate an `http://` or `https://` URL property.
+pub fn parse_url(properties: &HashMap<String, String>) -> Result<String, String> {
+    let url = properties
+        .get("http.url")
+        .ok_or("Missing required property: http.url")?
+        .trim()
+        .to_string();
+    if !url.starts_with("http://") && !url.starts_with("https://") {
+        return Err(format!(
+            "Invalid http.url '{url}': must start with http:// or https://"
+        ));
+    }
+    Ok(url)
+}
+
+/// Exponential-backoff retry policy for outbound requests (`http.retry.*`)
+#[derive(Debug, Clone)]
+pub struct HttpRetryConfig {
+    /// Retries after the first attempt (0 disables retrying)
+    pub max_attempts: u32,
+    pub initial_delay_ms: u64,
+    pub max_delay_ms: u64,
+    pub backoff_multiplier: f64,
+}
+
+impl HttpRetryConfig {
+    pub fn from_properties(properties: &HashMap<String, String>) -> Result<Self, String> {
+        let config = Self {
+            max_attempts: parse_or(properties, "http.retry.max-attempts", 3)?,
+            initial_delay_ms: parse_or(properties, "http.retry.initial-delay-ms", 100)?,
+            max_delay_ms: parse_or(properties, "http.retry.max-delay-ms", 10_000)?,
+            backoff_multiplier: parse_or(properties, "http.retry.backoff-multiplier", 2.0)?,
+        };
+        // NaN fails every comparison, so it needs its own rejection
+        if config.backoff_multiplier.is_nan() || config.backoff_multiplier < 1.0 {
+            return Err(format!(
+                "Invalid http.retry.backoff-multiplier '{}': must be >= 1.0",
+                config.backoff_multiplier
+            ));
+        }
+        Ok(config)
+    }
+
+    /// Delay before retry number `retry` (1-based), capped at the ceiling
+    pub fn delay_for(&self, retry: u32) -> Duration {
+        crate::core::error::retry::exponential_backoff_with_multiplier(
+            retry as usize,
+            Duration::from_millis(self.initial_delay_ms),
+            Duration::from_millis(self.max_delay_ms),
+            self.backoff_multiplier,
+        )
+    }
+}
+
+/// Parse an optional method property against an allowlist, normalizing to
+/// uppercase.
+pub fn parse_method(
+    properties: &HashMap<String, String>,
+    key: &str,
+    default: &str,
+    allowed: &[&str],
+) -> Result<String, String> {
+    let method = properties
+        .get(key)
+        .map_or_else(|| default.to_string(), |v| v.to_uppercase());
+    if !allowed.contains(&method.as_str()) {
+        return Err(format!(
+            "Invalid {key} '{method}': expected one of {}",
+            allowed.join(", ")
+        ));
+    }
+    Ok(method)
+}
+
+/// Build a request with the configured headers applied (body added by the
+/// caller). One definition instead of a copy per call site.
+pub fn build_request(
+    method: &str,
+    url: &str,
+    headers: &[(String, String)],
+) -> ureq::http::request::Builder {
+    // ureq re-exports the exact `http` crate version its API expects
+    let mut request = ureq::http::Request::builder().method(method).uri(url);
+    for (name, value) in headers {
+        request = request.header(name, value);
+    }
+    request
+}
+
+/// Compare a presented secret against the expected one without an
+/// early-exit on the first differing byte, so response timing does not
+/// leak how much of the token matched. (Length inequality still returns
+/// fast — the token length is not the secret.)
+pub fn constant_time_eq(presented: &[u8], expected: &[u8]) -> bool {
+    presented.len() == expected.len()
+        && presented
+            .iter()
+            .zip(expected)
+            .fold(0u8, |acc, (a, b)| acc | (a ^ b))
+            == 0
+}
+
+/// Whether a response status warrants a retry: request timeout, rate
+/// limiting, and server-side errors. Other 4xx mean the request itself is
+/// wrong — retrying cannot fix it.
+pub fn is_retryable_status(status: u16) -> bool {
+    status == 408 || status == 429 || (500..600).contains(&status)
+}
+
+/// Blocking client with a global per-request timeout. Non-2xx statuses are
+/// returned as responses (not errors) so callers branch on status codes.
+///
+/// Redirects are never followed: ureq's default would rewrite a redirected
+/// POST/PUT to a body-less GET (per 301/302/303 semantics), making the sink
+/// report a dropped payload as delivered. A 3xx instead surfaces to the
+/// caller as a non-2xx status — point the URL at the final location.
+pub fn build_agent(timeout_ms: u64) -> ureq::Agent {
+    ureq::Agent::config_builder()
+        .timeout_global(Some(Duration::from_millis(timeout_ms)))
+        .http_status_as_error(false)
+        .max_redirects(0)
+        .build()
+        .into()
+}
+
+/// Startup reachability probe: ANY HTTP response — including 4xx/405 —
+/// proves the endpoint is reachable; only transport failures (connect,
+/// timeout, TLS) fail the probe.
+pub fn probe_reachability(
+    agent: &ureq::Agent,
+    method: &str,
+    url: &str,
+    headers: &[(String, String)],
+) -> Result<(), EventFluxError> {
+    let request = build_request(method, url, headers).body(()).map_err(|e| {
+        EventFluxError::configuration(format!("Failed to build probe request for '{url}': {e}"))
+    })?;
+
+    agent
+        .run(request)
+        .map(|_| ())
+        .map_err(|e| EventFluxError::ConnectionUnavailable {
+            message: format!("HTTP endpoint '{url}' is not reachable: {e}"),
+            source: Some(Box::new(e)),
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_url_valid_and_invalid() {
+        let mut props = HashMap::new();
+        assert!(parse_url(&props).unwrap_err().contains("http.url"));
+
+        props.insert("http.url".to_string(), "ftp://x".to_string());
+        assert!(parse_url(&props).unwrap_err().contains("http://"));
+
+        props.insert(
+            "http.url".to_string(),
+            "https://example.com/hook".to_string(),
+        );
+        assert_eq!(parse_url(&props).unwrap(), "https://example.com/hook");
+    }
+
+    #[test]
+    fn test_retry_config_defaults_and_backoff() {
+        let config = HttpRetryConfig::from_properties(&HashMap::new()).unwrap();
+        assert_eq!(config.max_attempts, 3);
+        assert_eq!(config.delay_for(1), Duration::from_millis(100));
+        assert_eq!(config.delay_for(2), Duration::from_millis(200));
+        assert_eq!(config.delay_for(3), Duration::from_millis(400));
+        // Capped at the ceiling
+        assert_eq!(config.delay_for(20), Duration::from_millis(10_000));
+    }
+
+    #[test]
+    fn test_retry_config_rejects_sub_one_multiplier() {
+        for bad in ["0.5", "NaN"] {
+            let mut props = HashMap::new();
+            props.insert("http.retry.backoff-multiplier".to_string(), bad.to_string());
+            assert!(
+                HttpRetryConfig::from_properties(&props)
+                    .unwrap_err()
+                    .contains("backoff-multiplier"),
+                "'{bad}' must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn test_constant_time_eq() {
+        assert!(constant_time_eq(b"secret", b"secret"));
+        assert!(!constant_time_eq(b"secret", b"secreT"));
+        assert!(!constant_time_eq(b"secret", b"secret2"));
+        assert!(!constant_time_eq(b"", b"x"));
+        assert!(constant_time_eq(b"", b""));
+    }
+
+    #[test]
+    fn test_retryable_statuses() {
+        assert!(is_retryable_status(408));
+        assert!(is_retryable_status(429));
+        assert!(is_retryable_status(500));
+        assert!(is_retryable_status(503));
+        assert!(!is_retryable_status(200));
+        assert!(!is_retryable_status(400));
+        assert!(!is_retryable_status(404));
+    }
+}

--- a/src/core/stream/input/source/http_source.rs
+++ b/src/core/stream/input/source/http_source.rs
@@ -1,0 +1,883 @@
+/*
+ * Copyright 2025-2026 EventFlux.io
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! # HTTP Source
+//!
+//! Two modes, selected by `http.mode`:
+//!
+//! - **poll**: periodically requests a URL; each 2xx body is one payload
+//! - **webhook**: runs an axum listener; each accepted POST body is one payload
+//!
+//! ## Architecture
+//!
+//! ```text
+//! poll:    SourceWorker thread → ureq request every interval → bytes → SourceCallback → mapper
+//! webhook: SourceWorker thread → tokio runtime → axum (concurrent handlers)
+//!            → bounded mpsc → delivery thread → SourceCallback → mapper
+//! ```
+//!
+//! The webhook listener handles requests concurrently (bounded by
+//! `http.max.concurrent.requests`); payloads are funneled over a bounded
+//! channel to a single delivery thread that owns the error context, so a full
+//! queue backpressures handlers naturally. A delivery verdict of `Fail`
+//! responds 500 and shuts the listener down gracefully.
+
+use super::{sleep_while_running, Source, SourceCallback, SourceWorker};
+use crate::core::error::source_support::{
+    deliver_with_error_handling, DeliveryVerdict, SourceErrorContext,
+};
+use crate::core::exception::EventFluxError;
+use crate::core::extension::SourceFactory;
+use crate::core::stream::connector_util::parse_or;
+use crate::core::stream::http_common::{
+    build_agent, build_request, constant_time_eq, parse_headers, parse_method, parse_url,
+    probe_reachability,
+};
+use crate::core::stream::input::input_handler::InputHandler;
+use axum::extract::{Request, State};
+use axum::http::StatusCode;
+use axum::routing::post;
+use axum::Router;
+use std::collections::HashMap;
+use std::fmt::Debug;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+/// Poll-mode configuration
+#[derive(Debug, Clone)]
+pub struct HttpPollConfig {
+    /// URL to poll
+    pub url: String,
+    /// Time between polls (default 5000; interruptible)
+    pub interval_ms: u64,
+    /// `GET` (default) or `POST` (some APIs poll via POST)
+    pub method: String,
+    /// Request headers from `http.headers.<Name>`
+    pub headers: Vec<(String, String)>,
+    /// Per-request timeout (default 30000)
+    pub timeout_ms: u64,
+}
+
+/// Webhook-mode configuration
+#[derive(Debug, Clone)]
+pub struct HttpWebhookConfig {
+    /// Bind address (default 0.0.0.0)
+    pub host: String,
+    /// Port to listen on
+    pub port: u16,
+    /// Request path to accept (default "/")
+    pub path: String,
+    /// Optional inbound auth: required header name + exact value
+    pub auth: Option<(String, String)>,
+    /// Concurrency cap (default 256)
+    pub max_concurrent: usize,
+    /// Payload size cap in bytes (default 1 MiB); oversized → 413
+    pub max_body_bytes: usize,
+}
+
+/// Source mode + its configuration
+#[derive(Debug, Clone)]
+pub enum HttpSourceMode {
+    Poll(HttpPollConfig),
+    Webhook(HttpWebhookConfig),
+}
+
+impl HttpSourceMode {
+    /// Parse configuration from properties HashMap
+    pub fn from_properties(properties: &HashMap<String, String>) -> Result<Self, String> {
+        match properties
+            .get("http.mode")
+            .ok_or("Missing required property: http.mode ('poll' or 'webhook')")?
+            .as_str()
+        {
+            "poll" => Ok(Self::Poll(HttpPollConfig {
+                url: parse_url(properties)?,
+                interval_ms: parse_or(properties, "http.poll.interval.ms", 5000)?,
+                method: parse_method(properties, "http.method", "GET", &["GET", "POST"])?,
+                headers: parse_headers(properties),
+                timeout_ms: parse_or(properties, "http.timeout.ms", 30_000)?,
+            })),
+            "webhook" => {
+                let port: u16 = properties
+                    .get("http.port")
+                    .ok_or("Missing required property: http.port (webhook mode)")?
+                    .parse()
+                    .map_err(|e| format!("Invalid http.port: {e}"))?;
+                if port == 0 {
+                    // Port 0 binds an OS-assigned ephemeral port that no
+                    // webhook sender could know about
+                    return Err("Invalid http.port '0': a fixed port is required".to_string());
+                }
+
+                let path = properties
+                    .get("http.path")
+                    .cloned()
+                    .unwrap_or_else(|| "/".to_string());
+                if !path.starts_with('/') {
+                    return Err(format!("Invalid http.path '{path}': must start with '/'"));
+                }
+
+                let auth = match (
+                    properties.get("http.auth.header"),
+                    properties.get("http.auth.token"),
+                ) {
+                    (Some(header), Some(token)) => {
+                        if header.is_empty() || token.is_empty() {
+                            // An empty token would authenticate anyone who
+                            // sends the bare header
+                            return Err("http.auth.header and http.auth.token must be non-empty"
+                                .to_string());
+                        }
+                        if axum::http::HeaderName::from_bytes(header.as_bytes()).is_err() {
+                            // An invalid name can never match an incoming
+                            // header — every request would get 401
+                            return Err(format!(
+                                "Invalid http.auth.header '{header}': not a valid HTTP header name"
+                            ));
+                        }
+                        Some((header.clone(), token.clone()))
+                    }
+                    (None, None) => None,
+                    _ => {
+                        return Err(
+                            "http.auth.header and http.auth.token must be set together".to_string()
+                        )
+                    }
+                };
+
+                let max_concurrent = parse_or(properties, "http.max.concurrent.requests", 256)?;
+                if max_concurrent == 0 {
+                    // Zero would panic tokio's bounded channel and deadlock
+                    // the concurrency limiter
+                    return Err(
+                        "Invalid http.max.concurrent.requests '0': must be >= 1".to_string()
+                    );
+                }
+
+                Ok(Self::Webhook(HttpWebhookConfig {
+                    host: properties
+                        .get("http.host")
+                        .cloned()
+                        .unwrap_or_else(|| "0.0.0.0".to_string()),
+                    port,
+                    path,
+                    auth,
+                    max_concurrent,
+                    max_body_bytes: parse_or(properties, "http.max.body.bytes", 1_048_576)?,
+                }))
+            }
+            other => Err(format!(
+                "Invalid http.mode '{other}': expected 'poll' or 'webhook'"
+            )),
+        }
+    }
+
+    /// Identifier used in error-context log messages
+    fn stream_tag(&self) -> String {
+        match self {
+            Self::Poll(c) => c.url.clone(),
+            Self::Webhook(c) => format!("{}:{}{}", c.host, c.port, c.path),
+        }
+    }
+}
+
+/// One payload handed from a webhook handler to the delivery thread,
+/// with a channel for the verdict to travel back
+type DeliveryJob = (
+    axum::body::Bytes,
+    tokio::sync::oneshot::Sender<DeliveryVerdict>,
+);
+
+/// Shared state for concurrent webhook handlers
+struct WebhookState {
+    auth: Option<(String, String)>,
+    /// Payload size cap — enforced while reading the body, after auth
+    max_body_bytes: usize,
+    /// Bounded queue to the single delivery thread — `send().await`
+    /// backpressures handlers naturally when delivery is slow
+    delivery_tx: tokio::sync::mpsc::Sender<DeliveryJob>,
+    /// Set by a Fail verdict or a dead delivery thread — triggers
+    /// graceful shutdown
+    failed: AtomicBool,
+}
+
+/// Webhook request handler — handlers run concurrently; deliveries are
+/// funneled to one owning thread (see [`spawn_delivery_thread`])
+async fn webhook_handler(State(state): State<Arc<WebhookState>>, request: Request) -> StatusCode {
+    if state.failed.load(Ordering::SeqCst) {
+        // A Fail verdict already triggered shutdown — turn away new
+        // requests immediately instead of attempting delivery
+        return StatusCode::SERVICE_UNAVAILABLE;
+    }
+
+    // Auth is checked on the headers BEFORE the body is read, so an
+    // unauthenticated flood cannot make the server buffer payloads
+    if let Some((name, token)) = &state.auth {
+        let authorized = request
+            .headers()
+            .get(name.as_str())
+            .and_then(|v| v.to_str().ok())
+            .is_some_and(|v| constant_time_eq(v.as_bytes(), token.as_bytes()));
+        if !authorized {
+            return StatusCode::UNAUTHORIZED;
+        }
+    }
+
+    // Only authenticated requests get their body buffered, capped at
+    // max_body_bytes (a broken-connection read error takes the same exit —
+    // the client is gone either way)
+    let Ok(body) = axum::body::to_bytes(request.into_body(), state.max_body_bytes).await else {
+        return StatusCode::PAYLOAD_TOO_LARGE;
+    };
+
+    if body.is_empty() {
+        return StatusCode::OK; // accepted, nothing to deliver
+    }
+
+    let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+    if state.delivery_tx.send((body, reply_tx)).await.is_err() {
+        // Delivery thread is gone without a shutdown signal (it panicked) —
+        // a listener that can never deliver must not keep accepting
+        state.failed.store(true, Ordering::SeqCst);
+        return StatusCode::SERVICE_UNAVAILABLE;
+    }
+
+    match reply_rx.await {
+        Ok(DeliveryVerdict::Delivered) => StatusCode::OK,
+        // Consumed by the error strategy (drop/DLQ)
+        Ok(DeliveryVerdict::Disposed) => StatusCode::OK,
+        Ok(DeliveryVerdict::Fail) => {
+            log::error!("[HttpSource] Unrecoverable delivery error, shutting down listener");
+            state.failed.store(true, Ordering::SeqCst);
+            StatusCode::INTERNAL_SERVER_ERROR
+        }
+        Err(_) => {
+            // Delivery thread died mid-job — shut down, don't zombie
+            state.failed.store(true, Ordering::SeqCst);
+            StatusCode::INTERNAL_SERVER_ERROR
+        }
+    }
+}
+
+/// One thread owns the error context and performs all junction publishing —
+/// handlers stay non-blocking and there is no lock to contend on. Exits when
+/// the server (the only sender) shuts down.
+fn spawn_delivery_thread(
+    mut rx: tokio::sync::mpsc::Receiver<DeliveryJob>,
+    callback: Arc<dyn SourceCallback>,
+    mut error_ctx: Option<SourceErrorContext>,
+) -> std::thread::JoinHandle<()> {
+    std::thread::spawn(move || {
+        let mut received: u64 = 0;
+        let mut failed: u64 = 0;
+
+        while let Some((body, reply)) = rx.blocking_recv() {
+            received += 1;
+            let verdict =
+                deliver_with_error_handling(callback.as_ref(), &body, &mut error_ctx, "HttpSource");
+            if verdict != DeliveryVerdict::Delivered {
+                failed += 1;
+            }
+            // Handler may have timed out/disconnected — nothing to do then
+            let _ = reply.send(verdict);
+        }
+
+        log::info!("[HttpSource] Stopped (received: {received}, failed: {failed})");
+    })
+}
+
+/// HTTP source (poll or webhook mode)
+#[derive(Debug)]
+pub struct HttpSource {
+    /// Mode + configuration
+    mode: HttpSourceMode,
+    /// Worker thread lifecycle (spawn, signal, join on stop)
+    worker: SourceWorker,
+    /// Optional error handling context
+    error_ctx: Option<SourceErrorContext>,
+}
+
+impl HttpSource {
+    /// Create a new HTTP source without error handling
+    pub fn new(mode: HttpSourceMode) -> Self {
+        Self {
+            mode,
+            worker: SourceWorker::new("HttpSource"),
+            error_ctx: None,
+        }
+    }
+
+    /// Create an HTTP source from properties
+    ///
+    /// # Required Properties
+    /// - `http.mode`: `poll` or `webhook`
+    /// - poll: `http.url` · webhook: `http.port`
+    ///
+    /// # Optional Properties
+    /// - poll: `http.poll.interval.ms`, `http.method`, `http.headers.<Name>`,
+    ///   `http.timeout.ms`
+    /// - webhook: `http.host`, `http.path`, `http.auth.header` +
+    ///   `http.auth.token`, `http.max.concurrent.requests`,
+    ///   `http.max.body.bytes`
+    /// - `error.*`: Error handling properties (see SourceErrorContext)
+    pub fn from_properties(
+        properties: &HashMap<String, String>,
+        dlq_junction: Option<Arc<Mutex<InputHandler>>>,
+        stream_name: &str,
+    ) -> Result<Self, String> {
+        let mode = HttpSourceMode::from_properties(properties)?;
+        let error_ctx = SourceErrorContext::from_properties(properties, dlq_junction, stream_name)?;
+
+        Ok(Self {
+            error_ctx,
+            ..Self::new(mode)
+        })
+    }
+
+    fn start_poll(&mut self, config: HttpPollConfig, callback: Arc<dyn SourceCallback>) {
+        let mut error_ctx = self.error_ctx.take();
+
+        self.worker.start(move |running| {
+            let agent = build_agent(config.timeout_ms);
+            let interval = Duration::from_millis(config.interval_ms);
+            let mut polls_delivered: u64 = 0;
+            let mut polls_failed: u64 = 0;
+
+            log::info!(
+                "[HttpSource] Polling '{}' every {}ms",
+                config.url,
+                config.interval_ms
+            );
+
+            'poll: while running.load(Ordering::SeqCst) {
+                // The poll outcome distills to at most one connection error;
+                // one dispatch below decides continue-vs-stop for both the
+                // status and transport failure shapes
+                let mut connection_error: Option<String> = None;
+
+                let result = build_request(&config.method, &config.url, &config.headers)
+                    .body(())
+                    .map_err(|e| format!("request build: {e}"))
+                    .and_then(|req| agent.run(req).map_err(|e| e.to_string()));
+
+                match result {
+                    Ok(mut response) => {
+                        let status = response.status().as_u16();
+                        match status {
+                            200..=299 => match response.body_mut().read_to_vec() {
+                                Ok(body) if body.is_empty() => {
+                                    log::debug!("[HttpSource] Empty response body — skipping");
+                                }
+                                Ok(body) => match deliver_with_error_handling(
+                                    callback.as_ref(),
+                                    &body,
+                                    &mut error_ctx,
+                                    "HttpSource",
+                                ) {
+                                    DeliveryVerdict::Delivered => polls_delivered += 1,
+                                    DeliveryVerdict::Disposed => polls_failed += 1,
+                                    DeliveryVerdict::Fail => {
+                                        polls_failed += 1;
+                                        log::error!("[HttpSource] Unrecoverable error, stopping");
+                                        break 'poll;
+                                    }
+                                },
+                                Err(e) => {
+                                    connection_error = Some(format!("body read failed: {e}"));
+                                }
+                            },
+                            304 => {
+                                log::debug!("[HttpSource] 304 Not Modified — skipping");
+                            }
+                            _ => connection_error = Some(format!("returned status {status}")),
+                        }
+                    }
+                    Err(e) => connection_error = Some(format!("failed: {e}")),
+                }
+
+                if let Some(detail) = connection_error {
+                    let err = EventFluxError::ConnectionUnavailable {
+                        message: format!("Poll of '{}' {detail}", config.url),
+                        source: None,
+                    };
+                    if let Some(ctx) = &mut error_ctx {
+                        if !ctx.handle_error(None, &err) {
+                            break 'poll;
+                        }
+                    } else {
+                        log::error!("[HttpSource] {err}");
+                    }
+                }
+
+                // Interruptible: a long interval never delays stop()
+                sleep_while_running(&running, interval);
+            }
+
+            log::info!(
+                "[HttpSource] Stopped (delivered: {polls_delivered}, failed: {polls_failed})"
+            );
+        });
+    }
+
+    fn start_webhook(&mut self, config: HttpWebhookConfig, callback: Arc<dyn SourceCallback>) {
+        let error_ctx = self.error_ctx.take();
+
+        self.worker.start(move |running| {
+            let rt = match tokio::runtime::Runtime::new() {
+                Ok(rt) => rt,
+                Err(e) => {
+                    log::error!("[HttpSource] Failed to create tokio runtime: {e}");
+                    return;
+                }
+            };
+
+            // The queue capacity matches the handler concurrency cap — a
+            // full queue backpressures handlers via `send().await`
+            let (delivery_tx, delivery_rx) = tokio::sync::mpsc::channel(config.max_concurrent);
+            let delivery_thread = spawn_delivery_thread(delivery_rx, callback, error_ctx);
+
+            rt.block_on(async move {
+                let state = Arc::new(WebhookState {
+                    auth: config.auth.clone(),
+                    max_body_bytes: config.max_body_bytes,
+                    delivery_tx,
+                    failed: AtomicBool::new(false),
+                });
+
+                let router = Router::new()
+                    .route(&config.path, post(webhook_handler))
+                    .layer(tower::limit::GlobalConcurrencyLimitLayer::new(
+                        config.max_concurrent,
+                    ))
+                    .with_state(Arc::clone(&state));
+
+                let addr = format!("{}:{}", config.host, config.port);
+                let listener = match tokio::net::TcpListener::bind(&addr).await {
+                    Ok(l) => l,
+                    Err(e) => {
+                        log::error!("[HttpSource] Failed to bind webhook listener {addr}: {e}");
+                        return;
+                    }
+                };
+
+                log::info!(
+                    "[HttpSource] Webhook listening on {addr}{} (max concurrent: {})",
+                    config.path,
+                    config.max_concurrent
+                );
+
+                // Graceful shutdown when the worker is signalled or a Fail
+                // verdict was reached; in-flight requests complete first
+                let shutdown_state = Arc::clone(&state);
+                let shutdown = async move {
+                    loop {
+                        if !running.load(Ordering::SeqCst)
+                            || shutdown_state.failed.load(Ordering::SeqCst)
+                        {
+                            break;
+                        }
+                        tokio::time::sleep(Duration::from_millis(100)).await;
+                    }
+                };
+
+                if let Err(e) = axum::serve(listener, router)
+                    .with_graceful_shutdown(shutdown)
+                    .await
+                {
+                    log::error!("[HttpSource] Webhook server error: {e}");
+                }
+            });
+
+            // Server (the only sender) is gone — the delivery thread drains
+            // any queued jobs, sees the closed channel, and exits
+            if delivery_thread.join().is_err() {
+                log::error!("[HttpSource] Delivery thread panicked");
+            }
+        });
+    }
+}
+
+impl Clone for HttpSource {
+    fn clone(&self) -> Self {
+        Self {
+            mode: self.mode.clone(),
+            worker: self.worker.clone(), // Clones as a fresh, unstarted worker
+            error_ctx: None,             // Error context contains runtime state, not cloneable
+        }
+    }
+}
+
+impl Source for HttpSource {
+    fn start(&mut self, callback: Arc<dyn SourceCallback>) {
+        match self.mode.clone() {
+            HttpSourceMode::Poll(config) => self.start_poll(config, callback),
+            HttpSourceMode::Webhook(config) => self.start_webhook(config, callback),
+        }
+    }
+
+    fn stop(&mut self) {
+        log::info!("[HttpSource] Stopping...");
+        self.worker.stop();
+    }
+
+    fn clone_box(&self) -> Box<dyn Source> {
+        Box::new(self.clone())
+    }
+
+    fn set_error_dlq_junction(&mut self, junction: Arc<Mutex<InputHandler>>) {
+        if let Some(ref mut ctx) = self.error_ctx {
+            ctx.set_dlq_junction(junction);
+        }
+    }
+
+    fn validate_connectivity(&self) -> Result<(), EventFluxError> {
+        match &self.mode {
+            // HEAD is the least side-effectful probe; any HTTP response
+            // (including 405) proves reachability
+            HttpSourceMode::Poll(config) => probe_reachability(
+                &build_agent(config.timeout_ms),
+                "HEAD",
+                &config.url,
+                &config.headers,
+            ),
+            // Fail fast on port conflicts and permission errors
+            HttpSourceMode::Webhook(config) => {
+                let addr = format!("{}:{}", config.host, config.port);
+                std::net::TcpListener::bind(&addr).map(|_| ()).map_err(|e| {
+                    EventFluxError::ConnectionUnavailable {
+                        message: format!("Cannot bind webhook listener on {addr}: {e}"),
+                        source: Some(Box::new(e)),
+                    }
+                })
+            }
+        }
+    }
+}
+
+// ============================================================================
+// HTTP Source Factory
+// ============================================================================
+
+/// Factory for creating HTTP source instances.
+///
+/// This factory is registered with EventFluxContext and used to create
+/// HTTP sources from SQL WITH clause configuration.
+#[derive(Debug, Clone)]
+pub struct HttpSourceFactory;
+
+impl SourceFactory for HttpSourceFactory {
+    fn name(&self) -> &'static str {
+        "http"
+    }
+
+    fn supported_formats(&self) -> &[&str] {
+        &["json", "csv", "bytes"]
+    }
+
+    fn required_parameters(&self) -> &[&str] {
+        // Mode-specific requirements (http.url / http.port) are validated
+        // in from_properties, since they depend on http.mode
+        &["http.mode"]
+    }
+
+    fn optional_parameters(&self) -> &[&str] {
+        &[
+            // poll mode
+            "http.url",
+            "http.poll.interval.ms",
+            "http.method",
+            "http.timeout.ms",
+            // webhook mode
+            "http.host",
+            "http.port",
+            "http.path",
+            "http.auth.header",
+            "http.auth.token",
+            "http.max.concurrent.requests",
+            "http.max.body.bytes",
+            // http.headers.<Name> passthrough is also accepted
+            // Error handling options
+            "error.strategy",
+            "error.retry.max-attempts",
+            "error.retry.initial-delay-ms",
+            "error.retry.max-delay-ms",
+            "error.retry.backoff-multiplier",
+            "error.dlq.stream",
+        ]
+    }
+
+    fn create_initialized(
+        &self,
+        config: &HashMap<String, String>,
+    ) -> Result<Box<dyn Source>, EventFluxError> {
+        // DLQ junction is None initially — stream_initializer calls
+        // set_error_dlq_junction() after creation. Parse once; the mode's
+        // tag identifies the stream in error-context log messages.
+        let mode =
+            HttpSourceMode::from_properties(config).map_err(EventFluxError::configuration)?;
+        let error_ctx = SourceErrorContext::from_properties(config, None, &mode.stream_tag())
+            .map_err(EventFluxError::configuration)?;
+
+        Ok(Box::new(HttpSource {
+            error_ctx,
+            ..HttpSource::new(mode)
+        }))
+    }
+
+    fn clone_box(&self) -> Box<dyn SourceFactory> {
+        Box::new(self.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn poll_props() -> HashMap<String, String> {
+        let mut props = HashMap::new();
+        props.insert("http.mode".to_string(), "poll".to_string());
+        props.insert(
+            "http.url".to_string(),
+            "http://localhost:9999/data".to_string(),
+        );
+        props
+    }
+
+    fn webhook_props() -> HashMap<String, String> {
+        let mut props = HashMap::new();
+        props.insert("http.mode".to_string(), "webhook".to_string());
+        props.insert("http.port".to_string(), "8081".to_string());
+        props
+    }
+
+    #[test]
+    fn test_poll_config_defaults() {
+        let mode = HttpSourceMode::from_properties(&poll_props()).unwrap();
+        let HttpSourceMode::Poll(config) = mode else {
+            panic!("expected poll mode");
+        };
+        assert_eq!(config.url, "http://localhost:9999/data");
+        assert_eq!(config.interval_ms, 5000);
+        assert_eq!(config.method, "GET");
+        assert!(config.headers.is_empty());
+        assert_eq!(config.timeout_ms, 30_000);
+    }
+
+    #[test]
+    fn test_poll_config_all_options() {
+        let mut props = poll_props();
+        props.insert("http.poll.interval.ms".to_string(), "1000".to_string());
+        props.insert("http.method".to_string(), "post".to_string());
+        props.insert("http.timeout.ms".to_string(), "2000".to_string());
+        props.insert("http.headers.X-Api-Key".to_string(), "k".to_string());
+
+        let HttpSourceMode::Poll(config) = HttpSourceMode::from_properties(&props).unwrap() else {
+            panic!("expected poll mode");
+        };
+        assert_eq!(config.interval_ms, 1000);
+        assert_eq!(config.method, "POST"); // normalized
+        assert_eq!(config.timeout_ms, 2000);
+        assert_eq!(
+            config.headers,
+            vec![("X-Api-Key".to_string(), "k".to_string())]
+        );
+    }
+
+    #[test]
+    fn test_webhook_config_defaults() {
+        let HttpSourceMode::Webhook(config) =
+            HttpSourceMode::from_properties(&webhook_props()).unwrap()
+        else {
+            panic!("expected webhook mode");
+        };
+        assert_eq!(config.host, "0.0.0.0");
+        assert_eq!(config.port, 8081);
+        assert_eq!(config.path, "/");
+        assert!(config.auth.is_none());
+        assert_eq!(config.max_concurrent, 256);
+        assert_eq!(config.max_body_bytes, 1_048_576);
+    }
+
+    #[test]
+    fn test_webhook_config_all_options() {
+        let mut props = webhook_props();
+        props.insert("http.host".to_string(), "127.0.0.1".to_string());
+        props.insert("http.path".to_string(), "/hooks/alerts".to_string());
+        props.insert("http.auth.header".to_string(), "X-Token".to_string());
+        props.insert("http.auth.token".to_string(), "secret".to_string());
+        props.insert("http.max.concurrent.requests".to_string(), "16".to_string());
+        props.insert("http.max.body.bytes".to_string(), "1024".to_string());
+
+        let HttpSourceMode::Webhook(config) = HttpSourceMode::from_properties(&props).unwrap()
+        else {
+            panic!("expected webhook mode");
+        };
+        assert_eq!(config.host, "127.0.0.1");
+        assert_eq!(config.path, "/hooks/alerts");
+        assert_eq!(
+            config.auth,
+            Some(("X-Token".to_string(), "secret".to_string()))
+        );
+        assert_eq!(config.max_concurrent, 16);
+        assert_eq!(config.max_body_bytes, 1024);
+    }
+
+    #[test]
+    fn test_mode_required_and_validated() {
+        assert!(HttpSourceMode::from_properties(&HashMap::new())
+            .unwrap_err()
+            .contains("http.mode"));
+
+        let mut props = HashMap::new();
+        props.insert("http.mode".to_string(), "push".to_string());
+        assert!(HttpSourceMode::from_properties(&props)
+            .unwrap_err()
+            .contains("http.mode"));
+    }
+
+    #[test]
+    fn test_poll_requires_url() {
+        let mut props = HashMap::new();
+        props.insert("http.mode".to_string(), "poll".to_string());
+        assert!(HttpSourceMode::from_properties(&props)
+            .unwrap_err()
+            .contains("http.url"));
+    }
+
+    #[test]
+    fn test_poll_rejects_unsupported_method() {
+        let mut props = poll_props();
+        props.insert("http.method".to_string(), "DELETE".to_string());
+        assert!(HttpSourceMode::from_properties(&props)
+            .unwrap_err()
+            .contains("http.method"));
+    }
+
+    #[test]
+    fn test_webhook_requires_port() {
+        let mut props = HashMap::new();
+        props.insert("http.mode".to_string(), "webhook".to_string());
+        assert!(HttpSourceMode::from_properties(&props)
+            .unwrap_err()
+            .contains("http.port"));
+    }
+
+    #[test]
+    fn test_webhook_rejects_port_zero() {
+        let mut props = webhook_props();
+        props.insert("http.port".to_string(), "0".to_string());
+        assert!(HttpSourceMode::from_properties(&props)
+            .unwrap_err()
+            .contains("http.port"));
+    }
+
+    #[test]
+    fn test_webhook_rejects_zero_concurrency() {
+        let mut props = webhook_props();
+        props.insert("http.max.concurrent.requests".to_string(), "0".to_string());
+        assert!(HttpSourceMode::from_properties(&props)
+            .unwrap_err()
+            .contains("http.max.concurrent.requests"));
+    }
+
+    #[test]
+    fn test_webhook_auth_must_be_paired() {
+        let mut props = webhook_props();
+        props.insert("http.auth.header".to_string(), "X-Token".to_string());
+        assert!(HttpSourceMode::from_properties(&props)
+            .unwrap_err()
+            .contains("http.auth"));
+    }
+
+    #[test]
+    fn test_webhook_auth_rejects_empty_values() {
+        let mut props = webhook_props();
+        props.insert("http.auth.header".to_string(), "X-Token".to_string());
+        props.insert("http.auth.token".to_string(), String::new());
+        assert!(HttpSourceMode::from_properties(&props)
+            .unwrap_err()
+            .contains("non-empty"));
+    }
+
+    #[test]
+    fn test_webhook_auth_rejects_invalid_header_name() {
+        let mut props = webhook_props();
+        props.insert("http.auth.header".to_string(), "X Token".to_string());
+        props.insert("http.auth.token".to_string(), "secret".to_string());
+        assert!(HttpSourceMode::from_properties(&props)
+            .unwrap_err()
+            .contains("header name"));
+    }
+
+    #[test]
+    fn test_webhook_path_must_start_with_slash() {
+        let mut props = webhook_props();
+        props.insert("http.path".to_string(), "hooks".to_string());
+        assert!(HttpSourceMode::from_properties(&props)
+            .unwrap_err()
+            .contains("http.path"));
+    }
+
+    #[test]
+    fn test_source_from_properties_with_error_handling() {
+        let mut props = poll_props();
+        props.insert("error.strategy".to_string(), "drop".to_string());
+
+        let source = HttpSource::from_properties(&props, None, "TestStream").unwrap();
+        assert!(source.error_ctx.is_some());
+    }
+
+    #[test]
+    fn test_source_clone_resets_runtime_state() {
+        let mut props = poll_props();
+        props.insert("error.strategy".to_string(), "drop".to_string());
+        let source = HttpSource::from_properties(&props, None, "TestStream").unwrap();
+        let cloned = source.clone();
+        assert!(cloned.error_ctx.is_none());
+    }
+
+    // =========================================================================
+    // Factory Tests
+    // =========================================================================
+
+    #[test]
+    fn test_factory_metadata() {
+        let factory = HttpSourceFactory;
+        assert_eq!(factory.name(), "http");
+        assert!(factory.supported_formats().contains(&"json"));
+        assert!(factory.supported_formats().contains(&"csv"));
+        assert!(factory.supported_formats().contains(&"bytes"));
+        assert!(factory.required_parameters().contains(&"http.mode"));
+        assert!(factory.optional_parameters().contains(&"http.url"));
+        assert!(factory.optional_parameters().contains(&"http.port"));
+    }
+
+    #[test]
+    fn test_factory_create_both_modes() {
+        let factory = HttpSourceFactory;
+        assert!(factory.create_initialized(&poll_props()).is_ok());
+        assert!(factory.create_initialized(&webhook_props()).is_ok());
+        assert!(factory.create_initialized(&HashMap::new()).is_err());
+    }
+
+    #[test]
+    fn test_factory_clone() {
+        let factory = HttpSourceFactory;
+        assert_eq!(factory.clone_box().name(), "http");
+    }
+}

--- a/src/core/stream/input/source/kafka_source.rs
+++ b/src/core/stream/input/source/kafka_source.rs
@@ -61,8 +61,9 @@ use crate::core::error::source_support::{
 };
 use crate::core::exception::EventFluxError;
 use crate::core::extension::SourceFactory;
+use crate::core::stream::connector_util::parse_or;
 use crate::core::stream::input::input_handler::InputHandler;
-use crate::core::stream::kafka_common::{parse_or, validate_topics_exist, KafkaConnectionConfig};
+use crate::core::stream::kafka_common::{validate_topics_exist, KafkaConnectionConfig};
 use rdkafka::client::ClientContext;
 use rdkafka::consumer::{BaseConsumer, Consumer, ConsumerContext, Rebalance};
 use rdkafka::message::Message;

--- a/src/core/stream/input/source/mod.rs
+++ b/src/core/stream/input/source/mod.rs
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+#[cfg(feature = "http")]
+pub mod http_source;
 #[cfg(feature = "kafka")]
 pub mod kafka_source;
 #[cfg(feature = "rabbitmq")]

--- a/src/core/stream/input/source/websocket_source.rs
+++ b/src/core/stream/input/source/websocket_source.rs
@@ -144,13 +144,10 @@ impl WebSocketSourceConfig {
         }
 
         // Parse custom headers (websocket.headers.*)
-        for (key, value) in properties {
-            if let Some(header_name) = key.strip_prefix("websocket.headers.") {
-                config
-                    .headers
-                    .insert(header_name.to_string(), value.clone());
-            }
-        }
+        config.headers =
+            crate::core::stream::connector_util::parse_prefixed(properties, "websocket.headers.")
+                .into_iter()
+                .collect();
 
         Ok(config)
     }

--- a/src/core/stream/kafka_common.rs
+++ b/src/core/stream/kafka_common.rs
@@ -25,24 +25,7 @@ use crate::core::exception::EventFluxError;
 use rdkafka::client::{Client, ClientContext};
 use rdkafka::config::ClientConfig;
 use std::collections::HashMap;
-use std::fmt::Display;
-use std::str::FromStr;
 use std::time::Duration;
-
-/// Parse an optional property, falling back to `default` when absent.
-pub fn parse_or<T: FromStr>(
-    properties: &HashMap<String, String>,
-    key: &str,
-    default: T,
-) -> Result<T, String>
-where
-    T::Err: Display,
-{
-    match properties.get(key) {
-        Some(v) => v.parse().map_err(|e| format!("Invalid {key}: {e}")),
-        None => Ok(default),
-    }
-}
 
 /// Broker connection + security settings shared by source and sink configs
 #[derive(Debug, Clone)]
@@ -195,20 +178,6 @@ mod tests {
             "localhost:9092".to_string(),
         );
         props
-    }
-
-    #[test]
-    fn test_parse_or_default_and_value() {
-        let mut props = HashMap::new();
-        assert_eq!(parse_or(&props, "k", 5u64).unwrap(), 5);
-
-        props.insert("k".to_string(), "9".to_string());
-        assert_eq!(parse_or(&props, "k", 5u64).unwrap(), 9);
-
-        props.insert("k".to_string(), "no".to_string());
-        assert!(parse_or(&props, "k", 5u64)
-            .unwrap_err()
-            .contains("Invalid k"));
     }
 
     #[test]

--- a/src/core/stream/mod.rs
+++ b/src/core/stream/mod.rs
@@ -15,7 +15,10 @@
  * limitations under the License.
  */
 
+pub mod connector_util;
 pub mod handler;
+#[cfg(feature = "http")]
+pub mod http_common;
 pub mod input;
 pub mod junction_factory;
 #[cfg(feature = "kafka")]

--- a/src/core/stream/output/sink/http_sink.rs
+++ b/src/core/stream/output/sink/http_sink.rs
@@ -1,0 +1,488 @@
+/*
+ * Copyright 2025-2026 EventFlux.io
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! # HTTP Sink
+//!
+//! Sends each event's formatted payload as an HTTP request (webhook-style).
+//!
+//! ## Architecture
+//!
+//! ```text
+//! Events → per event: SinkMapper → bytes → HttpSink::publish() → ureq request (+ retry) → endpoint
+//! ```
+//!
+//! One event = one request. Retries with exponential backoff apply to
+//! transport errors and retryable statuses (408/429/5xx) — other 4xx mean the
+//! request itself is wrong and are returned to the pipeline immediately.
+//! Retries block inside `publish()`, which is backpressure by design.
+
+use super::sink_trait::Sink;
+use crate::core::exception::EventFluxError;
+use crate::core::extension::SinkFactory;
+use crate::core::stream::connector_util::{parse_or, INJECTED_FORMAT_KEY};
+use crate::core::stream::http_common::{
+    build_agent, build_request, is_retryable_status, parse_headers, parse_method, parse_url,
+    probe_reachability, HttpRetryConfig,
+};
+use std::collections::HashMap;
+use std::fmt::Debug;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+/// Configuration for HTTP sink
+#[derive(Debug, Clone)]
+pub struct HttpSinkConfig {
+    /// Endpoint to send to (http/https)
+    pub url: String,
+    /// `POST` (default), `PUT`, or `PATCH`
+    pub method: String,
+    /// Request headers from `http.headers.<Name>`
+    pub headers: Vec<(String, String)>,
+    /// Content-Type: explicit `http.content.type`, else derived from the
+    /// stream format (json/csv/bytes); `None` when a
+    /// `http.headers.Content-Type` entry supplies it verbatim instead
+    pub content_type: Option<String>,
+    /// Per-request timeout (default 30000)
+    pub timeout_ms: u64,
+    /// Exponential-backoff retry policy
+    pub retry: HttpRetryConfig,
+    /// Startup probe: `HEAD` (default), `GET`, `OPTIONS`, or `none`
+    pub validation_method: String,
+}
+
+impl HttpSinkConfig {
+    /// Parse configuration from properties HashMap
+    pub fn from_properties(properties: &HashMap<String, String>) -> Result<Self, String> {
+        let url = parse_url(properties)?;
+        let method = parse_method(properties, "http.method", "POST", &["POST", "PUT", "PATCH"])?;
+        let headers = parse_headers(properties);
+
+        // Precedence: a verbatim http.headers.Content-Type wins (setting
+        // both is rejected — two sources of truth); else explicit
+        // http.content.type; else derived from the stream's format (injected
+        // by stream_initializer as _format); else a safe binary default.
+        // `header()` appends rather than replaces, so the derived value must
+        // be withheld when a header already carries one.
+        let header_has_content_type = headers
+            .iter()
+            .any(|(name, _)| name.eq_ignore_ascii_case("content-type"));
+        let content_type =
+            if header_has_content_type {
+                if properties.contains_key("http.content.type") {
+                    return Err("Content-Type is set via both http.content.type and \
+                     http.headers.Content-Type — use one"
+                        .to_string());
+                }
+                None
+            } else {
+                Some(
+                    properties.get("http.content.type").cloned().unwrap_or_else(
+                        || match properties.get(INJECTED_FORMAT_KEY).map(String::as_str) {
+                            Some("json") => "application/json".to_string(),
+                            Some("csv") => "text/csv".to_string(),
+                            _ => "application/octet-stream".to_string(),
+                        },
+                    ),
+                )
+            };
+
+        let validation_method = parse_method(
+            properties,
+            "http.validation.method",
+            "HEAD",
+            &["HEAD", "GET", "OPTIONS", "NONE"],
+        )?;
+
+        Ok(Self {
+            url,
+            method,
+            headers,
+            content_type,
+            timeout_ms: parse_or(properties, "http.timeout.ms", 30_000)?,
+            retry: HttpRetryConfig::from_properties(properties)?,
+            validation_method,
+        })
+    }
+}
+
+/// Counters logged when the sink stops
+#[derive(Debug, Default)]
+struct SinkMetrics {
+    requests_sent: AtomicU64,
+    requests_failed: AtomicU64,
+}
+
+/// HTTP sink that sends each event as its own request
+///
+/// This implementation:
+/// - Uses a blocking `ureq` client (rustls) — no runtime bridging
+/// - Retries transport errors and 408/429/5xx with exponential backoff
+/// - Treats other 4xx as permanent request errors (no retry)
+#[derive(Debug)]
+pub struct HttpSink {
+    /// Configuration
+    config: HttpSinkConfig,
+    /// Reusable blocking client (thread-safe, connection pooling)
+    agent: ureq::Agent,
+    /// Sent/failed counters
+    metrics: Arc<SinkMetrics>,
+}
+
+impl HttpSink {
+    /// Create a new HTTP sink
+    pub fn new(config: HttpSinkConfig) -> Self {
+        let agent = build_agent(config.timeout_ms);
+        Self {
+            config,
+            agent,
+            metrics: Arc::new(SinkMetrics::default()),
+        }
+    }
+
+    /// Create an HTTP sink from properties
+    pub fn from_properties(properties: &HashMap<String, String>) -> Result<Self, String> {
+        Ok(Self::new(HttpSinkConfig::from_properties(properties)?))
+    }
+
+    /// One request attempt; `Ok(true)` = delivered, `Ok(false)` = retryable
+    /// failure, `Err` = permanent failure
+    fn attempt(&self, payload: &[u8]) -> Result<bool, EventFluxError> {
+        let mut request =
+            build_request(&self.config.method, &self.config.url, &self.config.headers);
+        if let Some(content_type) = &self.config.content_type {
+            request = request.header("Content-Type", content_type);
+        }
+        // The body borrows the payload — no copy, even across retry attempts
+        let request = request.body(payload).map_err(|e| {
+            EventFluxError::configuration(format!("Failed to build HTTP request: {e}"))
+        })?;
+
+        match self.agent.run(request) {
+            Ok(response) => {
+                let status = response.status().as_u16();
+                if (200..300).contains(&status) {
+                    Ok(true)
+                } else if is_retryable_status(status) {
+                    log::warn!(
+                        "[HttpSink] '{}' responded {status} — will retry",
+                        self.config.url
+                    );
+                    Ok(false)
+                } else {
+                    Err(EventFluxError::app_runtime(format!(
+                        "HTTP sink request to '{}' rejected with status {status}",
+                        self.config.url
+                    )))
+                }
+            }
+            Err(e) => {
+                // Transport-level failure (connect, timeout, TLS) — retryable
+                log::warn!("[HttpSink] Request to '{}' failed: {e}", self.config.url);
+                Ok(false)
+            }
+        }
+    }
+}
+
+impl Clone for HttpSink {
+    fn clone(&self) -> Self {
+        // ureq::Agent is Arc-shared internally — clones reuse the same
+        // connection pool; shared metrics keep the stop-log totals accurate
+        Self {
+            config: self.config.clone(),
+            agent: self.agent.clone(),
+            metrics: Arc::clone(&self.metrics),
+        }
+    }
+}
+
+impl Sink for HttpSink {
+    fn publish(&self, payload: &[u8]) -> Result<(), EventFluxError> {
+        let mut attempt_no: u32 = 0;
+        loop {
+            match self.attempt(payload) {
+                Ok(true) => {
+                    self.metrics.requests_sent.fetch_add(1, Ordering::Relaxed);
+                    return Ok(());
+                }
+                Ok(false) if attempt_no < self.config.retry.max_attempts => {
+                    attempt_no += 1;
+                    // Blocking backoff inside publish() = backpressure
+                    std::thread::sleep(self.config.retry.delay_for(attempt_no));
+                }
+                Ok(false) => {
+                    self.metrics.requests_failed.fetch_add(1, Ordering::Relaxed);
+                    return Err(EventFluxError::ConnectionUnavailable {
+                        message: format!(
+                            "HTTP sink request to '{}' failed after {} attempt(s)",
+                            self.config.url,
+                            attempt_no + 1
+                        ),
+                        source: None,
+                    });
+                }
+                Err(e) => {
+                    self.metrics.requests_failed.fetch_add(1, Ordering::Relaxed);
+                    return Err(e);
+                }
+            }
+        }
+    }
+
+    fn stop(&self) {
+        log::info!(
+            "[HttpSink] Stopped (sent: {}, failed: {})",
+            self.metrics.requests_sent.load(Ordering::Relaxed),
+            self.metrics.requests_failed.load(Ordering::Relaxed)
+        );
+    }
+
+    fn clone_box(&self) -> Box<dyn Sink> {
+        Box::new(self.clone())
+    }
+
+    fn validate_connectivity(&self) -> Result<(), EventFluxError> {
+        if self.config.validation_method == "NONE" {
+            return Ok(());
+        }
+        probe_reachability(
+            &self.agent,
+            &self.config.validation_method,
+            &self.config.url,
+            &self.config.headers,
+        )
+    }
+}
+
+// ============================================================================
+// HTTP Sink Factory
+// ============================================================================
+
+/// Factory for creating HTTP sink instances.
+///
+/// This factory is registered with EventFluxContext and used to create
+/// HTTP sinks from SQL WITH clause configuration.
+#[derive(Debug, Clone)]
+pub struct HttpSinkFactory;
+
+impl SinkFactory for HttpSinkFactory {
+    fn name(&self) -> &'static str {
+        "http"
+    }
+
+    fn supported_formats(&self) -> &[&str] {
+        &["json", "csv", "bytes"]
+    }
+
+    fn required_parameters(&self) -> &[&str] {
+        &["http.url"]
+    }
+
+    fn optional_parameters(&self) -> &[&str] {
+        &[
+            "http.method",
+            "http.content.type",
+            "http.timeout.ms",
+            "http.retry.max-attempts",
+            "http.retry.initial-delay-ms",
+            "http.retry.max-delay-ms",
+            "http.retry.backoff-multiplier",
+            "http.validation.method",
+            // http.headers.<Name> passthrough is also accepted
+        ]
+    }
+
+    fn create_initialized(
+        &self,
+        config: &HashMap<String, String>,
+    ) -> Result<Box<dyn Sink>, EventFluxError> {
+        let parsed =
+            HttpSinkConfig::from_properties(config).map_err(EventFluxError::configuration)?;
+        Ok(Box::new(HttpSink::new(parsed)))
+    }
+
+    fn clone_box(&self) -> Box<dyn SinkFactory> {
+        Box::new(self.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base_props() -> HashMap<String, String> {
+        let mut props = HashMap::new();
+        props.insert(
+            "http.url".to_string(),
+            "http://localhost:9999/hook".to_string(),
+        );
+        props
+    }
+
+    #[test]
+    fn test_config_required_only_defaults() {
+        let config = HttpSinkConfig::from_properties(&base_props()).unwrap();
+        assert_eq!(config.url, "http://localhost:9999/hook");
+        assert_eq!(config.method, "POST");
+        assert!(config.headers.is_empty());
+        assert_eq!(
+            config.content_type.as_deref(),
+            Some("application/octet-stream") // no format
+        );
+        assert_eq!(config.timeout_ms, 30_000);
+        assert_eq!(config.retry.max_attempts, 3);
+        assert_eq!(config.validation_method, "HEAD");
+    }
+
+    #[test]
+    fn test_config_all_options() {
+        let mut props = base_props();
+        props.insert("http.method".to_string(), "put".to_string());
+        props.insert(
+            "http.content.type".to_string(),
+            "application/xml".to_string(),
+        );
+        props.insert("http.timeout.ms".to_string(), "5000".to_string());
+        props.insert("http.retry.max-attempts".to_string(), "5".to_string());
+        props.insert("http.validation.method".to_string(), "none".to_string());
+        props.insert(
+            "http.headers.Authorization".to_string(),
+            "Bearer tok".to_string(),
+        );
+
+        let config = HttpSinkConfig::from_properties(&props).unwrap();
+        assert_eq!(config.method, "PUT"); // normalized
+        assert_eq!(config.content_type.as_deref(), Some("application/xml"));
+        assert_eq!(config.timeout_ms, 5000);
+        assert_eq!(config.retry.max_attempts, 5);
+        assert_eq!(config.validation_method, "NONE");
+        assert_eq!(
+            config.headers,
+            vec![("Authorization".to_string(), "Bearer tok".to_string())]
+        );
+    }
+
+    #[test]
+    fn test_content_type_derived_from_injected_format() {
+        for (format, expected) in [
+            ("json", "application/json"),
+            ("csv", "text/csv"),
+            ("bytes", "application/octet-stream"),
+        ] {
+            let mut props = base_props();
+            props.insert(INJECTED_FORMAT_KEY.to_string(), format.to_string());
+            let config = HttpSinkConfig::from_properties(&props).unwrap();
+            assert_eq!(
+                config.content_type.as_deref(),
+                Some(expected),
+                "format {format}"
+            );
+        }
+
+        // Explicit override beats derivation
+        let mut props = base_props();
+        props.insert(INJECTED_FORMAT_KEY.to_string(), "json".to_string());
+        props.insert("http.content.type".to_string(), "text/plain".to_string());
+        let config = HttpSinkConfig::from_properties(&props).unwrap();
+        assert_eq!(config.content_type.as_deref(), Some("text/plain"));
+    }
+
+    #[test]
+    fn test_content_type_header_wins_and_conflicts_rejected() {
+        // A verbatim http.headers.Content-Type suppresses the derived value
+        // (header() appends — a second Content-Type would be malformed)
+        let mut props = base_props();
+        props.insert(INJECTED_FORMAT_KEY.to_string(), "json".to_string());
+        props.insert(
+            "http.headers.Content-Type".to_string(),
+            "application/xml".to_string(),
+        );
+        let config = HttpSinkConfig::from_properties(&props).unwrap();
+        assert_eq!(config.content_type, None);
+        assert_eq!(
+            config.headers,
+            vec![("Content-Type".to_string(), "application/xml".to_string())]
+        );
+
+        // Both mechanisms at once is ambiguous — rejected
+        props.insert("http.content.type".to_string(), "text/plain".to_string());
+        let err = HttpSinkConfig::from_properties(&props).unwrap_err();
+        assert!(err.contains("http.content.type"), "got: {err}");
+    }
+
+    #[test]
+    fn test_config_invalid_method() {
+        let mut props = base_props();
+        props.insert("http.method".to_string(), "DELETE".to_string());
+        assert!(HttpSinkConfig::from_properties(&props)
+            .unwrap_err()
+            .contains("http.method"));
+    }
+
+    #[test]
+    fn test_config_invalid_validation_method() {
+        let mut props = base_props();
+        props.insert("http.validation.method".to_string(), "TRACE".to_string());
+        assert!(HttpSinkConfig::from_properties(&props)
+            .unwrap_err()
+            .contains("http.validation.method"));
+    }
+
+    #[test]
+    fn test_config_missing_url() {
+        assert!(HttpSinkConfig::from_properties(&HashMap::new())
+            .unwrap_err()
+            .contains("http.url"));
+    }
+
+    #[test]
+    fn test_validation_none_skips_probe() {
+        let mut props = base_props();
+        // Unreachable endpoint, but validation is disabled
+        props.insert("http.validation.method".to_string(), "none".to_string());
+        let sink = HttpSink::from_properties(&props).unwrap();
+        assert!(sink.validate_connectivity().is_ok());
+    }
+
+    // =========================================================================
+    // Factory Tests
+    // =========================================================================
+
+    #[test]
+    fn test_factory_metadata() {
+        let factory = HttpSinkFactory;
+        assert_eq!(factory.name(), "http");
+        assert!(factory.supported_formats().contains(&"json"));
+        assert!(factory.supported_formats().contains(&"csv"));
+        assert!(factory.supported_formats().contains(&"bytes"));
+        assert!(factory.required_parameters().contains(&"http.url"));
+        assert!(factory.optional_parameters().contains(&"http.method"));
+    }
+
+    #[test]
+    fn test_factory_create_and_missing_required() {
+        let factory = HttpSinkFactory;
+        assert!(factory.create_initialized(&base_props()).is_ok());
+        assert!(factory.create_initialized(&HashMap::new()).is_err());
+    }
+
+    #[test]
+    fn test_factory_clone() {
+        let factory = HttpSinkFactory;
+        assert_eq!(factory.clone_box().name(), "http");
+    }
+}

--- a/src/core/stream/output/sink/kafka_sink.rs
+++ b/src/core/stream/output/sink/kafka_sink.rs
@@ -45,7 +45,8 @@
 use super::sink_trait::Sink;
 use crate::core::exception::EventFluxError;
 use crate::core::extension::SinkFactory;
-use crate::core::stream::kafka_common::{parse_or, validate_topics_exist, KafkaConnectionConfig};
+use crate::core::stream::connector_util::parse_or;
+use crate::core::stream::kafka_common::{validate_topics_exist, KafkaConnectionConfig};
 use rdkafka::client::ClientContext;
 use rdkafka::error::KafkaError;
 use rdkafka::producer::{BaseRecord, Producer, ProducerContext, ThreadedProducer};

--- a/src/core/stream/output/sink/mod.rs
+++ b/src/core/stream/output/sink/mod.rs
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+#[cfg(feature = "http")]
+pub mod http_sink;
 #[cfg(feature = "kafka")]
 pub mod kafka_sink;
 pub mod log_sink;

--- a/src/core/stream/output/sink/sink_factory.rs
+++ b/src/core/stream/output/sink/sink_factory.rs
@@ -44,10 +44,10 @@ impl SinkFactoryRegistry {
             factories: HashMap::new(),
         };
 
-        // Register default sink factories
+        // Register default sink factories. Connector sinks (http, kafka,
+        // rabbitmq, websocket) are registered on EventFluxContext via
+        // register_default_extensions(), not through this registry.
         registry.register("log", Box::new(LogSinkFactory));
-        // Future: registry.register("kafka", Box::new(KafkaSinkFactory));
-        // Future: registry.register("http", Box::new(HttpSinkFactory));
 
         registry
     }

--- a/src/core/stream/output/sink/websocket_sink.rs
+++ b/src/core/stream/output/sink/websocket_sink.rs
@@ -172,13 +172,10 @@ impl WebSocketSinkConfig {
         }
 
         // Parse custom headers (websocket.headers.*)
-        for (key, value) in properties {
-            if let Some(header_name) = key.strip_prefix("websocket.headers.") {
-                config
-                    .headers
-                    .insert(header_name.to_string(), value.clone());
-            }
-        }
+        config.headers =
+            crate::core::stream::connector_util::parse_prefixed(properties, "websocket.headers.")
+                .into_iter()
+                .collect();
 
         Ok(config)
     }

--- a/src/core/stream/stream_initializer.rs
+++ b/src/core/stream/stream_initializer.rs
@@ -189,6 +189,8 @@ pub fn initialize_stream(
 /// by cargo features. The feature is always named after the extension (see
 /// the `[features]` section in Cargo.toml), so one entry per gated connector.
 const GATED_OUT_EXTENSIONS: &[&str] = &[
+    #[cfg(not(feature = "http"))]
+    "http",
     #[cfg(not(feature = "kafka"))]
     "kafka",
     #[cfg(not(feature = "rabbitmq"))]
@@ -210,6 +212,23 @@ fn connector_lookup_error(kind: &str, extension: &str) -> EventFluxError {
     } else {
         EventFluxError::extension_not_found(kind, extension)
     }
+}
+
+/// Properties handed to source/sink factories: the user's map plus
+/// engine-injected reserved keys (leading underscore). Currently `_format`
+/// carries the stream's declared format so connectors can derive
+/// format-dependent settings (e.g. the HTTP sink's Content-Type).
+fn factory_properties(
+    stream_config: &StreamTypeConfig,
+) -> std::collections::HashMap<String, String> {
+    let mut properties = stream_config.properties.clone();
+    if let Some(format) = stream_config.format() {
+        properties.insert(
+            crate::core::stream::connector_util::INJECTED_FORMAT_KEY.to_string(),
+            format.to_string(),
+        );
+    }
+    properties
 }
 
 /// Initialize a source stream with factory lookup and validation
@@ -277,7 +296,8 @@ fn initialize_source_stream(
     }
 
     // 5. Create fully initialized instances (fail-fast validation)
-    let source = source_factory.create_initialized(&stream_config.properties)?;
+    let factory_properties = factory_properties(stream_config);
+    let source = source_factory.create_initialized(&factory_properties)?;
     let mapper = mapper_factory
         .map(|factory| factory.create_initialized(&stream_config.properties))
         .transpose()?;
@@ -384,7 +404,8 @@ fn initialize_sink_stream_internal(
     }
 
     // 5. Create fully initialized instances (fail-fast validation)
-    let sink = sink_factory.create_initialized(&stream_config.properties)?;
+    let factory_properties = factory_properties(stream_config);
+    let sink = sink_factory.create_initialized(&factory_properties)?;
 
     // Create mapper with field names if provided, otherwise use standard initialization
     let mapper = mapper_factory
@@ -1020,7 +1041,7 @@ impl QuerySourceExtractor for Query {
 mod tests {
     use super::*;
     use crate::core::config::stream_config::{FlatConfig, PropertySource};
-    use crate::core::extension::example_factories::{ExampleSourceFactory, HttpSinkFactory};
+    use crate::core::extension::example_factories::{ExampleSinkFactory, ExampleSourceFactory};
     use crate::core::extension::{CsvSinkMapperFactory, JsonSourceMapperFactory};
 
     #[test]
@@ -1165,18 +1186,18 @@ mod tests {
     #[test]
     fn test_initialize_sink_stream_success() {
         let context = EventFluxContext::new();
-        context.add_sink_factory("http".to_string(), Box::new(HttpSinkFactory));
+        context.add_sink_factory("example-sink".to_string(), Box::new(ExampleSinkFactory));
         context.add_sink_mapper_factory("json".to_string(), Box::new(CsvSinkMapperFactory)); // Using CSV as placeholder
 
         let mut config = HashMap::new();
         config.insert(
-            "http.url".to_string(),
+            "example.url".to_string(),
             "http://localhost:8080/events".to_string(),
         );
 
         let stream_config = StreamTypeConfig::new(
             StreamType::Sink,
-            Some("http".to_string()),
+            Some("example-sink".to_string()),
             Some("json".to_string()),
             config,
         )
@@ -1187,7 +1208,7 @@ mod tests {
 
         match result.unwrap() {
             InitializedStream::Sink(sink) => {
-                assert_eq!(sink.extension, "http");
+                assert_eq!(sink.extension, "example-sink");
                 assert_eq!(sink.format.as_deref(), Some("json"));
             }
             _ => panic!("Expected Sink stream"),
@@ -1284,18 +1305,22 @@ mod tests {
     #[test]
     fn test_initialize_sink_stream_missing_required_format() {
         let context = EventFluxContext::new();
-        context.add_sink_factory("http".to_string(), Box::new(HttpSinkFactory));
+        context.add_sink_factory("example-sink".to_string(), Box::new(ExampleSinkFactory));
 
         let mut config = HashMap::new();
         config.insert(
-            "http.url".to_string(),
+            "example.url".to_string(),
             "http://localhost:8080/events".to_string(),
         );
 
-        // HTTP sink WITHOUT format - should be rejected
-        let stream_config =
-            StreamTypeConfig::new(StreamType::Sink, Some("http".to_string()), None, config)
-                .unwrap();
+        // Example sink WITHOUT format - should be rejected
+        let stream_config = StreamTypeConfig::new(
+            StreamType::Sink,
+            Some("example-sink".to_string()),
+            None,
+            config,
+        )
+        .unwrap();
 
         let result = initialize_stream(&context, &stream_config);
         assert!(result.is_err());
@@ -1304,7 +1329,7 @@ mod tests {
         match result.unwrap_err() {
             EventFluxError::Configuration { message, .. } => {
                 assert!(message.contains("requires a format specification"));
-                assert!(message.contains("http"));
+                assert!(message.contains("example-sink"));
                 assert!(message.contains("json"));
                 assert!(message.contains("data loss"));
             }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -753,3 +753,69 @@ impl AppRunner {
         self.runtime.query_aggregation(agg_id, within, per)
     }
 }
+
+// ============================================================================
+// Connector test helpers
+// ============================================================================
+
+/// Source callback that records every payload it receives, with a
+/// deadline-based wait — shared by connector integration tests.
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+pub struct CollectingCallback {
+    payloads: std::sync::Arc<std::sync::Mutex<Vec<Vec<u8>>>>,
+}
+
+#[allow(dead_code)]
+impl CollectingCallback {
+    pub fn new() -> Self {
+        Self {
+            payloads: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
+        }
+    }
+
+    /// Wait until `count` payloads arrived or `timeout` elapsed; returns
+    /// whatever was collected.
+    pub fn wait_for(&self, count: usize, timeout: std::time::Duration) -> Vec<Vec<u8>> {
+        let deadline = std::time::Instant::now() + timeout;
+        loop {
+            let payloads = self.payloads.lock().unwrap();
+            if payloads.len() >= count || std::time::Instant::now() >= deadline {
+                return payloads.clone();
+            }
+            drop(payloads);
+            std::thread::sleep(std::time::Duration::from_millis(20));
+        }
+    }
+}
+
+impl eventflux::core::stream::input::source::SourceCallback for CollectingCallback {
+    fn on_data(&self, data: &[u8]) -> Result<(), eventflux::core::exception::EventFluxError> {
+        self.payloads.lock().unwrap().push(data.to_vec());
+        Ok(())
+    }
+}
+
+/// A currently-free localhost port (racy by nature; fine for tests)
+#[allow(dead_code)]
+pub fn free_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port()
+}
+
+/// Block until something is accepting connections on the port (or panic
+/// after the deadline) — replaces fixed warm-up sleeps.
+#[allow(dead_code)]
+pub fn wait_listening(port: u16) {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    while std::time::Instant::now() < deadline {
+        if std::net::TcpStream::connect(("127.0.0.1", port)).is_ok() {
+            return;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(5));
+    }
+    panic!("nothing listening on 127.0.0.1:{port} within 10s");
+}

--- a/tests/custom_dyn_ext/Cargo.lock
+++ b/tests/custom_dyn_ext/Cargo.lock
@@ -18,17 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "aes"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
-dependencies = [
- "cfg-if",
- "cipher",
- "cpufeatures",
-]
-
-[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -54,54 +43,6 @@ name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
-
-[[package]]
-name = "amq-protocol"
-version = "7.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "587d313f3a8b4a40f866cc84b6059fe83133bf172165ac3b583129dd211d8e1c"
-dependencies = [
- "amq-protocol-tcp",
- "amq-protocol-types",
- "amq-protocol-uri",
- "cookie-factory",
- "nom",
- "serde",
-]
-
-[[package]]
-name = "amq-protocol-tcp"
-version = "7.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc707ab9aa964a85d9fc25908a3fdc486d2e619406883b3105b48bf304a8d606"
-dependencies = [
- "amq-protocol-uri",
- "tcp-stream",
- "tracing",
-]
-
-[[package]]
-name = "amq-protocol-types"
-version = "7.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf99351d92a161c61ec6ecb213bc7057f5b837dd4e64ba6cb6491358efd770c4"
-dependencies = [
- "cookie-factory",
- "nom",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "amq-protocol-uri"
-version = "7.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f89f8273826a676282208e5af38461a07fe939def57396af6ad5997fcf56577d"
-dependencies = [
- "amq-protocol-types",
- "percent-encoding",
- "url",
-]
 
 [[package]]
 name = "android_system_properties"
@@ -175,166 +116,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
-name = "asn1-rs"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60"
-dependencies = [
- "asn1-rs-derive",
- "asn1-rs-impl",
- "displaydoc",
- "nom",
- "num-traits",
- "rusticata-macros",
- "thiserror 2.0.17",
- "time",
-]
-
-[[package]]
-name = "asn1-rs-derive"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
-name = "asn1-rs-impl"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "async-channel"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
-dependencies = [
- "concurrent-queue",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-executor"
-version = "1.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497c00e0fd83a72a79a39fcbd8e3e2f055d6f6c7e025f3b3d91f4f8e76527fb8"
-dependencies = [
- "async-task",
- "concurrent-queue",
- "fastrand 2.3.0",
- "futures-lite 2.6.1",
- "pin-project-lite",
- "slab",
-]
-
-[[package]]
-name = "async-global-executor"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13f937e26114b93193065fd44f507aa2e9169ad0cdabbb996920b1fe1ddea7ba"
-dependencies = [
- "async-channel",
- "async-executor",
- "async-io 2.6.0",
- "async-lock 3.4.1",
- "blocking",
- "futures-lite 2.6.1",
-]
-
-[[package]]
-name = "async-global-executor-trait"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9af57045d58eeb1f7060e7025a1631cbc6399e0a1d10ad6735b3d0ea7f8346ce"
-dependencies = [
- "async-global-executor",
- "async-trait",
- "executor-trait",
-]
-
-[[package]]
-name = "async-io"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc5b45d93ef0529756f812ca52e44c221b35341892d3dcc34132ac02f3dd2af"
-dependencies = [
- "async-lock 2.8.0",
- "autocfg",
- "cfg-if",
- "concurrent-queue",
- "futures-lite 1.13.0",
- "log",
- "parking",
- "polling 2.8.0",
- "rustix 0.37.28",
- "slab",
- "socket2 0.4.10",
- "waker-fn",
-]
-
-[[package]]
-name = "async-io"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
-dependencies = [
- "autocfg",
- "cfg-if",
- "concurrent-queue",
- "futures-io",
- "futures-lite 2.6.1",
- "parking",
- "polling 3.11.0",
- "rustix 1.1.2",
- "slab",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "async-lock"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b"
-dependencies = [
- "event-listener 2.5.3",
-]
-
-[[package]]
-name = "async-lock"
-version = "3.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd03604047cee9b6ce9de9f70c6cd540a0520c813cbd49bae61f33ab80ed1dc"
-dependencies = [
- "event-listener 5.4.1",
- "event-listener-strategy",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-reactor-trait"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6012d170ad00de56c9ee354aef2e358359deb1ec504254e0e5a3774771de0e"
-dependencies = [
- "async-io 1.13.0",
- "async-trait",
- "futures-core",
- "reactor-trait",
-]
-
-[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -357,12 +138,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-task"
-version = "4.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
-
-[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -372,12 +147,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "atomic-waker"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -396,7 +165,7 @@ dependencies = [
  "bitflags 1.3.2",
  "bytes",
  "futures-util",
- "http 0.2.12",
+ "http",
  "http-body",
  "hyper",
  "itoa",
@@ -422,7 +191,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http 0.2.12",
+ "http",
  "http-body",
  "mime",
  "rustversion",
@@ -436,7 +205,7 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
 dependencies = [
- "fastrand 2.3.0",
+ "fastrand",
 ]
 
 [[package]]
@@ -461,12 +230,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
-name = "base64ct"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e050f626429857a27ddccb31e0aca21356bfa709c04041aefddac081a8f068a"
-
-[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -488,62 +251,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 
 [[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "block-padding"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "blocking"
-version = "1.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
-dependencies = [
- "async-channel",
- "async-task",
- "futures-io",
- "futures-lite 2.6.1",
- "piper",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
-
-[[package]]
-name = "cbc"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
-dependencies = [
- "cipher",
-]
 
 [[package]]
 name = "cc"
@@ -559,9 +276,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chrono"
@@ -575,16 +292,6 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
-]
-
-[[package]]
-name = "cipher"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
-dependencies = [
- "crypto-common",
- "inout",
 ]
 
 [[package]]
@@ -628,18 +335,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
-name = "cms"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b77c319abfd5219629c45c34c89ba945ed3c5e49fcde9d16b6c3885f118a730"
-dependencies = [
- "const-oid",
- "der",
- "spki",
- "x509-cert",
-]
-
-[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -660,50 +355,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "concurrent-queue"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "const-oid"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
-
-[[package]]
-name = "cookie-factory"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9885fa71e26b8ab7855e2ec7cae6e9b380edff76cd052e07c683a0319d51b3a2"
-
-[[package]]
-name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
-name = "cpufeatures"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "cron"
@@ -773,16 +428,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
-name = "crypto-common"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
 name = "custom_dyn_ext"
 version = "0.1.0"
 dependencies = [
@@ -791,9 +436,9 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "6.1.0"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -802,12 +447,6 @@ dependencies = [
  "once_cell",
  "parking_lot_core",
 ]
-
-[[package]]
-name = "data-encoding"
-version = "2.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
 name = "deadpool"
@@ -841,73 +480,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "der"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
-dependencies = [
- "const-oid",
- "der_derive",
- "flagset",
- "pem-rfc7468",
- "zeroize",
-]
-
-[[package]]
-name = "der-parser"
-version = "10.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
-dependencies = [
- "asn1-rs",
- "displaydoc",
- "nom",
- "num-bigint",
- "num-traits",
- "rusticata-macros",
-]
-
-[[package]]
-name = "der_derive"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "deranged"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
-dependencies = [
- "powerfmt",
-]
-
-[[package]]
-name = "des"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffdd80ce8ce993de27e9f063a444a4d53ce8e8db4c1f00cc03af5ad5a9867a1e"
-dependencies = [
- "cipher",
-]
-
-[[package]]
-name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer",
- "crypto-common",
- "subtle",
-]
-
-[[package]]
 name = "dirs"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -938,12 +510,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "doc-comment"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "780955b8b195a21ab8e4ac6b60dd1dbdcec1dc6c51c0617964b08c81785e12c9"
 
 [[package]]
 name = "either"
@@ -991,33 +557,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "event-listener"
-version = "2.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
-
-[[package]]
-name = "event-listener"
-version = "5.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
-dependencies = [
- "concurrent-queue",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
-name = "event-listener-strategy"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
-dependencies = [
- "event-listener 5.4.1",
- "pin-project-lite",
-]
-
-[[package]]
 name = "eventflux"
 version = "0.1.0"
 dependencies = [
@@ -1035,14 +574,13 @@ dependencies = [
  "dirs",
  "env_logger",
  "futures",
- "lapin",
  "libloading",
  "log",
  "lz4",
  "num_cpus",
  "once_cell",
  "prost",
- "rand 0.8.5",
+ "rand",
  "rayon",
  "redis",
  "regex",
@@ -1052,28 +590,16 @@ dependencies = [
  "serde_yaml",
  "snap",
  "sqlparser",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "thread_local",
  "tokio",
  "tokio-stream",
- "tokio-tungstenite",
  "toml",
  "tonic",
  "tonic-build",
  "tower",
- "tungstenite",
- "urlencoding",
  "uuid",
  "zstd",
-]
-
-[[package]]
-name = "executor-trait"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c39dff9342e4e0e16ce96be751eb21a94e94a87bb2f6e63ad1961c2ce109bf"
-dependencies = [
- "async-trait",
 ]
 
 [[package]]
@@ -1087,15 +613,6 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
-
-[[package]]
-name = "fastrand"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
-dependencies = [
- "instant",
-]
 
 [[package]]
 name = "fastrand"
@@ -1116,42 +633,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
-name = "flagset"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
-
-[[package]]
-name = "flume"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
-dependencies = [
- "futures-core",
- "futures-sink",
- "spin",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1211,34 +696,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
-name = "futures-lite"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
-dependencies = [
- "fastrand 1.9.0",
- "futures-core",
- "futures-io",
- "memchr",
- "parking",
- "pin-project-lite",
- "waker-fn",
-]
-
-[[package]]
-name = "futures-lite"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
-dependencies = [
- "fastrand 2.3.0",
- "futures-core",
- "futures-io",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
 name = "futures-macro"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1277,16 +734,6 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
 ]
 
 [[package]]
@@ -1329,7 +776,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http 0.2.12",
+ "http",
  "indexmap 2.11.4",
  "slab",
  "tokio",
@@ -1376,30 +823,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
-
-[[package]]
-name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
-
-[[package]]
-name = "hex"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "hmac"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest",
-]
 
 [[package]]
 name = "http"
@@ -1413,23 +839,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "http"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
-dependencies = [
- "bytes",
- "itoa",
-]
-
-[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http 0.2.12",
+ "http",
  "pin-project-lite",
 ]
 
@@ -1456,7 +872,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http 0.2.12",
+ "http",
  "http-body",
  "httparse",
  "httpdate",
@@ -1633,36 +1049,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "inout"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
-dependencies = [
- "block-padding",
- "generic-array",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "io-lifetimes"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
-dependencies = [
- "hermit-abi 0.3.9",
- "libc",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "io-uring"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1748,28 +1134,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lapin"
-version = "2.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d2aa4725b9607915fa1a73e940710a3be6af508ce700e56897cbe8847fbb07"
-dependencies = [
- "amq-protocol",
- "async-global-executor-trait",
- "async-reactor-trait",
- "async-trait",
- "executor-trait",
- "flume",
- "futures-core",
- "futures-io",
- "parking_lot",
- "pinky-swear",
- "reactor-trait",
- "serde",
- "tracing",
- "waker-fn",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1811,12 +1175,6 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1915,23 +1273,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
-name = "native-tls"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1950,12 +1291,6 @@ dependencies = [
  "num-integer",
  "num-traits",
 ]
-
-[[package]]
-name = "num-conv"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-integer"
@@ -1981,7 +1316,7 @@ version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
- "hermit-abi 0.5.2",
+ "hermit-abi",
  "libc",
 ]
 
@@ -1995,19 +1330,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "oid-registry"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
-dependencies = [
- "asn1-rs",
-]
-
-[[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -2016,82 +1342,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
-name = "openssl"
-version = "0.10.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
-dependencies = [
- "bitflags 2.9.4",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.111"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
-name = "p12-keystore"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cae83056e7cb770211494a0ecf66d9fa7eba7d00977e5bb91f0e925b40b937f"
-dependencies = [
- "cbc",
- "cms",
- "der",
- "des",
- "hex",
- "hmac",
- "pkcs12",
- "pkcs5",
- "rand 0.9.2",
- "rc2",
- "sha1",
- "sha2",
- "thiserror 2.0.17",
- "x509-parser",
-]
-
-[[package]]
-name = "parking"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -2114,25 +1368,6 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link",
-]
-
-[[package]]
-name = "pbkdf2"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
-dependencies = [
- "digest",
- "hmac",
-]
-
-[[package]]
-name = "pem-rfc7468"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
-dependencies = [
- "base64ct",
 ]
 
 [[package]]
@@ -2184,93 +1419,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "pinky-swear"
-version = "6.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1ea6e230dd3a64d61bcb8b79e597d3ab6b4c94ec7a234ce687dd718b4f2e657"
-dependencies = [
- "doc-comment",
- "flume",
- "parking_lot",
- "tracing",
-]
-
-[[package]]
-name = "piper"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
-dependencies = [
- "atomic-waker",
- "fastrand 2.3.0",
- "futures-io",
-]
-
-[[package]]
-name = "pkcs12"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "695b3df3d3cc1015f12d70235e35b6b79befc5fa7a9b95b951eab1dd07c9efc2"
-dependencies = [
- "cms",
- "const-oid",
- "der",
- "digest",
- "spki",
- "x509-cert",
- "zeroize",
-]
-
-[[package]]
-name = "pkcs5"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e847e2c91a18bfa887dd028ec33f2fe6f25db77db3619024764914affe8b69a6"
-dependencies = [
- "aes",
- "cbc",
- "der",
- "pbkdf2",
- "scrypt",
- "sha2",
- "spki",
-]
-
-[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
-
-[[package]]
-name = "polling"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
-dependencies = [
- "autocfg",
- "bitflags 1.3.2",
- "cfg-if",
- "concurrent-queue",
- "libc",
- "log",
- "pin-project-lite",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "polling"
-version = "3.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
-dependencies = [
- "cfg-if",
- "concurrent-queue",
- "hermit-abi 0.5.2",
- "pin-project-lite",
- "rustix 1.1.2",
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "portable-atomic"
@@ -2295,12 +1447,6 @@ checksum = "84df19adbe5b5a0782edcab45899906947ab039ccf4573713735ee7de1e6b08a"
 dependencies = [
  "zerovec",
 ]
-
-[[package]]
-name = "powerfmt"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -2414,18 +1560,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
-dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.3",
+ "rand_chacha",
+ "rand_core",
 ]
 
 [[package]]
@@ -2435,17 +1571,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.3",
+ "rand_core",
 ]
 
 [[package]]
@@ -2455,15 +1581,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.16",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
-dependencies = [
- "getrandom 0.3.3",
 ]
 
 [[package]]
@@ -2484,26 +1601,6 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
-]
-
-[[package]]
-name = "rc2"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62c64daa8e9438b84aaae55010a93f396f8e60e3911590fcba770d04643fc1dd"
-dependencies = [
- "cipher",
-]
-
-[[package]]
-name = "reactor-trait"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "438a4293e4d097556730f4711998189416232f009c137389e0f961d2bc0ddc58"
-dependencies = [
- "async-trait",
- "futures-core",
- "futures-io",
 ]
 
 [[package]]
@@ -2636,29 +1733,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
-name = "rusticata-macros"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
-dependencies = [
- "nom",
-]
-
-[[package]]
-name = "rustix"
-version = "0.37.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "519165d378b97752ca44bbe15047d5d3409e875f39327546b42ac81d7e18c1b6"
-dependencies = [
- "bitflags 1.3.2",
- "errno",
- "io-lifetimes",
- "libc",
- "linux-raw-sys 0.3.8",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "rustix"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2667,7 +1741,7 @@ dependencies = [
  "bitflags 2.9.4",
  "errno",
  "libc",
- "linux-raw-sys 0.11.0",
+ "linux-raw-sys",
  "windows-sys 0.61.2",
 ]
 
@@ -2680,49 +1754,9 @@ dependencies = [
  "log",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.102.8",
+ "rustls-webpki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls"
-version = "0.23.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
-dependencies = [
- "once_cell",
- "ring",
- "rustls-pki-types",
- "rustls-webpki 0.103.8",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "rustls-connector"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70cc376c6ba1823ae229bacf8ad93c136d93524eab0e4e5e0e4f96b9c4e5b212"
-dependencies = [
- "log",
- "rustls 0.23.35",
- "rustls-native-certs",
- "rustls-pki-types",
- "rustls-webpki 0.103.8",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
-dependencies = [
- "openssl-probe",
- "rustls-pemfile",
- "rustls-pki-types",
- "schannel",
- "security-framework",
 ]
 
 [[package]]
@@ -2755,17 +1789,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-webpki"
-version = "0.103.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
-dependencies = [
- "ring",
- "rustls-pki-types",
- "untrusted",
-]
-
-[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2778,62 +1801,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
-name = "salsa20"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
-dependencies = [
- "cipher",
-]
-
-[[package]]
-name = "schannel"
-version = "0.1.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "scrypt"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
-dependencies = [
- "pbkdf2",
- "salsa20",
- "sha2",
-]
-
-[[package]]
-name = "security-framework"
-version = "2.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
-dependencies = [
- "bitflags 2.9.4",
- "core-foundation",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
 
 [[package]]
 name = "serde"
@@ -2902,32 +1873,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
-]
-
-[[package]]
 name = "sha1_smol"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
-
-[[package]]
-name = "sha2"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
-]
 
 [[package]]
 name = "shlex"
@@ -2964,16 +1913,6 @@ checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
 name = "socket2"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "socket2"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
@@ -2990,25 +1929,6 @@ checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
-]
-
-[[package]]
-name = "spki"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
-dependencies = [
- "base64ct",
- "der",
 ]
 
 [[package]]
@@ -3079,27 +1999,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "tcp-stream"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "495b0abdce3dc1f8fd27240651c9e68890c14e9d9c61527b1ce44d8a5a7bd3d5"
-dependencies = [
- "cfg-if",
- "p12-keystore",
- "rustls-connector",
- "rustls-pemfile",
-]
-
-[[package]]
 name = "tempfile"
 version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
 dependencies = [
- "fastrand 2.3.0",
+ "fastrand",
  "getrandom 0.3.3",
  "once_cell",
- "rustix 1.1.2",
+ "rustix",
  "windows-sys 0.61.2",
 ]
 
@@ -3150,37 +2058,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "time"
-version = "0.3.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
-dependencies = [
- "deranged",
- "itoa",
- "num-conv",
- "powerfmt",
- "serde",
- "time-core",
- "time-macros",
-]
-
-[[package]]
-name = "time-core"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
-
-[[package]]
-name = "time-macros"
-version = "0.2.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
-dependencies = [
- "num-conv",
- "time-core",
 ]
 
 [[package]]
@@ -3235,22 +2112,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-rustls"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
 dependencies = [
- "rustls 0.22.4",
+ "rustls",
  "rustls-pki-types",
  "tokio",
 ]
@@ -3264,20 +2131,6 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
-]
-
-[[package]]
-name = "tokio-tungstenite"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
-dependencies = [
- "futures-util",
- "log",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tungstenite",
 ]
 
 [[package]]
@@ -3346,7 +2199,7 @@ dependencies = [
  "base64",
  "bytes",
  "h2",
- "http 0.2.12",
+ "http",
  "http-body",
  "hyper",
  "hyper-timeout",
@@ -3388,7 +2241,7 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand",
  "slab",
  "tokio",
  "tokio-util",
@@ -3448,31 +2301,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
-name = "tungstenite"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
-dependencies = [
- "byteorder",
- "bytes",
- "data-encoding",
- "http 1.4.0",
- "httparse",
- "log",
- "native-tls",
- "rand 0.8.5",
- "sha1",
- "thiserror 1.0.69",
- "utf-8",
-]
-
-[[package]]
-name = "typenum"
-version = "1.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3501,18 +2329,6 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
-
-[[package]]
-name = "urlencoding"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
-
-[[package]]
-name = "utf-8"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"
@@ -3548,12 +2364,6 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "waker-fn"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317211a0dc0ceedd78fb2ca9a44aed3d7b9b26f81870d485c07122b4350673b7"
 
 [[package]]
 name = "want"
@@ -3646,28 +2456,6 @@ checksum = "bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1"
 dependencies = [
  "unicode-ident",
 ]
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -3979,34 +2767,6 @@ name = "writeable"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
-
-[[package]]
-name = "x509-cert"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
-dependencies = [
- "const-oid",
- "der",
- "spki",
-]
-
-[[package]]
-name = "x509-parser"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4569f339c0c402346d4a75a9e39cf8dad310e287eef1ff56d4c68e5067f53460"
-dependencies = [
- "asn1-rs",
- "data-encoding",
- "der-parser",
- "lazy_static",
- "nom",
- "oid-registry",
- "rusticata-macros",
- "thiserror 2.0.17",
- "time",
-]
 
 [[package]]
 name = "yoke"

--- a/tests/http_integration.rs
+++ b/tests/http_integration.rs
@@ -1,0 +1,448 @@
+/*
+ * Copyright 2025-2026 EventFlux.io
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! # HTTP Integration Tests
+//!
+//! Requires building with the `http` feature:
+//! `cargo test --features http --test http_integration`
+//!
+//! Unlike the broker-backed connectors, these tests are self-hosting — the
+//! webhook source receives the sink's output, and poll tests use in-process
+//! `tiny_http` responders — so nothing is `#[ignore]`d and no external
+//! service is needed.
+
+#![cfg(feature = "http")]
+
+#[path = "common/mod.rs"]
+mod common;
+use common::{free_port, wait_listening, CollectingCallback};
+
+use eventflux::core::stream::input::source::http_source::HttpSource;
+use eventflux::core::stream::input::source::Source;
+use eventflux::core::stream::output::sink::http_sink::HttpSink;
+use eventflux::core::stream::output::sink::Sink;
+use std::collections::HashMap;
+use std::net::TcpListener;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+fn webhook_props(port: u16, path: &str) -> HashMap<String, String> {
+    let mut props = HashMap::new();
+    props.insert("http.mode".to_string(), "webhook".to_string());
+    props.insert("http.host".to_string(), "127.0.0.1".to_string());
+    props.insert("http.port".to_string(), port.to_string());
+    props.insert("http.path".to_string(), path.to_string());
+    props
+}
+
+fn sink_props(url: &str) -> HashMap<String, String> {
+    let mut props = HashMap::new();
+    props.insert("http.url".to_string(), url.to_string());
+    // Fast tests: minimal backoff
+    props.insert("http.retry.initial-delay-ms".to_string(), "20".to_string());
+    props.insert("http.retry.max-delay-ms".to_string(), "50".to_string());
+    props
+}
+
+/// In-process responder: serves the given (status, body) sequence, repeating
+/// the last entry, and counts requests. Returns (url, hit counter, stopper).
+fn spawn_responder(
+    responses: Vec<(u16, &'static str)>,
+) -> (String, Arc<AtomicUsize>, impl FnOnce()) {
+    let server = tiny_http::Server::http("127.0.0.1:0").unwrap();
+    let url = format!("http://{}/", server.server_addr());
+    let hits = Arc::new(AtomicUsize::new(0));
+    let stop = Arc::new(AtomicBool::new(false));
+
+    let thread_hits = Arc::clone(&hits);
+    let thread_stop = Arc::clone(&stop);
+    let handle = std::thread::spawn(move || {
+        while !thread_stop.load(Ordering::SeqCst) {
+            match server.recv_timeout(Duration::from_millis(50)) {
+                Ok(Some(request)) => {
+                    let n = thread_hits.fetch_add(1, Ordering::SeqCst);
+                    let (status, body) = responses[n.min(responses.len() - 1)];
+                    let response = tiny_http::Response::from_string(body)
+                        .with_status_code(tiny_http::StatusCode(status));
+                    let _ = request.respond(response);
+                }
+                _ => continue,
+            }
+        }
+    });
+
+    let stopper = move || {
+        stop.store(true, Ordering::SeqCst);
+        let _ = handle.join();
+    };
+    (url, hits, stopper)
+}
+
+// ============================================================================
+// Round trip: HTTP sink → webhook source (public API end to end)
+// ============================================================================
+
+#[test]
+fn test_sink_to_webhook_source_round_trip() {
+    let port = free_port();
+    let callback = CollectingCallback::new();
+    let mut source =
+        HttpSource::from_properties(&webhook_props(port, "/ingest"), None, "Test").unwrap();
+    source.start(Arc::new(callback.clone()));
+    wait_listening(port);
+
+    let sink =
+        HttpSink::from_properties(&sink_props(&format!("http://127.0.0.1:{port}/ingest"))).unwrap();
+    sink.publish(b"one").unwrap();
+    sink.publish(b"two").unwrap();
+    sink.publish(b"three").unwrap();
+    sink.stop();
+
+    let payloads = callback.wait_for(3, Duration::from_secs(10));
+    source.stop();
+
+    assert_eq!(
+        payloads,
+        vec![b"one".to_vec(), b"two".to_vec(), b"three".to_vec()]
+    );
+}
+
+#[test]
+fn test_webhook_concurrent_requests_all_delivered() {
+    let port = free_port();
+    let callback = CollectingCallback::new();
+    let mut source = HttpSource::from_properties(&webhook_props(port, "/"), None, "Test").unwrap();
+    source.start(Arc::new(callback.clone()));
+    wait_listening(port);
+
+    let url = format!("http://127.0.0.1:{port}/");
+    let handles: Vec<_> = (0..8)
+        .map(|i| {
+            let props = sink_props(&url);
+            std::thread::spawn(move || {
+                let sink = HttpSink::from_properties(&props).unwrap();
+                sink.publish(format!("payload-{i}").as_bytes()).unwrap();
+            })
+        })
+        .collect();
+    for handle in handles {
+        handle.join().unwrap();
+    }
+
+    let mut payloads = callback.wait_for(8, Duration::from_secs(10));
+    source.stop();
+
+    payloads.sort();
+    let expected: Vec<Vec<u8>> = (0..8)
+        .map(|i| format!("payload-{i}").into_bytes())
+        .collect();
+    assert_eq!(payloads, expected, "all concurrent requests must arrive");
+}
+
+// ============================================================================
+// Webhook protocol behavior (asserted with a direct ureq client so the
+// expectations are numeric response statuses)
+// ============================================================================
+
+#[test]
+fn test_webhook_rejections() {
+    let port = free_port();
+    let mut props = webhook_props(port, "/hook");
+    props.insert("http.auth.header".to_string(), "X-Token".to_string());
+    props.insert("http.auth.token".to_string(), "secret".to_string());
+    props.insert("http.max.body.bytes".to_string(), "64".to_string());
+
+    let callback = CollectingCallback::new();
+    let mut source = HttpSource::from_properties(&props, None, "Test").unwrap();
+    source.start(Arc::new(callback.clone()));
+    wait_listening(port);
+
+    // Direct client so protocol assertions are numeric response statuses,
+    // decoupled from the HTTP sink's error-message wording
+    let agent: ureq::Agent = ureq::Agent::config_builder()
+        .http_status_as_error(false)
+        .build()
+        .into();
+    let base = format!("http://127.0.0.1:{port}");
+
+    // Missing auth → 401
+    let status = agent.post(format!("{base}/hook")).send(&b"x"[..]).unwrap();
+    assert_eq!(status.status().as_u16(), 401);
+
+    // Wrong path → 404
+    let status = agent
+        .post(format!("{base}/other"))
+        .header("X-Token", "secret")
+        .send(&b"x"[..])
+        .unwrap();
+    assert_eq!(status.status().as_u16(), 404);
+
+    // Wrong method → 405
+    let status = agent
+        .put(format!("{base}/hook"))
+        .header("X-Token", "secret")
+        .send(&b"x"[..])
+        .unwrap();
+    assert_eq!(status.status().as_u16(), 405);
+
+    // Oversized body → 413
+    let status = agent
+        .post(format!("{base}/hook"))
+        .header("X-Token", "secret")
+        .send(&[0u8; 128][..])
+        .unwrap();
+    assert_eq!(status.status().as_u16(), 413);
+
+    // Oversized AND unauthenticated → 401: auth is checked before the body
+    // is buffered, so unauthenticated floods cannot consume memory
+    let status = agent
+        .post(format!("{base}/hook"))
+        .send(&[0u8; 128][..])
+        .unwrap();
+    assert_eq!(status.status().as_u16(), 401);
+
+    // Correct auth, path, method, size → 200 and delivered
+    let status = agent
+        .post(format!("{base}/hook"))
+        .header("X-Token", "secret")
+        .send(&b"valid"[..])
+        .unwrap();
+    assert_eq!(status.status().as_u16(), 200);
+
+    let payloads = callback.wait_for(1, Duration::from_secs(10));
+    source.stop();
+    assert_eq!(payloads, vec![b"valid".to_vec()]);
+}
+
+// ============================================================================
+// Poll mode (in-process canned responders)
+// ============================================================================
+
+#[test]
+fn test_poll_source_delivers_bodies() {
+    let (url, _hits, stop) = spawn_responder(vec![(200, "{\"n\":1}")]);
+
+    let mut props = HashMap::new();
+    props.insert("http.mode".to_string(), "poll".to_string());
+    props.insert("http.url".to_string(), url);
+    props.insert("http.poll.interval.ms".to_string(), "50".to_string());
+
+    let callback = CollectingCallback::new();
+    let mut source = HttpSource::from_properties(&props, None, "Test").unwrap();
+    source.start(Arc::new(callback.clone()));
+
+    let payloads = callback.wait_for(2, Duration::from_secs(10));
+    source.stop();
+    stop();
+
+    assert!(payloads.len() >= 2, "expected repeated polls to deliver");
+    assert_eq!(payloads[0], b"{\"n\":1}".to_vec());
+}
+
+#[test]
+fn test_poll_source_skips_empty_and_not_modified() {
+    // 204 empty, then 304, then a real body
+    let (url, _hits, stop) = spawn_responder(vec![(204, ""), (304, ""), (200, "data")]);
+
+    let mut props = HashMap::new();
+    props.insert("http.mode".to_string(), "poll".to_string());
+    props.insert("http.url".to_string(), url);
+    props.insert("http.poll.interval.ms".to_string(), "30".to_string());
+
+    let callback = CollectingCallback::new();
+    let mut source = HttpSource::from_properties(&props, None, "Test").unwrap();
+    source.start(Arc::new(callback.clone()));
+
+    let payloads = callback.wait_for(1, Duration::from_secs(10));
+    source.stop();
+    stop();
+
+    assert_eq!(payloads[0], b"data".to_vec(), "empty/304 must be skipped");
+}
+
+#[test]
+fn test_poll_empty_body_respects_interval() {
+    // Regression: an empty 2xx body must NOT skip the inter-poll sleep —
+    // that would busy-loop against the endpoint at full speed
+    let (url, hits, stop) = spawn_responder(vec![(204, "")]);
+
+    let mut props = HashMap::new();
+    props.insert("http.mode".to_string(), "poll".to_string());
+    props.insert("http.url".to_string(), url);
+    props.insert("http.poll.interval.ms".to_string(), "100".to_string());
+
+    let callback = CollectingCallback::new();
+    let mut source = HttpSource::from_properties(&props, None, "Test").unwrap();
+    source.start(Arc::new(callback.clone()));
+
+    std::thread::sleep(Duration::from_millis(600));
+    source.stop();
+    stop();
+
+    // ~6 polls fit in the window; a busy loop would rack up thousands
+    let polls = hits.load(Ordering::SeqCst);
+    assert!(
+        polls <= 10,
+        "empty bodies must not bypass the interval (got {polls} polls)"
+    );
+}
+
+#[test]
+fn test_poll_long_interval_stops_promptly() {
+    let (url, _hits, stop) = spawn_responder(vec![(200, "x")]);
+
+    let mut props = HashMap::new();
+    props.insert("http.mode".to_string(), "poll".to_string());
+    props.insert("http.url".to_string(), url);
+    // An interval far beyond the stop grace period
+    props.insert("http.poll.interval.ms".to_string(), "600000".to_string());
+
+    let callback = CollectingCallback::new();
+    let mut source = HttpSource::from_properties(&props, None, "Test").unwrap();
+    source.start(Arc::new(callback.clone()));
+    callback.wait_for(1, Duration::from_secs(10));
+
+    // sleep_while_running makes the interval interruptible
+    let start = Instant::now();
+    source.stop();
+    stop();
+    assert!(
+        start.elapsed() < Duration::from_secs(5),
+        "stop() must interrupt a long poll interval"
+    );
+}
+
+// ============================================================================
+// Sink retry semantics
+// ============================================================================
+
+#[test]
+fn test_sink_retries_5xx_then_succeeds() {
+    let (url, hits, stop) = spawn_responder(vec![(500, ""), (503, ""), (200, "ok")]);
+
+    let mut props = sink_props(&url);
+    props.insert("http.retry.max-attempts".to_string(), "3".to_string());
+    let sink = HttpSink::from_properties(&props).unwrap();
+
+    sink.publish(b"payload").unwrap();
+    stop();
+    assert_eq!(hits.load(Ordering::SeqCst), 3, "two failures + one success");
+}
+
+#[test]
+fn test_sink_does_not_retry_4xx() {
+    let (url, hits, stop) = spawn_responder(vec![(400, "bad")]);
+
+    let mut props = sink_props(&url);
+    props.insert("http.retry.max-attempts".to_string(), "5".to_string());
+    let sink = HttpSink::from_properties(&props).unwrap();
+
+    let err = sink.publish(b"payload").unwrap_err().to_string();
+    stop();
+    assert!(err.contains("400"), "got: {err}");
+    assert_eq!(
+        hits.load(Ordering::SeqCst),
+        1,
+        "4xx must not be retried — the request itself is wrong"
+    );
+}
+
+#[test]
+fn test_sink_does_not_follow_redirects() {
+    // Following a 302 would rewrite the POST to a body-less GET and the
+    // final 200 would count a dropped payload as delivered — redirects
+    // must surface as permanent errors instead
+    let (url, hits, stop) = spawn_responder(vec![(302, "")]);
+
+    let sink = HttpSink::from_properties(&sink_props(&url)).unwrap();
+    let err = sink.publish(b"payload").unwrap_err().to_string();
+    stop();
+
+    assert!(err.contains("302"), "got: {err}");
+    assert_eq!(
+        hits.load(Ordering::SeqCst),
+        1,
+        "redirect must not be followed or retried"
+    );
+}
+
+#[test]
+fn test_sink_retries_exhausted() {
+    let (url, hits, stop) = spawn_responder(vec![(500, "")]);
+
+    let mut props = sink_props(&url);
+    props.insert("http.retry.max-attempts".to_string(), "2".to_string());
+    let sink = HttpSink::from_properties(&props).unwrap();
+
+    let err = sink.publish(b"payload").unwrap_err().to_string();
+    stop();
+    assert!(err.contains("failed after 3 attempt"), "got: {err}");
+    assert_eq!(hits.load(Ordering::SeqCst), 3, "initial + 2 retries");
+}
+
+// ============================================================================
+// Connectivity validation
+// ============================================================================
+
+#[test]
+fn test_validate_connectivity() {
+    // Any HTTP response — even 404 — proves reachability
+    let (url, _hits, stop) = spawn_responder(vec![(404, "")]);
+    let sink = HttpSink::from_properties(&sink_props(&url)).unwrap();
+    sink.validate_connectivity().unwrap();
+    stop();
+
+    // Nothing listening → transport failure → validation error
+    let dead = format!("http://127.0.0.1:{}/", free_port());
+    let sink = HttpSink::from_properties(&sink_props(&dead)).unwrap();
+    assert!(sink.validate_connectivity().is_err());
+
+    // Webhook validation fails fast on an occupied port
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let source = HttpSource::from_properties(&webhook_props(port, "/"), None, "Test").unwrap();
+    assert!(source.validate_connectivity().is_err());
+    drop(listener);
+}
+
+// ============================================================================
+// Shutdown
+// ============================================================================
+
+#[test]
+fn test_webhook_source_stops_promptly() {
+    let port = free_port();
+    let callback = CollectingCallback::new();
+    let mut source = HttpSource::from_properties(&webhook_props(port, "/"), None, "Test").unwrap();
+    source.start(Arc::new(callback.clone()));
+    wait_listening(port);
+
+    let start = Instant::now();
+    source.stop();
+    assert!(
+        start.elapsed() < Duration::from_secs(5),
+        "graceful shutdown must complete promptly"
+    );
+
+    // The port is released after shutdown (retry briefly for OS cleanup)
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while TcpListener::bind(("127.0.0.1", port)).is_err() {
+        assert!(Instant::now() < deadline, "port not released after stop()");
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}

--- a/tests/kafka_integration.rs
+++ b/tests/kafka_integration.rs
@@ -34,13 +34,17 @@
 
 #![cfg(feature = "kafka")]
 
+#[path = "common/mod.rs"]
+mod common;
+use common::CollectingCallback;
+
 use eventflux::core::exception::EventFluxError;
 use eventflux::core::stream::input::source::kafka_source::KafkaSource;
 use eventflux::core::stream::input::source::{Source, SourceCallback};
 use eventflux::core::stream::output::sink::kafka_sink::KafkaSink;
 use eventflux::core::stream::output::sink::Sink;
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 fn broker() -> String {
@@ -77,39 +81,6 @@ fn sink_props(topic: &str) -> HashMap<String, String> {
     // Exercise the static record-key path
     props.insert("kafka.key".to_string(), "test-key".to_string());
     props
-}
-
-/// Callback that records every payload it receives
-#[derive(Debug, Clone)]
-struct CollectingCallback {
-    payloads: Arc<Mutex<Vec<Vec<u8>>>>,
-}
-
-impl CollectingCallback {
-    fn new() -> Self {
-        Self {
-            payloads: Arc::new(Mutex::new(Vec::new())),
-        }
-    }
-
-    fn wait_for(&self, count: usize, timeout: Duration) -> Vec<Vec<u8>> {
-        let deadline = Instant::now() + timeout;
-        loop {
-            let payloads = self.payloads.lock().unwrap();
-            if payloads.len() >= count || Instant::now() >= deadline {
-                return payloads.clone();
-            }
-            drop(payloads);
-            std::thread::sleep(Duration::from_millis(50));
-        }
-    }
-}
-
-impl SourceCallback for CollectingCallback {
-    fn on_data(&self, data: &[u8]) -> Result<(), EventFluxError> {
-        self.payloads.lock().unwrap().push(data.to_vec());
-        Ok(())
-    }
 }
 
 // Factory metadata and config-validation coverage lives in the in-module

--- a/website/docs/connectors/http.md
+++ b/website/docs/connectors/http.md
@@ -1,0 +1,143 @@
+---
+sidebar_position: 2
+title: HTTP Connector
+description: REST polling, webhook ingestion, and webhook delivery
+---
+
+# HTTP Connector
+
+The HTTP connector lets EventFlux ingest events over HTTP — by **polling** REST endpoints or by **listening** for webhooks — and deliver processed events as outbound webhook requests with retry. It supports JSON, CSV, and bytes formats.
+
+The stack uses the best tool per side: a blocking `ureq` client (rustls — hermetic, no system TLS) for the sink and polling, and an **axum** server (on tokio) for the webhook listener, giving concurrent request handling out of the box.
+
+## Prerequisites
+
+The HTTP connector is feature-gated. Build EventFlux with the `http` feature (Docker images already include all connectors). Both underlying crates are pure Rust — no extra toolchain needed:
+
+```bash
+cargo build --release --features http
+# or: cargo build --release --features connectors-all
+```
+
+## HTTP Source
+
+One extension, two modes selected by `http.mode`.
+
+### Poll Mode
+
+Periodically requests a URL; each 2xx response body becomes one payload through the mapper.
+
+```sql
+CREATE STREAM Prices (symbol STRING, price DOUBLE) WITH (
+    type = 'source',
+    extension = 'http',
+    format = 'json',
+    "http.mode" = 'poll',
+    "http.url" = 'https://api.example.com/v1/price?symbol=AAPL',
+    "http.poll.interval.ms" = '2000',
+    "http.headers.X-Api-Key" = '${API_KEY}'
+);
+```
+
+| Option | Required | Default | Description |
+|--------|----------|---------|-------------|
+| `http.mode` | Yes | - | `poll` |
+| `http.url` | Yes | - | URL to poll (http/https) |
+| `http.poll.interval.ms` | No | `5000` | Time between polls (interruptible — long intervals never delay shutdown) |
+| `http.method` | No | `GET` | `GET` or `POST` |
+| `http.headers.<Name>` | No | - | Request headers; put secrets in env vars: `'Bearer ${TOKEN}'` |
+| `http.timeout.ms` | No | `30000` | Per-request timeout |
+| `error.*` | No | - | Error strategies (`drop`/`retry`/`dlq`/`fail`) — same options as [Kafka](/docs/connectors/kafka#error-handling) |
+
+Poll behavior: `2xx` non-empty body → delivered · empty body / `204` / `304` → skipped · other statuses (including un-followed `3xx` redirects) and transport errors → routed through the error strategy (use `retry` for polling backoff). Response bodies are capped at 10 MB (the HTTP client's read limit); larger responses surface as read errors. Each poll is independent — deduplication is the endpoint's or the query's concern.
+
+### Webhook Mode
+
+Runs an HTTP listener; each accepted POST body becomes one payload. Requests are handled **concurrently** (bounded by the configured cap).
+
+```sql
+CREATE STREAM Alerts (service STRING, level STRING, message STRING) WITH (
+    type = 'source',
+    extension = 'http',
+    format = 'json',
+    "http.mode" = 'webhook',
+    "http.port" = '8081',
+    "http.path" = '/alerts',
+    "http.auth.header" = 'X-Webhook-Token',
+    "http.auth.token" = '${WEBHOOK_TOKEN}'
+);
+```
+
+| Option | Required | Default | Description |
+|--------|----------|---------|-------------|
+| `http.mode` | Yes | - | `webhook` |
+| `http.port` | Yes | - | Port to listen on |
+| `http.host` | No | `0.0.0.0` | Bind address |
+| `http.path` | No | `/` | Request path to accept |
+| `http.auth.header` / `http.auth.token` | No | - | Inbound auth: required header name + exact value (set together) |
+| `http.max.concurrent.requests` | No | `256` | Concurrency cap; excess requests queue |
+| `http.max.body.bytes` | No | `1048576` | Payload size cap |
+| `error.*` | No | - | Error strategies, as above |
+
+Response codes:
+
+| Situation | Response |
+|-----------|----------|
+| Payload accepted (delivered, or disposed by drop/DLQ strategy) | `200` |
+| Empty body | `200` (skipped) |
+| Auth missing/mismatched | `401` |
+| Wrong path / wrong method | `404` / `405` |
+| Body too large | `413` |
+| Unrecoverable delivery failure (`fail` strategy) | `500`, listener shuts down gracefully |
+| Listener shutting down (stop or after a failure) | `503` |
+
+Deployment: run the listener behind a reverse proxy (nginx/caddy) — it terminates TLS and enforces client read timeouts (the listener itself does not time out slow clients).
+
+## HTTP Sink
+
+Sends each event as its own request (one event = one message). Retries with exponential backoff apply to transport errors and `408`/`429`/`5xx`; other `4xx` are returned to the pipeline immediately — retrying a wrong request can't fix it. Redirects are never followed (following a `302` would silently convert the POST to a body-less GET); a `3xx` is a permanent error — point `http.url` at the final location.
+
+```sql
+CREATE STREAM Escalations (service STRING, message STRING) WITH (
+    type = 'sink',
+    extension = 'http',
+    format = 'json',
+    "http.url" = 'https://hooks.example.com/escalate',
+    "http.headers.Authorization" = 'Bearer ${HOOK_TOKEN}',
+    "http.retry.max-attempts" = '5'
+);
+```
+
+| Option | Required | Default | Description |
+|--------|----------|---------|-------------|
+| `http.url` | Yes | - | Endpoint to send to |
+| `http.method` | No | `POST` | `POST`, `PUT`, or `PATCH` |
+| `http.headers.<Name>` | No | - | Request headers (auth goes here) |
+| `http.content.type` | No | derived | From the stream format: json → `application/json`, csv → `text/csv`, bytes → `application/octet-stream`. A verbatim `http.headers.Content-Type` wins instead; setting both is rejected |
+| `http.timeout.ms` | No | `30000` | Per-request timeout |
+| `http.retry.max-attempts` | No | `3` | Retries after the first attempt (`0` disables) |
+| `http.retry.initial-delay-ms` | No | `100` | First retry delay |
+| `http.retry.max-delay-ms` | No | `10000` | Retry delay ceiling |
+| `http.retry.backoff-multiplier` | No | `2.0` | Exponential factor |
+| `http.validation.method` | No | `HEAD` | Startup reachability probe: `HEAD`, `GET`, `OPTIONS`, or `none` to skip |
+
+Retries block inside the publish call — backpressure by design.
+
+## Connection Validation
+
+At startup (fail-fast):
+
+- **Sink / poll source**: sends the probe (`HEAD` for polling; configurable for the sink). *Any* HTTP response — including `404` or `405` — proves reachability; only transport failures (connect/timeout/TLS) block startup. Endpoints that can't tolerate probes: `"http.validation.method" = 'none'`.
+- **Webhook source**: binds the configured port and releases it — port conflicts and permission errors fail immediately.
+
+## Complete End-to-End Example
+
+See [`examples/http.eventflux`](https://github.com/eventflux-io/eventflux/blob/main/examples/http.eventflux) — a webhook-in → filter → webhook-out pipeline testable with `curl` alone, no external infrastructure.
+
+## Not Yet Supported
+
+- Request/response mode (query result as the HTTP response) — designed, tracked in [#134](https://github.com/eventflux-io/eventflux/issues/134)
+- Batched sink requests (N events per POST)
+- Connector-managed conditional GET (pass `If-None-Match`/`If-Modified-Since` through `http.headers.*` yourself; `304` responses are skipped)
+- OAuth token flows (use static bearer headers with env vars)
+- In-process TLS for the listener (reverse proxy)

--- a/website/docs/connectors/overview.md
+++ b/website/docs/connectors/overview.md
@@ -101,6 +101,7 @@ extension name. The default build is fully minimal (core engine plus the
 built-in `timer` source and `log` sink):
 
 ```bash
+cargo build --release --features http              # just HTTP
 cargo build --release --features kafka             # just Kafka
 cargo build --release --features rabbitmq          # just RabbitMQ
 cargo build --release --features websocket         # just WebSocket
@@ -123,10 +124,10 @@ build. Rebuild with `--features rabbitmq` (or `--features connectors-all`).
 |-----------|--------|------|--------------|--------|-------------|
 | **Timer** | Yes | — | (always built) | Production Ready | Periodic tick source |
 | **Log** | — | Yes | (always built) | Production Ready | Logging sink for debugging |
+| **HTTP** | Yes | Yes | `http` | Production Ready | REST polling, webhooks in/out |
 | **Kafka** | Yes | Yes | `kafka` | Production Ready | Apache Kafka streaming |
 | **RabbitMQ** | Yes | Yes | `rabbitmq` | Production Ready | AMQP 0-9-1 message broker |
 | **WebSocket** | Yes | Yes | `websocket` | Production Ready | Real-time bidirectional streaming |
-| **HTTP** | Planned | Planned | — | Roadmap | REST/Webhook endpoints |
 | **File** | Planned | Planned | — | Roadmap | File-based input/output |
 
 ## Available Mappers
@@ -218,6 +219,7 @@ manager.context().add_sink_factory(
 
 ## Next Steps
 
+- **[HTTP Connector](/docs/connectors/http)** - REST polling, webhook ingestion and delivery
 - **[Kafka Connector](/docs/connectors/kafka)** - Consume from and produce to Apache Kafka topics
 - **[RabbitMQ Connector](/docs/connectors/rabbitmq)** - Connect to RabbitMQ message broker
 - **[WebSocket Connector](/docs/connectors/websocket)** - Connect to WebSocket endpoints for real-time streaming

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -41,6 +41,7 @@ a cargo feature named exactly after its SQL extension name:
 
 | Feature | Connector | In default build? |
 |---------|-----------|-------------------|
+| `http` | HTTP source (polling + webhook) + sink | No |
 | `kafka` | Kafka source + sink (needs cmake to build) | No |
 | `rabbitmq` | RabbitMQ source + sink | No |
 | `websocket` | WebSocket source + sink | No |

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -51,6 +51,7 @@ const sidebars = {
       collapsed: false,
       items: [
         'connectors/overview',
+        'connectors/http',
         'connectors/kafka',
         'connectors/rabbitmq',
         'connectors/websocket',


### PR DESCRIPTION
Implements the HTTP connector (Priority 2) per the spec in `feat/http/README.md`. Closes #133.

## Source (`extension = 'http'`, two modes via `http.mode`)

- **poll** — periodically requests a URL with a blocking `ureq` client (rustls); each 2xx body is one payload. Interruptible interval (`sleep_while_running`), empty/`204`/`304` responses skipped, other statuses and transport/body-read errors routed through the standard `error.*` strategies.
- **webhook** — axum listener (http1 + tokio only) handling requests concurrently up to `http.max.concurrent.requests`. Payloads funnel over a bounded mpsc channel to a single delivery thread that owns the error context — no lock contention, natural backpressure. Optional header-token auth with a constant-time compare, checked **before** the body is buffered; body size capped; `Fail` verdicts (or an abnormally dead delivery thread) shut the listener down gracefully.

## Sink

One event = one request (`POST`/`PUT`/`PATCH`) with exponential-backoff retry on transport errors and `408`/`429`/`5xx`; other `4xx` are permanent. Redirects are deliberately not followed — following a `302` would rewrite the POST to a body-less GET and report a dropped payload as delivered. Content-Type is derived from the stream format via the new reserved `_format` injected property (explicit `http.content.type` or a verbatim `http.headers.Content-Type` override it; setting both is rejected). Fail-fast startup probe (`HEAD`/`GET`/`OPTIONS`/`none`).

## Shared infrastructure

- `connector_util`: `parse_or`, `parse_prefixed` (adopted by the WebSocket connector's header parsing; `parse_or` moved out of `kafka_common`), and the reserved `INJECTED_FORMAT_KEY` injected by `stream_initializer` for all source/sink factories
- `exponential_backoff_with_multiplier` in `core::error::retry` (existing `exponential_backoff` delegates; bit-identical for existing callers)
- Placeholder `HttpSinkFactory` in `example_factories` renamed to `ExampleSinkFactory` (`example.*` keys) now that a real HTTP sink exists
- Shared test helpers (`CollectingCallback`, `free_port`, `wait_listening`) in `tests/common`, adopted by the Kafka integration tests

## Gating, tests, docs

- Feature-gated behind `http` (axum + ureq optional deps), included in `connectors-all`; `GATED_OUT_EXTENSIONS` hint, per-connector CI/justfile/CONTRIBUTING checks updated
- 13 integration tests are fully self-hosting (sink → webhook-source round trip, tiny_http canned responders) — nothing `#[ignore]`d, no external service needed
- Website connector page with full config tables, `examples/http.eventflux` end-to-end demo testable with curl alone, README/ROADMAP/writing_extensions updated

Deferred with rationale in the spec: request/response mode (#134), batched requests, connector-managed conditional GET, OAuth, in-process TLS and client-read timeouts (reverse proxy for v1).