### PR TITLE
fix: start sources last to prevent startup event loss

### DIFF
--- a/src/core/eventflux_app_runtime.rs
+++ b/src/core/eventflux_app_runtime.rs
@@ -864,25 +864,29 @@ impl EventFluxAppRuntime {
             )));
         }
 
-        // 4. Execution phase - start all components (with rollback on error)
-        // Start all registered sources
-        if let Err(e) = self.start_all_sources() {
-            log::error!("Failed to start sources: {}", e);
-            self.rollback_startup();
-            *self.state.write().unwrap() = RuntimeState::Failed;
-            return Err(EventFluxError::app_runtime(format!(
-                "Failed to start sources: {}",
-                e
-            )));
-        }
-
-        // Start all registered sinks
+        // 4. Execution phase - start all components (with rollback on error).
+        // Downstream-first: sinks start before sources so that when the
+        // first event is consumed, every sink is subscribed and connected.
+        // The reverse order lost events published into not-yet-ready sink
+        // streams (#136). Shutdown mirrors this (sources stop first,
+        // sinks last).
         if let Err(e) = self.start_all_sinks() {
             log::error!("Failed to start sinks: {}", e);
             self.rollback_startup();
             *self.state.write().unwrap() = RuntimeState::Failed;
             return Err(EventFluxError::app_runtime(format!(
                 "Failed to start sinks: {}",
+                e
+            )));
+        }
+
+        // Sources start last — this is what begins event consumption
+        if let Err(e) = self.start_all_sources() {
+            log::error!("Failed to start sources: {}", e);
+            self.rollback_startup();
+            *self.state.write().unwrap() = RuntimeState::Failed;
+            return Err(EventFluxError::app_runtime(format!(
+                "Failed to start sources: {}",
                 e
             )));
         }
@@ -1212,7 +1216,8 @@ impl EventFluxAppRuntime {
     ///
     /// # Returns
     ///
-    /// * `Ok(())` - Source successfully attached and started
+    /// * `Ok(())` - Source successfully attached (it is started later by
+    ///   `start_all_sources` in the execution phase)
     /// * `Err(EventFluxError)` - Detailed error with context
     fn attach_source_common(
         &self,
@@ -1225,9 +1230,7 @@ impl EventFluxAppRuntime {
         use crate::core::stream::stream_initializer::{initialize_stream, InitializedStream};
 
         // Check if handler already registered (idempotent operation)
-        if let Some(existing_handler) = self.get_source_handler(stream_name) {
-            // Handler already exists - just ensure it's started
-            existing_handler.start()?;
+        if self.get_source_handler(stream_name).is_some() {
             return Ok(());
         }
 
@@ -1275,16 +1278,13 @@ impl EventFluxAppRuntime {
             stream_name.to_string(),
         ));
 
-        // Register handler in runtime
-        self.register_source_handler(stream_name.to_string(), Arc::clone(&handler));
-
-        // Start the source
-        handler.start().map_err(|e| {
-            EventFluxError::app_runtime(format!(
-                "Failed to start {} source '{}': {}",
-                context_label, stream_name, e
-            ))
-        })?;
+        // Register handler in runtime. The source is NOT started here:
+        // attachment only wires components. Consumption begins in the
+        // execution phase (start_all_sources), which runs after every sink
+        // is subscribed and started — a source that consumed at attach time
+        // could publish into a sink stream that has no subscriber yet,
+        // silently dropping events (#136).
+        self.register_source_handler(stream_name.to_string(), handler);
 
         Ok(())
     }

--- a/tests/startup_ordering.rs
+++ b/tests/startup_ordering.rs
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2025-2026 EventFlux.io
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! # Startup ordering regression test (#136)
+//!
+//! Sources must not begin consuming until every sink is attached and
+//! started. The bug: `attach_source_common` started sources during the
+//! attachment phase, so a source's first events could flow through a sink
+//! stream's junction before the sink subscribed — every such event was
+//! silently dropped (0 subscribers). A source that emits synchronously
+//! inside `start()` makes the failure deterministic instead of a race.
+
+use eventflux::core::eventflux_manager::EventFluxManager;
+use eventflux::core::exception::EventFluxError;
+use eventflux::core::extension::{SinkFactory, SourceFactory};
+use eventflux::core::stream::input::source::{Source, SourceCallback};
+use eventflux::core::stream::output::sink::Sink;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+/// Source that emits its payloads synchronously inside `start()` — the
+/// earliest moment any source is allowed to deliver events.
+#[derive(Debug, Clone)]
+struct ImmediateSource {
+    payloads: Vec<Vec<u8>>,
+}
+
+impl Source for ImmediateSource {
+    fn start(&mut self, callback: Arc<dyn SourceCallback>) {
+        for payload in &self.payloads {
+            callback
+                .on_data(payload)
+                .expect("immediate delivery must succeed");
+        }
+    }
+
+    fn stop(&mut self) {}
+
+    fn clone_box(&self) -> Box<dyn Source> {
+        Box::new(self.clone())
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ImmediateSourceFactory;
+
+impl SourceFactory for ImmediateSourceFactory {
+    fn name(&self) -> &'static str {
+        "immediate"
+    }
+
+    fn supported_formats(&self) -> &[&str] {
+        &["json"]
+    }
+
+    fn required_parameters(&self) -> &[&str] {
+        &[]
+    }
+
+    fn optional_parameters(&self) -> &[&str] {
+        &[]
+    }
+
+    fn create_initialized(
+        &self,
+        _config: &HashMap<String, String>,
+    ) -> Result<Box<dyn Source>, EventFluxError> {
+        Ok(Box::new(ImmediateSource {
+            payloads: vec![
+                br#"{"v": 1}"#.to_vec(),
+                br#"{"v": 2}"#.to_vec(),
+                br#"{"v": 3}"#.to_vec(),
+            ],
+        }))
+    }
+
+    fn clone_box(&self) -> Box<dyn SourceFactory> {
+        Box::new(self.clone())
+    }
+}
+
+/// Sink recording every published payload into a shared buffer.
+#[derive(Debug, Clone)]
+struct RecordingSink {
+    published: Arc<Mutex<Vec<Vec<u8>>>>,
+}
+
+impl Sink for RecordingSink {
+    fn publish(&self, payload: &[u8]) -> Result<(), EventFluxError> {
+        self.published.lock().unwrap().push(payload.to_vec());
+        Ok(())
+    }
+
+    fn clone_box(&self) -> Box<dyn Sink> {
+        Box::new(self.clone())
+    }
+}
+
+#[derive(Debug, Clone)]
+struct RecordingSinkFactory {
+    published: Arc<Mutex<Vec<Vec<u8>>>>,
+}
+
+impl SinkFactory for RecordingSinkFactory {
+    fn name(&self) -> &'static str {
+        "recording"
+    }
+
+    fn supported_formats(&self) -> &[&str] {
+        &["json"]
+    }
+
+    fn required_parameters(&self) -> &[&str] {
+        &[]
+    }
+
+    fn optional_parameters(&self) -> &[&str] {
+        &[]
+    }
+
+    fn create_initialized(
+        &self,
+        _config: &HashMap<String, String>,
+    ) -> Result<Box<dyn Sink>, EventFluxError> {
+        Ok(Box::new(RecordingSink {
+            published: Arc::clone(&self.published),
+        }))
+    }
+
+    fn clone_box(&self) -> Box<dyn SinkFactory> {
+        Box::new(self.clone())
+    }
+}
+
+#[tokio::test]
+async fn test_source_events_emitted_at_start_reach_the_sink() {
+    let published = Arc::new(Mutex::new(Vec::new()));
+
+    let manager = EventFluxManager::new();
+    manager.add_source_factory("immediate".to_string(), Box::new(ImmediateSourceFactory));
+    manager.add_sink_factory(
+        "recording".to_string(),
+        Box::new(RecordingSinkFactory {
+            published: Arc::clone(&published),
+        }),
+    );
+
+    let sql = r#"
+        CREATE STREAM In (v INT) WITH (
+            type = 'source', extension = 'immediate', format = 'json'
+        );
+        CREATE STREAM Out (v INT) WITH (
+            type = 'sink', extension = 'recording', format = 'json'
+        );
+        INSERT INTO Out SELECT v FROM In;
+    "#;
+
+    let runtime = manager
+        .create_eventflux_app_runtime_from_string(sql)
+        .await
+        .expect("runtime");
+    runtime.start().expect("start");
+
+    // The source delivered synchronously inside start(), so the events are
+    // either already at the sink or lost — a short deadline absorbs mapper
+    // scheduling only.
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while published.lock().unwrap().len() < 3 && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    runtime.shutdown();
+
+    let published = published.lock().unwrap();
+    assert_eq!(
+        published.len(),
+        3,
+        "events emitted the moment a source starts must reach the sink — \
+         sinks must be attached and started before any source runs (#136)"
+    );
+}


### PR DESCRIPTION
Closes #136.

## Root cause (differs from the issue's initial hypothesis)

The flake was a **startup** race, not a shutdown one. `attach_source_common` called `handler.start()` during the *attachment* phase of `EventFluxAppRuntime::start()`, so sources began consuming before sink adapters were subscribed to their junctions (and before `start_all_sinks()` ran at all). A source's first burst could flow through a sink stream's junction while it had **zero subscribers** — `dispatch_to_subscribers_sync` silently succeeds in that case, so every such event vanished without a trace. All-or-nothing, exactly as observed.

Caught red-handed with temporary probes on a failing run, in this order:

```
[DIAG] junction 'OutputTrades' dispatch with 0 subscribers — event dropped   (×3)
[DIAG] sink subscribed to junction 'OutputTrades'
[DIAG] starting sources
[DIAG] starting sinks
```

The in-process test callback saw all events only because the test harness subscribes it before `start()` runs — which is why the failure looked like a sink-side loss.

## Fix

Two changes in `eventflux_app_runtime.rs`:

1. **Attachment no longer starts sources.** Attach only wires and registers; consumption begins solely in the execution phase via `start_all_sources()`. (The eager start also made the later `start_all_sources()` a no-op, and the sink start ordering irrelevant.)
2. **The execution phase starts sinks before sources** (previously sources first). By the time any producer runs, every sink is subscribed and connected. Shutdown already mirrors this (sources stop first, sinks last); `rollback_startup` stops both best-effort with idempotent stops, so both failure paths remain safe.

## Validation

- New deterministic regression test (`tests/startup_ordering.rs`): a source that emits synchronously inside `start()` — the earliest legal moment — must reach the sink. It **fails on the unfixed runtime every run** (no race needed) and passes with the fix.
- Stress: the RabbitMQ integration suite, which reproduced the flake at ~10% per run under parallel load (also 2/20 on unmodified `main`), ran **30/30 clean** with the fix against a live broker.
- Full check suite green: clippy `-D warnings` (minimal + `connectors-all`), 3135/2981 tests, statics.

The separate async-mode drain gap found while mapping this (`ExecutorService::wait_all` is a no-op; `StreamJunction::stop_processing` is never called, so async-junction events queued at shutdown are abandoned) is real but distinct — filed as a follow-up issue.