### PR TITLE
feat: add file connector

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -137,6 +137,7 @@ jobs:
       # Each connector alone (including test code) — catches missing #[cfg]s
       # and accidental cross-feature dependencies.
       run: |
+        cargo check --all-targets --features file
         cargo check --all-targets --features http
         cargo check --all-targets --features kafka
         cargo check --all-targets --features rabbitmq

--- a/.typos.toml
+++ b/.typos.toml
@@ -16,6 +16,9 @@ extend-exclude = [
 WHENs = "WHENs"
 WINDOWs = "WINDOWs"
 
+# The gzip crate is really named flate2
+flate2 = "flate2"
+
 [default.extend-words]
 # HashiCorp proper noun (substring match)
 Hashi = "Hashi"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,8 @@ cargo nextest run --features connectors-all        # or: cargo test --features c
 cargo nextest run                                  # minimal build tests (no connectors)
 cargo test --doc --features connectors-all
 cargo check --all-targets                          # minimal baseline compiles
-cargo check --all-targets --features http          # each connector alone
+cargo check --all-targets --features file          # each connector alone
+cargo check --all-targets --features http
 cargo check --all-targets --features kafka
 cargo check --all-targets --features rabbitmq
 cargo check --all-targets --features websocket

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,11 +32,14 @@ cloud-native = ["kubernetes", "consul", "etcd", "vault"]
 # no connector ships in a plain `cargo build`. Release/Docker builds use
 # `--features connectors-all`. See docs/writing_extensions.md for the
 # per-connector gating checklist.
+# The file connector is std-only (zstd for rolled files is already a root
+# dependency) — the feature exists for the uniform gating convention.
+file = []
 http = ["dep:axum", "dep:ureq"]
 kafka = ["dep:rdkafka"]
 rabbitmq = ["dep:lapin", "dep:urlencoding"]
 websocket = ["dep:tokio-tungstenite"]
-connectors-all = ["http", "kafka", "rabbitmq", "websocket"]
+connectors-all = ["file", "http", "kafka", "rabbitmq", "websocket"]
 
 [dependencies]
 async-trait = "0.1"

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ feature named after its SQL extension name:
 
 | Feature | Connector | In default build? |
 |---------|-----------|-------------------|
+| `file` | File source (replay + follow) + sink (rotation) | No |
 | `http` | HTTP source (polling + webhook) + sink | No |
 | `kafka` | Kafka source + sink (needs cmake to build) | No |
 | `rabbitmq` | RabbitMQ source + sink | No |
@@ -103,7 +104,7 @@ Full docs at **[eventflux.io](https://eventflux.io)**:
 
 - [Getting Started](https://eventflux.io/docs/getting-started/installation) — install and run your first query
 - [SQL Reference](https://eventflux.io/docs/sql-reference/queries) — windows, joins, patterns, aggregations
-- [Connectors](https://eventflux.io/docs/connectors/overview) — Kafka, RabbitMQ, WebSocket, HTTP
+- [Connectors](https://eventflux.io/docs/connectors/overview) — File, HTTP, Kafka, RabbitMQ, WebSocket
 - [Examples](https://eventflux.io/docs/demo/crypto-trading) — real-world use cases
 - [Architecture](https://eventflux.io/docs/architecture/overview) — how it works under the hood
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -165,11 +165,11 @@ All have state holder implementations for checkpointing.
 |------------|-------------|-------------|------------------|------------------|
 | Timer      | Done        | —           | —                | (always built)   |
 | Log        | —           | Done        | —                | (always built)   |
+| File       | Done        | Done        | JSON, CSV, bytes | `file`           |
 | HTTP       | Done        | Done        | JSON, CSV, bytes | `http`           |
 | Kafka      | Done        | Done        | JSON, CSV, bytes | `kafka`          |
 | RabbitMQ   | Done        | Done        | JSON, CSV, bytes | `rabbitmq`       |
 | WebSocket  | Done        | Done        | JSON, CSV, bytes | `websocket`      |
-| File       | Not started | Not started | —                | —                |
 | TCP/Socket | Not started | Not started | —                | —                |
 
 Connectors are cargo features named after the SQL extension name; the default
@@ -364,12 +364,18 @@ client + async axum server — best tool per side. Feature-gated behind `http`; 
 tests are self-hosting (no CI service needed). Deferred: request/response mode (#134),
 batched requests, connector-managed conditional GET, OAuth.
 
-File connector (Priority 3) is the next connector.
+### Priority 3: File Connector — **DONE (2026-07)**
 
-### Priority 3: File Connector
+Implemented per `feat/file/README.md`: an always-following source (replay existing content
+per `file.start.position`, then keep observing — EOF is not completion) with `tail -F`
+rotation/truncation handling and held partial lines, and a line-per-event sink with
+size/time rotation and zstd-compressed rolls. Adds no new dependencies (zstd/chrono are
+already core). Fully self-hosting integration tests (temp files, nothing ignored). Deferred:
+directory spool mode, offset checkpointing (StateHolder follow-up), native FS watching,
+gzip rolls.
 
-- File source: CSV, JSON, tail mode
-- File sink: rotation, compression
+TCP/Socket is the remaining connector; Pattern Processing Gaps (Priority 4) is the next
+priority.
 
 ### Priority 4: Pattern Processing Gaps
 

--- a/docs/writing_extensions.md
+++ b/docs/writing_extensions.md
@@ -168,7 +168,7 @@ When adding a new in-tree connector, touch exactly these points:
 | Registration | `#[cfg(feature = "x")]` on the import and `add_source_factory`/`add_sink_factory` lines in `register_default_extensions()` |
 | Unavailable-extension hint | add the name to `GATED_OUT_EXTENSIONS` in `stream_initializer.rs` so builds without the feature report "rebuild with `--features x`" instead of "extension not found" |
 | Integration tests | `#![cfg(feature = "x")]` at the top of `tests/x_integration.rs` |
-| CI | add `cargo check --features x` to the per-connector gating check in `.github/workflows/rust.yml` |
+| CI | add `cargo check --all-targets --features x` to the per-connector gating checks in `.github/workflows/rust.yml`, `justfile` (`check-minimal`), and the CONTRIBUTING.md command list — all three must stay in sync |
 | Docs | feature-flags table in README.md; example files note the required feature |
 
 ## Dynamic Extensions

--- a/examples/file.eventflux
+++ b/examples/file.eventflux
@@ -1,0 +1,73 @@
+-- ============================================================================
+-- EventFlux File Source/Sink Example
+-- ============================================================================
+--
+-- This example demonstrates end-to-end stream processing over files:
+--   1. File Source: replays an existing JSONL file, then keeps following it
+--   2. EventFlux Query: keeps only high-volume trades
+--   3. File Sink: appends matches to an output JSONL file
+--
+-- Everything is testable with printf/echo/tail alone — no external infrastructure.
+--
+-- ============================================================================
+-- PREREQUISITES
+-- ============================================================================
+--
+-- 0. Build EventFlux with the file connector enabled:
+--
+--    cargo build --release --features file
+--    (Docker images include all connectors already)
+--
+-- 1. Create the input file with some existing trades:
+--
+--    printf '%s\n' \
+--      '{"symbol":"AAPL","price":185.5,"volume":5000}' \
+--      '{"symbol":"GOOGL","price":142.3,"volume":800}' \
+--      > /tmp/trades.jsonl
+--
+-- 2. Run this example:
+--
+--    cargo run --features file --bin run_eventflux examples/file.eventflux
+--
+--    The AAPL trade (volume > 1000) appears in /tmp/high_volume.jsonl
+--    immediately; GOOGL is filtered out.
+--
+-- 3. The source keeps observing — append more trades from another terminal:
+--
+--    echo '{"symbol":"MSFT","price":378.25,"volume":1500}' >> /tmp/trades.jsonl
+--
+-- 4. Watch the output grow:
+--
+--    tail -f /tmp/high_volume.jsonl
+--
+-- ============================================================================
+
+CREATE STREAM Trades (
+    symbol STRING,
+    price DOUBLE,
+    volume INT
+) WITH (
+    type = 'source',
+    extension = 'file',
+    format = 'json',
+    "file.path" = '/tmp/trades.jsonl',
+    -- Replay existing content, then follow appends (this is the default)
+    "file.start.position" = 'beginning',
+    "file.poll.interval.ms" = '200'
+);
+
+CREATE STREAM HighVolume (
+    symbol STRING,
+    price DOUBLE,
+    volume INT
+) WITH (
+    type = 'sink',
+    extension = 'file',
+    format = 'json',
+    "file.path" = '/tmp/high_volume.jsonl'
+);
+
+INSERT INTO HighVolume
+SELECT symbol, price, volume
+FROM Trades
+WHERE volume > 1000;

--- a/feat/file/README.md
+++ b/feat/file/README.md
@@ -1,0 +1,202 @@
+# File Connector — Specification
+
+**Status**: IMPLEMENTED (2026-07) — spec reviewed, single always-following source
+**Priority**: 3 (per ROADMAP)
+**Feature flag**: `file` (no external dependencies)
+**Extension name**: `file` (source and sink)
+
+---
+
+## 1. Overview
+
+The File connector ingests events from a local file and writes processed
+events to local files. It targets the classic operational uses:
+
+- **Replay then follow**: read an existing JSONL or CSV file through a query,
+  then keep delivering lines as other processes append
+  (`file.start.position = 'beginning'`, the default)
+- **Log following**: start at the end of a growing file and follow appends,
+  with rotation/truncation handling (`file.start.position = 'end'`)
+- **Durable output**: append query results to a file with size/time-based
+  rotation and optional compression of rolled files
+
+The source **never finishes**: reaching EOF just means "nothing new yet" —
+it keeps observing the file and delivers whatever any other application
+appends. Everything is long-running and realtime; there is no bounded
+"read once and stop" mode.
+
+Everything is line-delimited in v1: **one line = one event payload** (JSONL
+line, CSV row, or arbitrary bytes per line). This matches the one event = one
+message contract every other connector follows, and both the JSON and CSV
+mappers already consume exactly one record per payload.
+
+## 2. Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Dependencies | **None** — `std::fs` + polling | No `notify`/inotify crate in v1. Polling with an interruptible interval (`sleep_while_running`) is deterministic on every platform, needs no watcher lifecycle, and the config surface stays compatible if a native watcher backend is added later (the poll interval simply becomes its fallback). Known costs, both documented: detection latency ≤ poll interval, and (since the rotated-away file is drained through the still-open fd before switching) only lines a writer appends to the old file after that final drain are missed. |
+| One mode, one knob | No `file.mode`; only `file.start.position` | Since the source always keeps following after EOF, "read" vs "tail" collapses to where to begin. Less surface, no semantics fork. |
+| Framing | Line-delimited (`\n`, `\r\n` tolerated) | One line = one event. Custom delimiters and multi-line records are future additive config. |
+| Rotation detection | Size shrink → reopen from 0; path replacement (new identity: inode on Unix, creation time elsewhere) → reopen from 0 | The `tail -F` contract, detected per poll via `metadata()` — no OS watcher needed. |
+| Offsets across restarts | **Not persisted in v1** | A file has no broker-side offsets; after a restart only `file.start.position` governs: `end` skips lines appended while down, `beginning` re-reads (duplicates downstream). Checkpointed `(file identity, offset)` via StateHolder is the designed follow-up (§9) — no config break. |
+| Rolled-file compression | `zstd` (already a workspace dependency) | Zero new deps. See §9 for when gzip becomes worth adding. |
+| Directory spool mode | **Deferred** | Observing one given file keeps v1 simple (reviewer decision). §9 sketches the forward path; `file.mode` stays reserved for it. |
+| Blocking in `publish()` | Yes (write + flush policy) | Same backpressure-by-design contract as the HTTP/Kafka sinks. |
+
+## 3. Architecture
+
+```text
+source:  SourceWorker thread → poll every interval:
+           metadata check (missing / truncated / replaced → reopen)
+           → read appended complete lines (partial line held)
+           → SourceCallback → mapper → junction
+sink:    Events → per event: SinkMapper → bytes → publish() → BufWriter (+ \n)
+           → flush policy → rotation check (size/time) → roll (+ optional zstd)
+```
+
+Both sides are `std`-only and synchronous. The source embeds a `SourceWorker`
+(interruptible polling, bounded stop, Drop-RAII) exactly like the other
+connectors.
+
+## 4. File Source
+
+### 4.1 Configuration
+
+| Option | Required | Default | Description |
+|--------|----------|---------|-------------|
+| `file.path` | Yes | – | Path of the file to observe |
+| `file.start.position` | No | `beginning` | `beginning` = deliver existing content first, then follow appends; `end` = only lines appended after startup |
+| `file.poll.interval.ms` | No | `500` | How often to check for new data / rotation (interruptible) |
+| `file.skip.lines` | No | `0` | Skip the first N lines (e.g. a CSV header row) — applies whenever reading starts from offset 0 (startup from `beginning`, and every rotation reopen) |
+| `file.require.exists` | No | `false` | `false` = a missing file is awaited (`tail -F` semantics); `true` = fail fast at startup if absent |
+| `error.*` | No | – | Standard error strategies (`drop`/`retry`/`dlq`/`fail`) via `SourceErrorContext` |
+
+### 4.2 Semantics
+
+- Startup: open, seek per `file.start.position` (`beginning` applies
+  `file.skip.lines` first), then poll forever.
+- Each poll delivers any appended **complete** lines. A partial final line
+  (no terminator yet) is held until completed — writers that flush mid-line
+  do not produce split events.
+- **EOF is not completion**: after existing content is consumed, the source
+  idles on the poll interval and delivers whatever other applications append
+  later.
+- **Rotation** (path points to a different file): the renamed-away file's
+  remaining lines are drained through the still-open handle first, then
+  reading switches to the new file from offset 0, re-applying
+  `file.skip.lines`. **Truncation** (same file, size shrank): reopen from
+  offset 0 — the overwritten content is gone by definition.
+- **Missing file**: awaited (unless `file.require.exists = true` failed the
+  start); a file appearing later is not an error, and a file disappearing
+  mid-run returns to the awaiting state.
+- **I/O errors** (permission loss, read failures): routed through the
+  standard `error.*` strategy as connection errors — `retry` gives
+  reconnect-with-backoff behavior. After a transient read error, reading
+  resumes at the last consumed offset (skip budget preserved) rather than
+  replaying the file.
+- Payload bytes are the raw line without the terminator. Empty lines are
+  skipped (consistent with "empty body → nothing to deliver" elsewhere).
+
+### 4.3 Validation (`validate_connectivity`)
+
+Parent directory exists and `file.path` is not a directory; the file
+itself must exist only when `file.require.exists = true` (in which case it
+must also open for reading).
+
+## 5. File Sink
+
+### 5.1 Configuration
+
+| Option | Required | Default | Description |
+|--------|----------|---------|-------------|
+| `file.path` | Yes | – | Output file path (parent directory must exist) |
+| `file.append` | No | `true` | `true` = append to an existing file, `false` = truncate at startup |
+| `file.flush.interval.ms` | No | `0` | `0` = flush after every event (durable, default); N > 0 = flush at most once every N ms, checked per publish — crash-loss bounded in bytes (write buffer), not wall time |
+| `file.rotate.size.bytes` | No | `0` (off) | Roll the file when it reaches this size |
+| `file.rotate.interval.ms` | No | `0` (off) | Roll the file at this age, counted from file open |
+| `file.rotate.compression` | No | `none` | `none` or `zstd` — compress the rolled file (`<name>.zst`), applied in the publishing thread (blocking = backpressure) |
+
+Both rotation triggers may be set; whichever fires first rolls. Rolled files
+are renamed to `<path>.<UTC timestamp>` (e.g. `out.jsonl.20260722T101530Z`,
+with a numeric suffix on collision), then a fresh file is opened at
+`file.path`. Setting `file.rotate.compression` without any rotation trigger
+is rejected at parse time (two sources of truth for "never rolls").
+
+### 5.2 Semantics
+
+- One event = one line: payload bytes + `\n`. The mapper produces the payload
+  (JSON object, CSV row, raw bytes); the sink adds only the terminator.
+- `publish()` returns after the write (and flush, under the default policy)
+  succeeds — a returned `Ok` means the bytes reached the OS. Write errors are
+  returned to the pipeline as connection errors.
+- Rotation check runs inside `publish()` after the write, so a line is never
+  split across files.
+- `stop()` flushes and closes; the summary log reports written/failed/rolled counts
+  (same shape as the other sinks).
+
+### 5.3 Validation
+
+Parent directory exists and is writable (probe: open the file in append mode
+and close — creates it if absent, which matches append semantics).
+
+## 6. Delivery Guarantees
+
+- **Source**: at-least-once *within a run*. No offsets are persisted; a
+  restart obeys `file.start.position` (`end` may skip lines written while
+  down, `beginning` re-reads — both documented). Checkpointed offsets are
+  the designed follow-up (§9).
+- **Sink**: an event is durably in the file (through the OS) before
+  `publish()` returns under the default flush policy; `file.flush.interval.ms > 0`
+  trades a bounded loss window for throughput.
+
+## 7. Feature Gating
+
+Standard checklist (docs/writing_extensions.md):
+
+- `[features] file = []` — no optional deps (zstd is already a root
+  dependency); added to `connectors-all`
+- `#[cfg(feature = "file")]` module declarations + registrations
+- `GATED_OUT_EXTENSIONS` entry
+- `#![cfg(feature = "file")]` on `tests/file_integration.rs`
+- `cargo check --all-targets --features file` in CI, justfile, CONTRIBUTING
+
+## 8. Testing Plan
+
+Fully self-hosting via `tempfile` (already a dev-dependency) — nothing
+`#[ignore]`d, no external services:
+
+- **Unit (config)**: defaults, invalid `file.start.position`,
+  compression-without-rotation rejected, skip-lines / flush / rotation
+  parsing, validation failures (missing dir; `require.exists` with missing
+  file)
+- **Source**: existing JSONL and CSV content delivered from `beginning`
+  (with `file.skip.lines = 1`); **EOF-then-append: content consumed, then an
+  external append is delivered on the next poll** (the review scenario);
+  `end` delivers only appends; partial line held until terminated;
+  truncation reopen; rename-over rotation reopen; missing file appears
+  later; prompt stop during a long poll interval
+- **Sink**: append vs truncate; one line per event; flush-per-event
+  durability; size rotation (rolled name format, fresh file continues); time
+  rotation; zstd-compressed roll (decode and assert content)
+- **Round trip**: file sink → file source through the direct connector API
+  (the self-hosting analogue of the HTTP round trip)
+- **E2E**: SQL app reading JSONL, filtering, writing JSONL out (CSV framing
+  is covered by the skip-header source test)
+- **Regression pins** from the audit rounds: rotated-file tail salvage,
+  oversized-line drop/resync, truncate-mode reopen never wipes, same-second
+  zstd rolls never collide
+
+Plus `examples/file.eventflux`: replay a JSONL file of trades → filter →
+JSONL output, verifiable with `printf`, `echo >>`, and `tail -f` alone.
+
+## 9. Deferred / Forward-Compatibility Notes
+
+| Feature | Forward path |
+|---------|--------------|
+| Directory spool mode (process files appearing in a dir; move/delete after processing) | Reserved `file.mode = 'dir'` (unknown keys today produce no silent behavior); config keys would be additive (`file.dir.uri`, `file.action.after.process`) |
+| Offset checkpointing across restarts | `StateHolder` integration: persist `(file identity, offset)`; activates via the existing checkpoint machinery, no config change needed (`file.start.position` becomes the no-checkpoint fallback) |
+| Native FS watching (inotify/FSEvents via `notify`) | Backend swap behind the same config; `file.poll.interval.ms` becomes the fallback for platforms/filesystems without native events |
+| gzip rolled files | Additive `file.rotate.compression = 'gzip'` value (`flat2` dep at that point). Needed when rolled files must interop with the gzip ecosystem: stock `zcat`/`gzip` on machines without zstd, logrotate-style tooling, log shippers and S3/data-lake ingestion pipelines that auto-detect only `.gz`. Until a consumer like that exists, zstd is strictly better (faster, smaller). |
+| Custom delimiters / multi-line records | Additive `file.delimiter` / framing config |
+| Max line length guard | v1 ships a fixed 8 MiB safety cap (oversized lines dropped, reading resyncs at the next terminator); a configurable `file.max.line.bytes` is additive |
+| Writing to a file being tailed by the same app | Works (sink flushes complete lines; source holds partial lines) — exercised by the round-trip test |

--- a/feat/kafka/README.md
+++ b/feat/kafka/README.md
@@ -82,9 +82,9 @@ pipeline via `SourceCallback`.
 | `kafka.rdkafka.<prop>` | No | - | Escape hatch: passed verbatim to librdkafka (e.g. `kafka.rdkafka.fetch.min.bytes`). Same pattern as Flink's `properties.*` |
 | `error.strategy` | No | - | Error handling strategy (drop, retry, dlq, fail) |
 | `error.retry.max-attempts` | No | 3 | Max retry attempts |
-| `error.retry.initial-delay-ms` | No | 100 | Initial retry delay in ms |
-| `error.retry.max-delay-ms` | No | 10000 | Max retry delay in ms |
-| `error.retry.backoff-multiplier` | No | 2.0 | Backoff multiplier |
+| `error.retry.backoff` | No | exponential | Backoff strategy: exponential/linear/fixed |
+| `error.retry.initial-delay` | No | 100ms | Initial retry delay (duration string) |
+| `error.retry.max-delay` | No | 30s | Max retry delay (duration string) |
 | `error.dlq.stream` | No | - | DLQ stream name (required when strategy=dlq) |
 
 Reserved keys (`bootstrap.servers`, `group.id`, offset/commit settings) may not be overridden via

--- a/feat/rabbitmq/README.md
+++ b/feat/rabbitmq/README.md
@@ -51,9 +51,9 @@ Consumes messages from a RabbitMQ queue and delivers them to the EventFlux pipel
 | `rabbitmq.auto.ack` | No | true | Auto-acknowledge messages |
 | `error.strategy` | No | - | Error handling strategy (drop, retry, dlq, fail) |
 | `error.retry.max-attempts` | No | 3 | Max retry attempts |
-| `error.retry.initial-delay-ms` | No | 100 | Initial retry delay in ms |
-| `error.retry.max-delay-ms` | No | 10000 | Max retry delay in ms |
-| `error.retry.backoff-multiplier` | No | 2.0 | Backoff multiplier |
+| `error.retry.backoff` | No | exponential | Backoff strategy: exponential/linear/fixed |
+| `error.retry.initial-delay` | No | 100ms | Initial retry delay (duration string) |
+| `error.retry.max-delay` | No | 30s | Max retry delay (duration string) |
 | `error.dlq.stream` | No | - | DLQ stream name (required when strategy=dlq) |
 
 ### Usage Example

--- a/justfile
+++ b/justfile
@@ -33,6 +33,7 @@ lint:
 # Feature-gating honesty: minimal build and each connector alone must compile
 check-minimal:
   cargo check --all-targets
+  cargo check --all-targets --features file
   cargo check --all-targets --features http
   cargo check --all-targets --features kafka
   cargo check --all-targets --features rabbitmq

--- a/src/core/config/eventflux_context.rs
+++ b/src/core/config/eventflux_context.rs
@@ -426,6 +426,8 @@ impl EventFluxContext {
             OrAttributeAggregatorFactory, StdDevAttributeAggregatorFactory,
             SumAttributeAggregatorFactory,
         };
+        #[cfg(feature = "file")]
+        use crate::core::stream::input::source::file_source::FileSourceFactory;
         #[cfg(feature = "http")]
         use crate::core::stream::input::source::http_source::HttpSourceFactory;
         #[cfg(feature = "kafka")]
@@ -434,6 +436,8 @@ impl EventFluxContext {
         use crate::core::stream::input::source::rabbitmq_source::RabbitMQSourceFactory;
         #[cfg(feature = "websocket")]
         use crate::core::stream::input::source::websocket_source::WebSocketSourceFactory;
+        #[cfg(feature = "file")]
+        use crate::core::stream::output::sink::file_sink::FileSinkFactory;
         #[cfg(feature = "http")]
         use crate::core::stream::output::sink::http_sink::HttpSinkFactory;
         #[cfg(feature = "kafka")]
@@ -536,6 +540,8 @@ impl EventFluxContext {
         self.add_table_factory("jdbc".to_string(), Box::new(JdbcTableFactory));
         self.add_table_factory("cache".to_string(), Box::new(CacheTableFactory));
         self.add_source_factory("timer".to_string(), Box::new(TimerSourceFactory));
+        #[cfg(feature = "file")]
+        self.add_source_factory("file".to_string(), Box::new(FileSourceFactory));
         #[cfg(feature = "http")]
         self.add_source_factory("http".to_string(), Box::new(HttpSourceFactory));
         #[cfg(feature = "kafka")]
@@ -545,6 +551,8 @@ impl EventFluxContext {
         #[cfg(feature = "websocket")]
         self.add_source_factory("websocket".to_string(), Box::new(WebSocketSourceFactory));
         self.add_sink_factory("log".to_string(), Box::new(LogSinkFactory));
+        #[cfg(feature = "file")]
+        self.add_sink_factory("file".to_string(), Box::new(FileSinkFactory));
         #[cfg(feature = "http")]
         self.add_sink_factory("http".to_string(), Box::new(HttpSinkFactory));
         #[cfg(feature = "kafka")]

--- a/src/core/error/source_support.rs
+++ b/src/core/error/source_support.rs
@@ -63,6 +63,26 @@ use crate::core::config::FlatConfig;
 use crate::core::error::ErrorConfig;
 use crate::core::event::Event;
 use crate::core::exception::EventFluxError;
+
+/// Optional configuration keys consumed by
+/// [`SourceErrorContext::from_properties`] (via `ErrorConfig`). Source
+/// factories append these to their `optional_parameters()` list, so the
+/// error-handling surface is defined in exactly one place.
+///
+/// Delays are duration strings (`100ms`, `30s`); `error.retry.backoff` is a
+/// strategy name (`exponential`/`linear`/`fixed`). The DLQ fallback retry
+/// family (`error.dlq.fallback-retry.*`) is a prefix, represented here by
+/// its strategy key.
+pub const SOURCE_ERROR_PARAMETERS: &[&str] = &[
+    "error.strategy",
+    "error.log-level",
+    "error.retry.max-attempts",
+    "error.retry.backoff",
+    "error.retry.initial-delay",
+    "error.retry.max-delay",
+    "error.dlq.stream",
+    "error.dlq.fallback-strategy",
+];
 use crate::core::stream::input::input_handler::InputHandler;
 use std::sync::{Arc, Mutex};
 use std::thread;

--- a/src/core/stream/connector_util.rs
+++ b/src/core/stream/connector_util.rs
@@ -27,6 +27,17 @@ use std::str::FromStr;
 /// accept it from user configuration under another meaning.
 pub const INJECTED_FORMAT_KEY: &str = "_format";
 
+/// Fetch a required property, rejecting missing or blank values.
+pub fn parse_required(properties: &HashMap<String, String>, key: &str) -> Result<String, String> {
+    let value = properties
+        .get(key)
+        .ok_or_else(|| format!("Missing required property: {key}"))?;
+    if value.trim().is_empty() {
+        return Err(format!("{key} cannot be empty"));
+    }
+    Ok(value.clone())
+}
+
 /// Parse an optional property, falling back to `default` when absent.
 pub fn parse_or<T: FromStr>(
     properties: &HashMap<String, String>,
@@ -75,6 +86,20 @@ mod tests {
         assert!(parse_or(&props, "k", 5u64)
             .unwrap_err()
             .contains("Invalid k"));
+    }
+
+    #[test]
+    fn test_parse_required() {
+        let mut props = HashMap::new();
+        assert!(parse_required(&props, "k")
+            .unwrap_err()
+            .contains("Missing required property: k"));
+
+        props.insert("k".to_string(), "  ".to_string());
+        assert!(parse_required(&props, "k").unwrap_err().contains("empty"));
+
+        props.insert("k".to_string(), "v".to_string());
+        assert_eq!(parse_required(&props, "k").unwrap(), "v");
     }
 
     #[test]

--- a/src/core/stream/input/source/file_source.rs
+++ b/src/core/stream/input/source/file_source.rs
@@ -1,0 +1,893 @@
+/*
+ * Copyright 2025-2026 EventFlux.io
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! # File Source
+//!
+//! Observes one file and delivers each complete line as one payload. The
+//! source never finishes: reaching EOF only means "nothing new yet" — it
+//! keeps polling and delivers whatever other applications append later.
+//!
+//! ## Architecture
+//!
+//! ```text
+//! SourceWorker thread → poll every interval:
+//!   metadata check (missing / truncated / replaced → reopen)
+//!   → read appended complete lines (partial final line held)
+//!   → SourceCallback → mapper → junction
+//! ```
+//!
+//! Rotation handling follows the `tail -F` contract: when the path points
+//! at a different file (new device/inode, or creation time elsewhere), the
+//! renamed-away file's remaining lines are first drained through the
+//! still-open handle, then reading reopens from offset 0 and re-applies
+//! `file.skip.lines`; a size shrink (truncation) reopens without salvage. A
+//! missing file is awaited, not an error. Transient read errors resume at
+//! the last consumed offset instead of replaying, and an unterminated line
+//! beyond an 8 MiB safety cap is dropped with a resync at the next
+//! terminator.
+
+use super::{sleep_while_running, Source, SourceCallback, SourceWorker};
+use crate::core::error::source_support::{
+    deliver_with_error_handling, DeliveryVerdict, SourceErrorContext,
+};
+use crate::core::exception::EventFluxError;
+use crate::core::extension::SourceFactory;
+use crate::core::stream::connector_util::parse_or;
+use crate::core::stream::input::input_handler::InputHandler;
+use std::collections::HashMap;
+use std::fmt::Debug;
+use std::fs::{File, Metadata};
+use std::io::{Read, Seek, SeekFrom};
+use std::path::PathBuf;
+use std::sync::atomic::Ordering;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+/// Where to begin on the initially-present file
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StartPosition {
+    /// Deliver existing content first, then follow appends (default)
+    Beginning,
+    /// Only lines appended after startup
+    End,
+}
+
+/// File source configuration
+#[derive(Debug, Clone)]
+pub struct FileSourceConfig {
+    /// Path of the file to observe
+    pub path: PathBuf,
+    /// Where to begin on the initially-present file
+    pub start_position: StartPosition,
+    /// Poll cadence (interruptible; default 500)
+    pub poll_interval_ms: u64,
+    /// Lines to skip whenever reading starts from offset 0 (e.g. CSV header)
+    pub skip_lines: u64,
+    /// Fail fast at startup when the file is absent (default: await it)
+    pub require_exists: bool,
+}
+
+impl FileSourceConfig {
+    /// Parse configuration from properties HashMap
+    pub fn from_properties(properties: &HashMap<String, String>) -> Result<Self, String> {
+        let path = crate::core::stream::connector_util::parse_required(properties, "file.path")?;
+
+        let start_position = match properties
+            .get("file.start.position")
+            .map(String::as_str)
+            .unwrap_or("beginning")
+        {
+            "beginning" => StartPosition::Beginning,
+            "end" => StartPosition::End,
+            other => {
+                return Err(format!(
+                    "Invalid file.start.position '{other}': expected 'beginning' or 'end'"
+                ))
+            }
+        };
+
+        Ok(Self {
+            path: PathBuf::from(&path),
+            start_position,
+            poll_interval_ms: parse_or(properties, "file.poll.interval.ms", 500)?,
+            skip_lines: parse_or(properties, "file.skip.lines", 0)?,
+            require_exists: parse_or(properties, "file.require.exists", false)?,
+        })
+    }
+}
+
+/// Identity of the file behind a path, used to detect rename-over rotation.
+/// Inode on Unix; creation time elsewhere (best effort).
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct FileIdentity {
+    #[cfg(unix)]
+    dev: u64,
+    #[cfg(unix)]
+    ino: u64,
+    #[cfg(not(unix))]
+    created: Option<std::time::SystemTime>,
+}
+
+impl FileIdentity {
+    fn of(meta: &Metadata) -> Self {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::MetadataExt;
+            Self {
+                dev: meta.dev(),
+                ino: meta.ino(),
+            }
+        }
+        #[cfg(not(unix))]
+        {
+            Self {
+                created: meta.created().ok(),
+            }
+        }
+    }
+}
+
+/// Open file being followed, with read progress and the held partial line
+struct TailReader {
+    file: File,
+    identity: FileIdentity,
+    /// Bytes consumed from the file so far (including any held partial line).
+    /// The OS cursor stays in lockstep: the only seek happens at open, and a
+    /// read error discards the whole reader.
+    offset: u64,
+    /// Bytes after the last `\n` — held until the line is terminated
+    partial: Vec<u8>,
+    /// Set when `partial` blew past [`MAX_HELD_LINE_BYTES`]: the oversized
+    /// line's remainder is discarded until the next terminator resyncs
+    discarding: bool,
+    /// Remaining `file.skip.lines` budget for this open-from-zero
+    lines_to_skip: u64,
+    /// Reusable read buffer (allocated once per open)
+    buf: Box<[u8]>,
+}
+
+/// Safety cap on a held unterminated line (a delimiter-less file — e.g. a
+/// binary pointed at by mistake — must not accrete into memory without
+/// bound). The oversized line is dropped and reading resyncs at the next
+/// terminator. A configurable `file.max.line.bytes` is a planned follow-up.
+const MAX_HELD_LINE_BYTES: usize = 8 * 1024 * 1024;
+
+/// Running totals for the shutdown summary log
+#[derive(Default)]
+struct DeliveryStats {
+    delivered: u64,
+    failed: u64,
+}
+
+/// File source observing a single file (see module docs)
+#[derive(Debug)]
+pub struct FileSource {
+    config: FileSourceConfig,
+    worker: SourceWorker,
+    error_ctx: Option<SourceErrorContext>,
+}
+
+impl Clone for FileSource {
+    fn clone(&self) -> Self {
+        Self {
+            config: self.config.clone(),
+            worker: self.worker.clone(), // Clones as a fresh, unstarted worker
+            error_ctx: None,             // Error context contains runtime state, not cloneable
+        }
+    }
+}
+
+impl FileSource {
+    pub fn new(config: FileSourceConfig) -> Self {
+        Self {
+            config,
+            worker: SourceWorker::new("FileSource"),
+            error_ctx: None,
+        }
+    }
+
+    /// Create a file source from properties
+    ///
+    /// # Required Properties
+    /// - `file.path`
+    ///
+    /// # Optional Properties
+    /// - `file.start.position`, `file.poll.interval.ms`, `file.skip.lines`,
+    ///   `file.require.exists`
+    /// - `error.*`: Error handling properties (see SourceErrorContext)
+    pub fn from_properties(
+        properties: &HashMap<String, String>,
+        dlq_junction: Option<Arc<Mutex<InputHandler>>>,
+        stream_name: &str,
+    ) -> Result<Self, String> {
+        let config = FileSourceConfig::from_properties(properties)?;
+        let error_ctx = SourceErrorContext::from_properties(properties, dlq_junction, stream_name)?;
+
+        Ok(Self {
+            error_ctx,
+            ..Self::new(config)
+        })
+    }
+}
+
+/// A continuation point stashed when a read error drops the reader: the
+/// file's identity, the offset of the first unconsumed byte (held partial
+/// excluded, so no line gets truncated), and the unspent skip budget.
+type ResumeMarker = (FileIdentity, u64, u64);
+
+/// Open the file and position per the rules: `at_end` seeks to the current
+/// end (initial `start.position = 'end'` only); a `resume` marker matching
+/// the opened file continues after a transient read error — at its offset,
+/// with its remaining skip budget — instead of replaying from 0; otherwise
+/// offset 0 with the full skip-lines budget.
+///
+/// Identity is taken from the OPENED handle's metadata, so it can never
+/// diverge from the file actually being read (no path-vs-handle race).
+fn open_reader(
+    path: &std::path::Path,
+    at_end: bool,
+    skip_lines: u64,
+    resume: Option<ResumeMarker>,
+) -> std::io::Result<TailReader> {
+    let mut file = File::open(path)?;
+    let meta = file.metadata()?;
+    let identity = FileIdentity::of(&meta);
+
+    let (offset, lines_to_skip) = if at_end {
+        (file.seek(SeekFrom::End(0))?, 0)
+    } else {
+        match resume {
+            // Same file as before the error — continue where reading left
+            // off with the skip budget that was still unspent there
+            Some((resume_identity, resume_offset, resume_skip))
+                if resume_identity == identity && resume_offset <= meta.len() =>
+            {
+                (file.seek(SeekFrom::Start(resume_offset))?, resume_skip)
+            }
+            _ => (0, skip_lines),
+        }
+    };
+
+    Ok(TailReader {
+        file,
+        identity,
+        offset,
+        partial: Vec::new(),
+        discarding: false,
+        lines_to_skip,
+        buf: vec![0u8; 64 * 1024].into_boxed_slice(),
+    })
+}
+
+/// Deliver one complete line (skip-lines budget and empty lines are handled
+/// here). `Break` means an unrecoverable delivery failure.
+fn handle_line(
+    line: &[u8],
+    lines_to_skip: &mut u64,
+    callback: &dyn SourceCallback,
+    error_ctx: &mut Option<SourceErrorContext>,
+    stats: &mut DeliveryStats,
+) -> std::ops::ControlFlow<()> {
+    if *lines_to_skip > 0 {
+        *lines_to_skip -= 1;
+        return std::ops::ControlFlow::Continue(());
+    }
+    if line.is_empty() {
+        return std::ops::ControlFlow::Continue(()); // nothing to deliver
+    }
+
+    match deliver_with_error_handling(callback, line, error_ctx, "FileSource") {
+        DeliveryVerdict::Delivered => stats.delivered += 1,
+        DeliveryVerdict::Disposed => stats.failed += 1,
+        DeliveryVerdict::Fail => {
+            stats.failed += 1;
+            log::error!("[FileSource] Unrecoverable error, stopping");
+            return std::ops::ControlFlow::Break(());
+        }
+    }
+    std::ops::ControlFlow::Continue(())
+}
+
+/// Read newly appended bytes and deliver each complete line zero-copy.
+///
+/// Complete lines inside a read chunk are delivered as slices of the reused
+/// buffer; only a fragment spanning chunk boundaries touches the `partial`
+/// buffer. `Break` propagates an unrecoverable delivery failure.
+fn drain_new_lines(
+    reader: &mut TailReader,
+    running: &std::sync::atomic::AtomicBool,
+    callback: &dyn SourceCallback,
+    error_ctx: &mut Option<SourceErrorContext>,
+    stats: &mut DeliveryStats,
+) -> std::io::Result<std::ops::ControlFlow<()>> {
+    // The chunk loop checks `running` so stop() stays bounded even while
+    // draining a multi-GB backlog — the worker must never outlive its
+    // grace period mid-drain
+    while running.load(Ordering::SeqCst) {
+        let read = reader.file.read(&mut reader.buf)?;
+        if read == 0 {
+            break;
+        }
+        reader.offset += read as u64;
+
+        let mut start = 0;
+        while let Some(pos) = reader.buf[start..read].iter().position(|b| *b == b'\n') {
+            let end = start + pos;
+            let flow = if reader.discarding {
+                // Remainder of an oversized dropped line — this terminator
+                // resyncs reading onto real line boundaries. The dropped
+                // line still counts against the skip budget: skipping the
+                // wrong (real) line later would be worse.
+                reader.discarding = false;
+                reader.partial.clear();
+                reader.lines_to_skip = reader.lines_to_skip.saturating_sub(1);
+                std::ops::ControlFlow::Continue(())
+            } else if reader.partial.is_empty() {
+                // Whole line inside the chunk — deliver without copying
+                let mut line = &reader.buf[start..end];
+                if line.last() == Some(&b'\r') {
+                    line = &line[..line.len() - 1];
+                }
+                handle_line(line, &mut reader.lines_to_skip, callback, error_ctx, stats)
+            } else {
+                // This chunk completes the held fragment
+                reader.partial.extend_from_slice(&reader.buf[start..end]);
+                if reader.partial.last() == Some(&b'\r') {
+                    reader.partial.pop();
+                }
+                let flow = handle_line(
+                    &reader.partial,
+                    &mut reader.lines_to_skip,
+                    callback,
+                    error_ctx,
+                    stats,
+                );
+                reader.partial.clear();
+                flow
+            };
+            if flow.is_break() {
+                return Ok(std::ops::ControlFlow::Break(()));
+            }
+            start = end + 1;
+        }
+
+        // Unterminated tail (usually empty) — hold until completed, bounded
+        // by the safety cap; beyond it the line is dropped and reading
+        // resyncs at the next terminator
+        if !reader.discarding {
+            reader.partial.extend_from_slice(&reader.buf[start..read]);
+            if reader.partial.len() > MAX_HELD_LINE_BYTES {
+                log::warn!(
+                    "[FileSource] Dropping unterminated line exceeding {MAX_HELD_LINE_BYTES} \
+                     bytes — resyncing at the next line terminator"
+                );
+                reader.partial = Vec::new(); // also releases the capacity
+                reader.discarding = true;
+            }
+        }
+    }
+    Ok(std::ops::ControlFlow::Continue(()))
+}
+
+/// Best-effort final drain of a file that went away (unlinked, rotated, or
+/// replaced by a directory): the open fd still reads to EOF. `Break` means
+/// an unrecoverable delivery failure; read errors forfeit only the
+/// remaining tail and are logged.
+fn salvage_tail(
+    old: &mut TailReader,
+    what: &str,
+    path: &std::path::Path,
+    running: &std::sync::atomic::AtomicBool,
+    callback: &dyn SourceCallback,
+    error_ctx: &mut Option<SourceErrorContext>,
+    stats: &mut DeliveryStats,
+) -> std::ops::ControlFlow<()> {
+    match drain_new_lines(old, running, callback, error_ctx, stats) {
+        Ok(flow) => flow,
+        Err(e) => {
+            log::warn!(
+                "[FileSource] Salvage read of the {what} '{}' failed — its \
+                 remaining tail is lost: {e}",
+                path.display()
+            );
+            std::ops::ControlFlow::Continue(())
+        }
+    }
+}
+
+impl Source for FileSource {
+    fn start(&mut self, callback: Arc<dyn SourceCallback>) {
+        let config = self.config.clone();
+        let mut error_ctx = self.error_ctx.take();
+
+        self.worker.start(move |running| {
+            let interval = Duration::from_millis(config.poll_interval_ms);
+            let mut reader: Option<TailReader> = None;
+            // start.position applies only to the file present at startup; a
+            // file that appears later is new and reads from the beginning
+            let mut initial = true;
+            // Set on a transient read error so the reopen continues at the
+            // last consumed offset instead of replaying the whole file
+            let mut resume: Option<ResumeMarker> = None;
+            let mut stats = DeliveryStats::default();
+
+            log::info!(
+                "[FileSource] Observing '{}' every {}ms",
+                config.path.display(),
+                config.poll_interval_ms
+            );
+
+            'poll: while running.load(Ordering::SeqCst) {
+                let mut io_error: Option<std::io::Error> = None;
+
+                match std::fs::metadata(&config.path) {
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                        // Missing is awaited, not an error (tail -F). The
+                        // unlinked file stays readable through the open fd —
+                        // salvage its last lines before letting it go
+                        if let Some(mut old) = reader.take() {
+                            log::info!(
+                                "[FileSource] '{}' disappeared — awaiting recreation",
+                                config.path.display()
+                            );
+                            if salvage_tail(
+                                &mut old,
+                                "removed",
+                                &config.path,
+                                &running,
+                                callback.as_ref(),
+                                &mut error_ctx,
+                                &mut stats,
+                            )
+                            .is_break()
+                            {
+                                break 'poll;
+                            }
+                        }
+                        initial = false;
+                    }
+                    Err(e) => {
+                        // A real stat failure (EACCES, EIO, …) — keep the
+                        // reader (the open fd may be fine) and `initial`
+                        // (nothing about the file was decided), and route
+                        // the error through the strategy like open errors
+                        io_error = Some(e);
+                    }
+                    Ok(meta) if meta.is_dir() => {
+                        // A directory can never become the startup file —
+                        // whatever real file appears later is new. The
+                        // previously-followed file (if any) was replaced;
+                        // its tail is still readable through the open fd.
+                        if let Some(mut old) = reader.take() {
+                            if salvage_tail(
+                                &mut old,
+                                "replaced",
+                                &config.path,
+                                &running,
+                                callback.as_ref(),
+                                &mut error_ctx,
+                                &mut stats,
+                            )
+                            .is_break()
+                            {
+                                break 'poll;
+                            }
+                        }
+                        initial = false;
+                        io_error = Some(std::io::Error::new(
+                            std::io::ErrorKind::InvalidInput,
+                            "path is a directory, not a file",
+                        ));
+                    }
+                    Ok(meta) => {
+                        let identity = FileIdentity::of(&meta);
+                        let rotated =
+                            matches!(&reader, Some(r) if r.identity != identity);
+                        let truncated =
+                            matches!(&reader, Some(r) if r.identity == identity && meta.len() < r.offset);
+
+                        if rotated {
+                            log::info!(
+                                "[FileSource] '{}' was rotated — reopening",
+                                config.path.display()
+                            );
+                            // The renamed-away file is still readable through
+                            // the old fd — deliver its tail before switching
+                            // (the tail -F contract)
+                            if let Some(mut old) = reader.take() {
+                                if salvage_tail(
+                                    &mut old,
+                                    "rotated-away",
+                                    &config.path,
+                                    &running,
+                                    callback.as_ref(),
+                                    &mut error_ctx,
+                                    &mut stats,
+                                )
+                                .is_break()
+                                {
+                                    break 'poll;
+                                }
+                            }
+                        } else if truncated {
+                            log::info!(
+                                "[FileSource] '{}' was truncated — reopening",
+                                config.path.display()
+                            );
+                            // Same file object — the overwritten content is
+                            // gone; nothing to salvage
+                            reader = None;
+                        }
+
+                        if reader.is_none() {
+                            let at_end = initial && config.start_position == StartPosition::End;
+                            // `resume` is only cleared on a successful open —
+                            // a transient open failure must not burn the
+                            // marker and force a replay later
+                            match open_reader(&config.path, at_end, config.skip_lines, resume) {
+                                Ok(r) => {
+                                    reader = Some(r);
+                                    resume = None;
+                                    initial = false;
+                                }
+                                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                                    // Lost a race with an rm/rename between
+                                    // the metadata check and the open — back
+                                    // to awaiting, not an error
+                                    initial = false;
+                                }
+                                Err(e) => {
+                                    // Transient (e.g. EACCES): keep `initial`
+                                    // so start.position=end still holds once
+                                    // the file finally opens
+                                    io_error = Some(e);
+                                }
+                            }
+                        } else {
+                            initial = false;
+                        }
+
+                        // Only read when there are new bytes — idle polls
+                        // stay syscall-free after the metadata check. (An
+                        // identity mismatch means the handle is newer than
+                        // the path metadata — drain it regardless.)
+                        if let Some(r) = &mut reader {
+                            if meta.len() > r.offset || r.identity != identity {
+                                match drain_new_lines(
+                                    r,
+                                    &running,
+                                    callback.as_ref(),
+                                    &mut error_ctx,
+                                    &mut stats,
+                                ) {
+                                    Ok(std::ops::ControlFlow::Continue(())) => {}
+                                    Ok(std::ops::ControlFlow::Break(())) => break 'poll,
+                                    Err(e) => {
+                                        // Stash where reading stopped (held
+                                        // partial excluded, so no line gets
+                                        // truncated): if the same file is
+                                        // still there at reopen, reading
+                                        // resumes instead of replaying. A
+                                        // mid-discard reader gets no marker —
+                                        // the fresh replay re-hits the cap
+                                        // and resyncs the same way.
+                                        if let Some(r) = reader.take() {
+                                            if !r.discarding {
+                                                resume = Some((
+                                                    r.identity,
+                                                    r.offset - r.partial.len() as u64,
+                                                    r.lines_to_skip,
+                                                ));
+                                            }
+                                        }
+                                        io_error = Some(e);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                if let Some(e) = io_error {
+                    let err = EventFluxError::ConnectionUnavailable {
+                        message: format!("File '{}' read failed: {e}", config.path.display()),
+                        source: Some(Box::new(e)),
+                    };
+                    if let Some(ctx) = &mut error_ctx {
+                        if !ctx.handle_error(None, &err) {
+                            break 'poll;
+                        }
+                    } else {
+                        log::error!("[FileSource] {err}");
+                    }
+                }
+
+                // Interruptible: a long interval never delays stop()
+                sleep_while_running(&running, interval);
+            }
+
+            log::info!(
+                "[FileSource] Stopped (delivered: {}, failed: {})",
+                stats.delivered,
+                stats.failed
+            );
+        });
+    }
+
+    fn stop(&mut self) {
+        log::info!("[FileSource] Stopping...");
+        self.worker.stop();
+    }
+
+    fn clone_box(&self) -> Box<dyn Source> {
+        Box::new(self.clone())
+    }
+
+    fn set_error_dlq_junction(&mut self, junction: Arc<Mutex<InputHandler>>) {
+        if let Some(ref mut ctx) = self.error_ctx {
+            ctx.set_dlq_junction(junction);
+        }
+    }
+
+    fn validate_connectivity(&self) -> Result<(), EventFluxError> {
+        if self.config.path.is_dir() {
+            return Err(EventFluxError::ConnectionUnavailable {
+                message: format!(
+                    "file.path '{}' is a directory, not a file",
+                    self.config.path.display()
+                ),
+                source: None,
+            });
+        }
+
+        let parent = self
+            .config
+            .path
+            .parent()
+            .filter(|p| !p.as_os_str().is_empty());
+        if let Some(parent) = parent {
+            if !parent.is_dir() {
+                return Err(EventFluxError::ConnectionUnavailable {
+                    message: format!(
+                        "Parent directory '{}' of file.path does not exist",
+                        parent.display()
+                    ),
+                    source: None,
+                });
+            }
+        }
+
+        if self.config.require_exists {
+            File::open(&self.config.path).map(|_| ()).map_err(|e| {
+                EventFluxError::ConnectionUnavailable {
+                    message: format!(
+                        "file.require.exists is set but '{}' cannot be opened: {e}",
+                        self.config.path.display()
+                    ),
+                    source: Some(Box::new(e)),
+                }
+            })?;
+        }
+
+        Ok(())
+    }
+}
+
+// ============================================================================
+// File Source Factory
+// ============================================================================
+
+/// Factory for creating file source instances.
+///
+/// This factory is registered with EventFluxContext and used to create
+/// file sources from SQL WITH clause configuration.
+#[derive(Debug, Clone)]
+pub struct FileSourceFactory;
+
+impl SourceFactory for FileSourceFactory {
+    fn name(&self) -> &'static str {
+        "file"
+    }
+
+    fn supported_formats(&self) -> &[&str] {
+        &["json", "csv", "bytes"]
+    }
+
+    fn required_parameters(&self) -> &[&str] {
+        &["file.path"]
+    }
+
+    fn optional_parameters(&self) -> &[&str] {
+        // Connector keys + the shared error-handling keys (owned by
+        // SourceErrorContext) — concatenated once, on first use
+        static PARAMS: std::sync::LazyLock<Vec<&'static str>> = std::sync::LazyLock::new(|| {
+            [
+                &[
+                    "file.start.position",
+                    "file.poll.interval.ms",
+                    "file.skip.lines",
+                    "file.require.exists",
+                ][..],
+                crate::core::error::source_support::SOURCE_ERROR_PARAMETERS,
+            ]
+            .concat()
+        });
+        &PARAMS
+    }
+
+    fn create_initialized(
+        &self,
+        config: &HashMap<String, String>,
+    ) -> Result<Box<dyn Source>, EventFluxError> {
+        // DLQ junction is None initially — stream_initializer calls
+        // set_error_dlq_junction() after creation. The path identifies the
+        // stream in error-context log messages.
+        let stream_tag = config.get("file.path").cloned().unwrap_or_default();
+        FileSource::from_properties(config, None, &stream_tag)
+            .map(|source| Box::new(source) as Box<dyn Source>)
+            .map_err(EventFluxError::configuration)
+    }
+
+    fn clone_box(&self) -> Box<dyn SourceFactory> {
+        Box::new(self.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base_props() -> HashMap<String, String> {
+        let mut props = HashMap::new();
+        props.insert("file.path".to_string(), "/tmp/test-input.jsonl".to_string());
+        props
+    }
+
+    #[test]
+    fn test_config_defaults() {
+        let config = FileSourceConfig::from_properties(&base_props()).unwrap();
+        assert_eq!(config.path, PathBuf::from("/tmp/test-input.jsonl"));
+        assert_eq!(config.start_position, StartPosition::Beginning);
+        assert_eq!(config.poll_interval_ms, 500);
+        assert_eq!(config.skip_lines, 0);
+        assert!(!config.require_exists);
+    }
+
+    #[test]
+    fn test_config_all_options() {
+        let mut props = base_props();
+        props.insert("file.start.position".to_string(), "end".to_string());
+        props.insert("file.poll.interval.ms".to_string(), "100".to_string());
+        props.insert("file.skip.lines".to_string(), "1".to_string());
+        props.insert("file.require.exists".to_string(), "true".to_string());
+
+        let config = FileSourceConfig::from_properties(&props).unwrap();
+        assert_eq!(config.start_position, StartPosition::End);
+        assert_eq!(config.poll_interval_ms, 100);
+        assert_eq!(config.skip_lines, 1);
+        assert!(config.require_exists);
+    }
+
+    #[test]
+    fn test_config_requires_path() {
+        assert!(FileSourceConfig::from_properties(&HashMap::new())
+            .unwrap_err()
+            .contains("file.path"));
+
+        let mut props = HashMap::new();
+        props.insert("file.path".to_string(), "  ".to_string());
+        assert!(FileSourceConfig::from_properties(&props)
+            .unwrap_err()
+            .contains("file.path"));
+    }
+
+    #[test]
+    fn test_config_rejects_invalid_start_position() {
+        let mut props = base_props();
+        props.insert("file.start.position".to_string(), "middle".to_string());
+        assert!(FileSourceConfig::from_properties(&props)
+            .unwrap_err()
+            .contains("file.start.position"));
+    }
+
+    #[test]
+    fn test_source_from_properties_with_error_handling() {
+        let mut props = base_props();
+        props.insert("error.strategy".to_string(), "drop".to_string());
+
+        let source = FileSource::from_properties(&props, None, "TestStream").unwrap();
+        assert!(source.error_ctx.is_some());
+    }
+
+    #[test]
+    fn test_source_clone_resets_runtime_state() {
+        let mut props = base_props();
+        props.insert("error.strategy".to_string(), "drop".to_string());
+        let source = FileSource::from_properties(&props, None, "TestStream").unwrap();
+        let cloned = source.clone();
+        assert!(cloned.error_ctx.is_none());
+    }
+
+    #[test]
+    fn test_validate_missing_parent_dir_fails() {
+        let mut props = HashMap::new();
+        props.insert(
+            "file.path".to_string(),
+            "/nonexistent-dir-136/x.jsonl".to_string(),
+        );
+        let source = FileSource::from_properties(&props, None, "Test").unwrap();
+        assert!(source.validate_connectivity().is_err());
+    }
+
+    #[test]
+    fn test_validate_rejects_directory_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut props = HashMap::new();
+        props.insert("file.path".to_string(), dir.path().display().to_string());
+        let source = FileSource::from_properties(&props, None, "Test").unwrap();
+        assert!(source
+            .validate_connectivity()
+            .unwrap_err()
+            .to_string()
+            .contains("directory"));
+    }
+
+    #[test]
+    fn test_validate_require_exists() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("absent.jsonl");
+        let mut props = HashMap::new();
+        props.insert("file.path".to_string(), path.display().to_string());
+        props.insert("file.require.exists".to_string(), "true".to_string());
+
+        let source = FileSource::from_properties(&props, None, "Test").unwrap();
+        assert!(source.validate_connectivity().is_err());
+
+        std::fs::write(&path, "x\n").unwrap();
+        assert!(source.validate_connectivity().is_ok());
+    }
+
+    // =========================================================================
+    // Factory Tests
+    // =========================================================================
+
+    #[test]
+    fn test_factory_metadata() {
+        let factory = FileSourceFactory;
+        assert_eq!(factory.name(), "file");
+        assert!(factory.supported_formats().contains(&"json"));
+        assert!(factory.supported_formats().contains(&"csv"));
+        assert!(factory.supported_formats().contains(&"bytes"));
+        assert!(factory.required_parameters().contains(&"file.path"));
+        assert!(factory
+            .optional_parameters()
+            .contains(&"file.start.position"));
+    }
+
+    #[test]
+    fn test_factory_create_and_missing_required() {
+        let factory = FileSourceFactory;
+        assert!(factory.create_initialized(&base_props()).is_ok());
+        assert!(factory.create_initialized(&HashMap::new()).is_err());
+    }
+
+    #[test]
+    fn test_factory_clone() {
+        let factory = FileSourceFactory;
+        assert_eq!(factory.clone_box().name(), "file");
+    }
+}

--- a/src/core/stream/input/source/http_source.rs
+++ b/src/core/stream/input/source/http_source.rs
@@ -596,29 +596,31 @@ impl SourceFactory for HttpSourceFactory {
     }
 
     fn optional_parameters(&self) -> &[&str] {
-        &[
-            // poll mode
-            "http.url",
-            "http.poll.interval.ms",
-            "http.method",
-            "http.timeout.ms",
-            // webhook mode
-            "http.host",
-            "http.port",
-            "http.path",
-            "http.auth.header",
-            "http.auth.token",
-            "http.max.concurrent.requests",
-            "http.max.body.bytes",
-            // http.headers.<Name> passthrough is also accepted
-            // Error handling options
-            "error.strategy",
-            "error.retry.max-attempts",
-            "error.retry.initial-delay-ms",
-            "error.retry.max-delay-ms",
-            "error.retry.backoff-multiplier",
-            "error.dlq.stream",
-        ]
+        // Connector keys + the shared error-handling keys (owned by
+        // SourceErrorContext) — concatenated once, on first use
+        static PARAMS: std::sync::LazyLock<Vec<&'static str>> = std::sync::LazyLock::new(|| {
+            [
+                &[
+                    // poll mode
+                    "http.url",
+                    "http.poll.interval.ms",
+                    "http.method",
+                    "http.timeout.ms",
+                    // webhook mode
+                    "http.host",
+                    "http.port",
+                    "http.path",
+                    "http.auth.header",
+                    "http.auth.token",
+                    "http.max.concurrent.requests",
+                    "http.max.body.bytes",
+                    // http.headers.<Name> passthrough is also accepted
+                ][..],
+                crate::core::error::source_support::SOURCE_ERROR_PARAMETERS,
+            ]
+            .concat()
+        });
+        &PARAMS
     }
 
     fn create_initialized(

--- a/src/core/stream/input/source/kafka_source.rs
+++ b/src/core/stream/input/source/kafka_source.rs
@@ -491,25 +491,27 @@ impl SourceFactory for KafkaSourceFactory {
     }
 
     fn optional_parameters(&self) -> &[&str] {
-        &[
-            "kafka.group.id",
-            "kafka.auto.offset.reset",
-            "kafka.enable.auto.commit",
-            "kafka.poll.timeout.ms",
-            "kafka.security.protocol",
-            "kafka.sasl.mechanism",
-            "kafka.sasl.username",
-            "kafka.sasl.password",
-            "kafka.ssl.ca.location",
-            // kafka.rdkafka.<prop> passthrough is also accepted
-            // Error handling options
-            "error.strategy",
-            "error.retry.max-attempts",
-            "error.retry.initial-delay-ms",
-            "error.retry.max-delay-ms",
-            "error.retry.backoff-multiplier",
-            "error.dlq.stream",
-        ]
+        // Connector keys + the shared error-handling keys (owned by
+        // SourceErrorContext) — concatenated once, on first use
+        static PARAMS: std::sync::LazyLock<Vec<&'static str>> = std::sync::LazyLock::new(|| {
+            [
+                &[
+                    "kafka.group.id",
+                    "kafka.auto.offset.reset",
+                    "kafka.enable.auto.commit",
+                    "kafka.poll.timeout.ms",
+                    "kafka.security.protocol",
+                    "kafka.sasl.mechanism",
+                    "kafka.sasl.username",
+                    "kafka.sasl.password",
+                    "kafka.ssl.ca.location",
+                    // kafka.rdkafka.<prop> passthrough is also accepted
+                ][..],
+                crate::core::error::source_support::SOURCE_ERROR_PARAMETERS,
+            ]
+            .concat()
+        });
+        &PARAMS
     }
 
     fn create_initialized(

--- a/src/core/stream/input/source/mod.rs
+++ b/src/core/stream/input/source/mod.rs
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+#[cfg(feature = "file")]
+pub mod file_source;
 #[cfg(feature = "http")]
 pub mod http_source;
 #[cfg(feature = "kafka")]

--- a/src/core/stream/input/source/rabbitmq_source.rs
+++ b/src/core/stream/input/source/rabbitmq_source.rs
@@ -883,23 +883,25 @@ impl SourceFactory for RabbitMQSourceFactory {
     }
 
     fn optional_parameters(&self) -> &[&str] {
-        &[
-            "rabbitmq.port",
-            "rabbitmq.vhost",
-            "rabbitmq.username",
-            "rabbitmq.password",
-            "rabbitmq.prefetch",
-            "rabbitmq.consumer.tag",
-            "rabbitmq.auto.ack",
-            "rabbitmq.declare.queue",
-            // Error handling options
-            "error.strategy",
-            "error.retry.max-attempts",
-            "error.retry.initial-delay-ms",
-            "error.retry.max-delay-ms",
-            "error.retry.backoff-multiplier",
-            "error.dlq.stream",
-        ]
+        // Connector keys + the shared error-handling keys (owned by
+        // SourceErrorContext) — concatenated once, on first use
+        static PARAMS: std::sync::LazyLock<Vec<&'static str>> = std::sync::LazyLock::new(|| {
+            [
+                &[
+                    "rabbitmq.port",
+                    "rabbitmq.vhost",
+                    "rabbitmq.username",
+                    "rabbitmq.password",
+                    "rabbitmq.prefetch",
+                    "rabbitmq.consumer.tag",
+                    "rabbitmq.auto.ack",
+                    "rabbitmq.declare.queue",
+                ][..],
+                crate::core::error::source_support::SOURCE_ERROR_PARAMETERS,
+            ]
+            .concat()
+        });
+        &PARAMS
     }
 
     fn create_initialized(
@@ -1141,10 +1143,7 @@ mod tests {
         // Add error handling config
         config.insert("error.strategy".to_string(), "retry".to_string());
         config.insert("error.retry.max-attempts".to_string(), "3".to_string());
-        config.insert(
-            "error.retry.initial-delay-ms".to_string(),
-            "100".to_string(),
-        );
+        config.insert("error.retry.initial-delay".to_string(), "100ms".to_string());
 
         let result = factory.create_initialized(&config);
         assert!(result.is_ok(), "Factory should accept error.* config");

--- a/src/core/stream/input/source/websocket_source.rs
+++ b/src/core/stream/input/source/websocket_source.rs
@@ -652,21 +652,23 @@ impl SourceFactory for WebSocketSourceFactory {
     }
 
     fn optional_parameters(&self) -> &[&str] {
-        &[
-            "websocket.reconnect",
-            "websocket.reconnect.delay.ms",
-            "websocket.reconnect.max.delay.ms",
-            "websocket.reconnect.max.attempts",
-            "websocket.subprotocol",
-            // Headers are dynamic: websocket.headers.*
-            // Error handling options
-            "error.strategy",
-            "error.retry.max-attempts",
-            "error.retry.initial-delay-ms",
-            "error.retry.max-delay-ms",
-            "error.retry.backoff-multiplier",
-            "error.dlq.stream",
-        ]
+        // Connector keys + the shared error-handling keys (owned by
+        // SourceErrorContext) — concatenated once, on first use
+        static PARAMS: std::sync::LazyLock<Vec<&'static str>> = std::sync::LazyLock::new(|| {
+            [
+                &[
+                    "websocket.reconnect",
+                    "websocket.reconnect.delay.ms",
+                    "websocket.reconnect.max.delay.ms",
+                    "websocket.reconnect.max.attempts",
+                    "websocket.subprotocol",
+                    // Headers are dynamic: websocket.headers.*
+                ][..],
+                crate::core::error::source_support::SOURCE_ERROR_PARAMETERS,
+            ]
+            .concat()
+        });
+        &PARAMS
     }
 
     fn create_initialized(

--- a/src/core/stream/output/sink/file_sink.rs
+++ b/src/core/stream/output/sink/file_sink.rs
@@ -1,0 +1,563 @@
+/*
+ * Copyright 2025-2026 EventFlux.io
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! # File Sink
+//!
+//! Appends each event's formatted payload as one line to a file, with
+//! optional size/time-based rotation and zstd compression of rolled files.
+//!
+//! ## Architecture
+//!
+//! ```text
+//! Events → per event: SinkMapper → bytes → publish() → BufWriter (+ \n)
+//!   → flush policy → rotation check (size/time) → roll (+ optional zstd)
+//! ```
+//!
+//! One event = one line. `publish()` blocks for the write (and flush, under
+//! the default policy) — backpressure by design, like the other sinks. The
+//! rotation check runs after the write, so a line is never split across
+//! files.
+
+use super::sink_trait::Sink;
+use crate::core::exception::EventFluxError;
+use crate::core::extension::SinkFactory;
+use crate::core::stream::connector_util::parse_or;
+use std::collections::HashMap;
+use std::fmt::Debug;
+use std::fs::{File, OpenOptions};
+use std::io::{BufWriter, Write};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+/// Compression applied to rolled files
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RotateCompression {
+    None,
+    /// Rolled file becomes `<name>.zst` (zstd is already a workspace
+    /// dependency; gzip is deferred — rationale in feat/file/README.md §9)
+    Zstd,
+}
+
+/// File sink configuration
+#[derive(Debug, Clone)]
+pub struct FileSinkConfig {
+    /// Output file path (parent directory must exist)
+    pub path: PathBuf,
+    /// Append to an existing file (default) or truncate at startup
+    pub append: bool,
+    /// 0 = flush after every event (default); N > 0 = flush at most every N ms
+    pub flush_interval_ms: u64,
+    /// Roll when the file reaches this size (0 = off)
+    pub rotate_size_bytes: u64,
+    /// Roll when the file's age — counted from when it was opened —
+    /// reaches this (0 = off)
+    pub rotate_interval_ms: u64,
+    /// Compression for rolled files
+    pub rotate_compression: RotateCompression,
+}
+
+impl FileSinkConfig {
+    /// Parse configuration from properties HashMap
+    pub fn from_properties(properties: &HashMap<String, String>) -> Result<Self, String> {
+        let path = crate::core::stream::connector_util::parse_required(properties, "file.path")?;
+
+        let rotate_compression = match properties
+            .get("file.rotate.compression")
+            .map(String::as_str)
+            .unwrap_or("none")
+        {
+            "none" => RotateCompression::None,
+            "zstd" => RotateCompression::Zstd,
+            other => {
+                return Err(format!(
+                    "Invalid file.rotate.compression '{other}': expected 'none' or 'zstd'"
+                ))
+            }
+        };
+
+        let config = Self {
+            path: PathBuf::from(&path),
+            append: parse_or(properties, "file.append", true)?,
+            flush_interval_ms: parse_or(properties, "file.flush.interval.ms", 0)?,
+            rotate_size_bytes: parse_or(properties, "file.rotate.size.bytes", 0)?,
+            rotate_interval_ms: parse_or(properties, "file.rotate.interval.ms", 0)?,
+            rotate_compression,
+        };
+
+        if config.rotate_compression != RotateCompression::None
+            && config.rotate_size_bytes == 0
+            && config.rotate_interval_ms == 0
+        {
+            return Err(
+                "file.rotate.compression is set but no rotation trigger is configured — \
+                 set file.rotate.size.bytes and/or file.rotate.interval.ms"
+                    .to_string(),
+            );
+        }
+
+        Ok(config)
+    }
+}
+
+/// Open output file with write progress and flush bookkeeping
+struct SinkInner {
+    writer: BufWriter<File>,
+    /// Current size of the file (drives size rotation)
+    bytes_written: u64,
+    /// When this file was opened (drives time rotation)
+    opened_at: Instant,
+    /// Last flush (drives the interval flush policy)
+    last_flush: Instant,
+}
+
+/// Mutex-guarded sink state: the open file plus counters for the stop log.
+/// Plain integers, not atomics — every touch already happens under this
+/// lock (unlike the lock-free HTTP sink, where atomics are load-bearing).
+#[derive(Default)]
+struct SinkState {
+    /// Open only while started; publish opens on demand as a fallback
+    file: Option<SinkInner>,
+    /// Set when a truncating startup open failed: the on-demand reopen in
+    /// publish() still owes the `file.append = false` truncation
+    truncate_pending: bool,
+    written: u64,
+    failed: u64,
+    rolled: u64,
+}
+
+/// File sink appending one line per event (see module docs)
+pub struct FileSink {
+    config: FileSinkConfig,
+    state: Arc<Mutex<SinkState>>,
+}
+
+impl Debug for FileSink {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FileSink")
+            .field("config", &self.config)
+            .finish_non_exhaustive()
+    }
+}
+
+impl FileSink {
+    /// Create a new file sink (the file is opened by `start()`)
+    pub fn new(config: FileSinkConfig) -> Self {
+        Self {
+            config,
+            state: Arc::new(Mutex::new(SinkState::default())),
+        }
+    }
+
+    /// Create a file sink from properties
+    pub fn from_properties(properties: &HashMap<String, String>) -> Result<Self, String> {
+        Ok(Self::new(FileSinkConfig::from_properties(properties)?))
+    }
+
+    /// `truncate` must be true only for the startup open with
+    /// `file.append = false`. Every later reopen (rotation, recovery after a
+    /// failed roll, publish after stop) appends — reapplying startup
+    /// truncation there would wipe live data.
+    fn open_inner(config: &FileSinkConfig, truncate: bool) -> std::io::Result<SinkInner> {
+        let file = OpenOptions::new()
+            .create(true)
+            .append(!truncate)
+            .write(true)
+            .truncate(truncate)
+            .open(&config.path)?;
+        let bytes_written = if truncate { 0 } else { file.metadata()?.len() };
+        let now = Instant::now();
+        Ok(SinkInner {
+            writer: BufWriter::new(file),
+            bytes_written,
+            opened_at: now,
+            last_flush: now,
+        })
+    }
+
+    fn io_error(&self, action: &str, e: &std::io::Error) -> EventFluxError {
+        EventFluxError::ConnectionUnavailable {
+            message: format!(
+                "File sink {action} '{}' failed: {e}",
+                self.config.path.display()
+            ),
+            source: None,
+        }
+    }
+
+    /// Whether a rotation trigger has fired for the current file
+    fn should_rotate(&self, inner: &SinkInner) -> bool {
+        (self.config.rotate_size_bytes > 0 && inner.bytes_written >= self.config.rotate_size_bytes)
+            || (self.config.rotate_interval_ms > 0
+                && inner.opened_at.elapsed()
+                    >= Duration::from_millis(self.config.rotate_interval_ms))
+    }
+
+    /// Roll the current file: flush + close, rename to a timestamped name
+    /// (numeric suffix on collision), optionally compress, reopen fresh.
+    fn rotate(&self, state: &mut SinkState) -> std::io::Result<()> {
+        // Flush BEFORE closing: if it fails, the writer (and its buffered
+        // already-acknowledged events) must stay alive for a later retry
+        // instead of being dropped with the error swallowed
+        if let Some(current) = state.file.as_mut() {
+            current.writer.flush()?;
+        }
+        state.file = None; // closes the file
+
+        let rolled = rolled_path(&self.config.path);
+        std::fs::rename(&self.config.path, &rolled)?;
+
+        // The roll physically happened at the rename — count it now so a
+        // failed compression doesn't hide it from the stop summary
+        state.rolled += 1;
+
+        if self.config.rotate_compression == RotateCompression::Zstd {
+            compress_zstd(&rolled)?;
+        }
+
+        // The rename freed the path — the successor file always appends
+        state.file = Some(Self::open_inner(&self.config, false)?);
+        log::info!(
+            "[FileSink] Rolled '{}' → '{}'{}",
+            self.config.path.display(),
+            rolled.display(),
+            if self.config.rotate_compression == RotateCompression::Zstd {
+                " (zstd)"
+            } else {
+                ""
+            }
+        );
+        Ok(())
+    }
+}
+
+/// `<path>.<UTC timestamp>`, with a numeric suffix if that name is taken.
+/// A name counts as taken when either it or its compressed form exists —
+/// after a zstd roll only `<name>.zst` remains, and a same-second second
+/// roll must not reuse (and thereby overwrite) it.
+fn rolled_path(path: &Path) -> PathBuf {
+    let taken = |p: &Path| p.exists() || PathBuf::from(format!("{}.zst", p.display())).exists();
+
+    let stamp = chrono::Utc::now().format("%Y%m%dT%H%M%SZ");
+    let base = PathBuf::from(format!("{}.{stamp}", path.display()));
+    if !taken(&base) {
+        return base;
+    }
+    for n in 1.. {
+        let candidate = PathBuf::from(format!("{}.{n}", base.display()));
+        if !taken(&candidate) {
+            return candidate;
+        }
+    }
+    unreachable!("suffix loop always finds a free name");
+}
+
+/// Compress `<rolled>` to `<rolled>.zst` and remove the original. On
+/// failure the partial `.zst` is cleaned up (best effort) so consumers
+/// never see a truncated frame; the uncompressed roll stays intact.
+fn compress_zstd(rolled: &Path) -> std::io::Result<()> {
+    let target = PathBuf::from(format!("{}.zst", rolled.display()));
+    let mut input = File::open(rolled)?;
+    let output = File::create(&target)?;
+    if let Err(e) = zstd::stream::copy_encode(&mut input, output, 0) {
+        let _ = std::fs::remove_file(&target);
+        return Err(e);
+    }
+    std::fs::remove_file(rolled)
+}
+
+impl Clone for FileSink {
+    fn clone(&self) -> Self {
+        // Clones share the state — a file has exactly one writing cursor,
+        // and shared counters keep the stop-log totals accurate
+        Self {
+            config: self.config.clone(),
+            state: Arc::clone(&self.state),
+        }
+    }
+}
+
+impl Sink for FileSink {
+    fn publish(&self, payload: &[u8]) -> Result<(), EventFluxError> {
+        let mut state = self.state.lock().unwrap();
+
+        // start() opens the file; opening on demand keeps direct publish()
+        // use (tests, embedding) working
+        if state.file.is_none() {
+            // Recovery/late-open path — appends, unless a truncating
+            // startup open failed and the truncation is still owed
+            match Self::open_inner(&self.config, state.truncate_pending) {
+                Ok(inner) => {
+                    state.file = Some(inner);
+                    state.truncate_pending = false;
+                }
+                Err(e) => {
+                    state.failed += 1;
+                    return Err(self.io_error("open of", &e));
+                }
+            }
+        }
+
+        let write_result = {
+            let inner = state.file.as_mut().expect("opened above");
+            (|| -> std::io::Result<()> {
+                inner.writer.write_all(payload)?;
+                inner.writer.write_all(b"\n")?;
+                inner.bytes_written += payload.len() as u64 + 1;
+                // Flush policy: every event (0) or at most every N ms
+                if self.config.flush_interval_ms == 0
+                    || inner.last_flush.elapsed()
+                        >= Duration::from_millis(self.config.flush_interval_ms)
+                {
+                    inner.writer.flush()?;
+                    inner.last_flush = Instant::now();
+                }
+                Ok(())
+            })()
+        };
+        if let Err(e) = write_result {
+            state.failed += 1;
+            return Err(self.io_error("write to", &e));
+        }
+
+        // The event is durably written from here on — count it before the
+        // rotation check so a failed roll doesn't misreport it as failed
+        state.written += 1;
+
+        // After the write, so a line never splits across files
+        let rotate_due = state.file.as_ref().is_some_and(|f| self.should_rotate(f));
+        if rotate_due {
+            if let Err(e) = self.rotate(&mut state) {
+                return Err(self.io_error("rotation of", &e));
+            }
+        }
+
+        Ok(())
+    }
+
+    fn start(&self) {
+        let mut state = self.state.lock().unwrap();
+        let truncate = !self.config.append;
+        // Every (re)start applies the configured startup semantics
+        // deterministically: with file.append = false the file is truncated
+        // even if a stray publish already opened it append-mode between
+        // stop() and this start()
+        if truncate {
+            state.file = None; // close before reopening with truncation
+        }
+        if state.file.is_none() {
+            match Self::open_inner(&self.config, truncate) {
+                Ok(inner) => {
+                    state.file = Some(inner);
+                    state.truncate_pending = false;
+                }
+                Err(e) => {
+                    // publish() will retry the open — and still owes the
+                    // startup truncation — and surfaces errors through the
+                    // pipeline's error handling
+                    state.truncate_pending = truncate;
+                    log::error!(
+                        "[FileSink] Failed to open '{}': {e}",
+                        self.config.path.display()
+                    );
+                }
+            }
+        }
+    }
+
+    fn stop(&self) {
+        let mut state = self.state.lock().unwrap();
+        if let Some(mut inner) = state.file.take() {
+            if let Err(e) = inner.writer.flush() {
+                log::error!(
+                    "[FileSink] Final flush of '{}' failed: {e}",
+                    self.config.path.display()
+                );
+            }
+        }
+        log::info!(
+            "[FileSink] Stopped (written: {}, failed: {}, rolled: {})",
+            state.written,
+            state.failed,
+            state.rolled,
+        );
+    }
+
+    fn clone_box(&self) -> Box<dyn Sink> {
+        Box::new(self.clone())
+    }
+
+    fn validate_connectivity(&self) -> Result<(), EventFluxError> {
+        // Probe: open in append mode and close — creates the file if absent,
+        // which matches append semantics; catches missing/unwritable dirs
+        OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.config.path)
+            .map(|_| ())
+            .map_err(|e| self.io_error("validation open of", &e))
+    }
+}
+
+// ============================================================================
+// File Sink Factory
+// ============================================================================
+
+/// Factory for creating file sink instances.
+///
+/// This factory is registered with EventFluxContext and used to create
+/// file sinks from SQL WITH clause configuration.
+#[derive(Debug, Clone)]
+pub struct FileSinkFactory;
+
+impl SinkFactory for FileSinkFactory {
+    fn name(&self) -> &'static str {
+        "file"
+    }
+
+    fn supported_formats(&self) -> &[&str] {
+        &["json", "csv", "bytes"]
+    }
+
+    fn required_parameters(&self) -> &[&str] {
+        &["file.path"]
+    }
+
+    fn optional_parameters(&self) -> &[&str] {
+        &[
+            "file.append",
+            "file.flush.interval.ms",
+            "file.rotate.size.bytes",
+            "file.rotate.interval.ms",
+            "file.rotate.compression",
+        ]
+    }
+
+    fn create_initialized(
+        &self,
+        config: &HashMap<String, String>,
+    ) -> Result<Box<dyn Sink>, EventFluxError> {
+        let parsed =
+            FileSinkConfig::from_properties(config).map_err(EventFluxError::configuration)?;
+        Ok(Box::new(FileSink::new(parsed)))
+    }
+
+    fn clone_box(&self) -> Box<dyn SinkFactory> {
+        Box::new(self.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base_props(path: &str) -> HashMap<String, String> {
+        let mut props = HashMap::new();
+        props.insert("file.path".to_string(), path.to_string());
+        props
+    }
+
+    #[test]
+    fn test_config_defaults() {
+        let config = FileSinkConfig::from_properties(&base_props("/tmp/out.jsonl")).unwrap();
+        assert_eq!(config.path, PathBuf::from("/tmp/out.jsonl"));
+        assert!(config.append);
+        assert_eq!(config.flush_interval_ms, 0);
+        assert_eq!(config.rotate_size_bytes, 0);
+        assert_eq!(config.rotate_interval_ms, 0);
+        assert_eq!(config.rotate_compression, RotateCompression::None);
+    }
+
+    #[test]
+    fn test_config_all_options() {
+        let mut props = base_props("/tmp/out.jsonl");
+        props.insert("file.append".to_string(), "false".to_string());
+        props.insert("file.flush.interval.ms".to_string(), "250".to_string());
+        props.insert("file.rotate.size.bytes".to_string(), "1024".to_string());
+        props.insert("file.rotate.interval.ms".to_string(), "60000".to_string());
+        props.insert("file.rotate.compression".to_string(), "zstd".to_string());
+
+        let config = FileSinkConfig::from_properties(&props).unwrap();
+        assert!(!config.append);
+        assert_eq!(config.flush_interval_ms, 250);
+        assert_eq!(config.rotate_size_bytes, 1024);
+        assert_eq!(config.rotate_interval_ms, 60000);
+        assert_eq!(config.rotate_compression, RotateCompression::Zstd);
+    }
+
+    #[test]
+    fn test_config_requires_path() {
+        assert!(FileSinkConfig::from_properties(&HashMap::new())
+            .unwrap_err()
+            .contains("file.path"));
+    }
+
+    #[test]
+    fn test_config_rejects_invalid_compression() {
+        let mut props = base_props("/tmp/out.jsonl");
+        props.insert("file.rotate.compression".to_string(), "gzip".to_string());
+        assert!(FileSinkConfig::from_properties(&props)
+            .unwrap_err()
+            .contains("file.rotate.compression"));
+    }
+
+    #[test]
+    fn test_config_rejects_compression_without_rotation() {
+        let mut props = base_props("/tmp/out.jsonl");
+        props.insert("file.rotate.compression".to_string(), "zstd".to_string());
+        assert!(FileSinkConfig::from_properties(&props)
+            .unwrap_err()
+            .contains("rotation trigger"));
+    }
+
+    #[test]
+    fn test_validate_missing_parent_dir_fails() {
+        let sink =
+            FileSink::from_properties(&base_props("/nonexistent-dir-136/out.jsonl")).unwrap();
+        assert!(sink.validate_connectivity().is_err());
+    }
+
+    // =========================================================================
+    // Factory Tests
+    // =========================================================================
+
+    #[test]
+    fn test_factory_metadata() {
+        let factory = FileSinkFactory;
+        assert_eq!(factory.name(), "file");
+        assert!(factory.supported_formats().contains(&"json"));
+        assert!(factory.supported_formats().contains(&"csv"));
+        assert!(factory.supported_formats().contains(&"bytes"));
+        assert!(factory.required_parameters().contains(&"file.path"));
+        assert!(factory.optional_parameters().contains(&"file.append"));
+    }
+
+    #[test]
+    fn test_factory_create_and_missing_required() {
+        let factory = FileSinkFactory;
+        assert!(factory
+            .create_initialized(&base_props("/tmp/out.jsonl"))
+            .is_ok());
+        assert!(factory.create_initialized(&HashMap::new()).is_err());
+    }
+
+    #[test]
+    fn test_factory_clone() {
+        let factory = FileSinkFactory;
+        assert_eq!(factory.clone_box().name(), "file");
+    }
+}

--- a/src/core/stream/output/sink/mod.rs
+++ b/src/core/stream/output/sink/mod.rs
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+#[cfg(feature = "file")]
+pub mod file_sink;
 #[cfg(feature = "http")]
 pub mod http_sink;
 #[cfg(feature = "kafka")]

--- a/src/core/stream/stream_initializer.rs
+++ b/src/core/stream/stream_initializer.rs
@@ -189,6 +189,8 @@ pub fn initialize_stream(
 /// by cargo features. The feature is always named after the extension (see
 /// the `[features]` section in Cargo.toml), so one entry per gated connector.
 const GATED_OUT_EXTENSIONS: &[&str] = &[
+    #[cfg(not(feature = "file"))]
+    "file",
     #[cfg(not(feature = "http"))]
     "http",
     #[cfg(not(feature = "kafka"))]

--- a/tests/file_integration.rs
+++ b/tests/file_integration.rs
@@ -1,0 +1,615 @@
+/*
+ * Copyright 2025-2026 EventFlux.io
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! # File Connector Integration Tests
+//!
+//! Requires building with the `file` feature:
+//! `cargo test --features file --test file_integration`
+//!
+//! Fully self-hosting: every test works against temp files — nothing is
+//! `#[ignore]`d and no external service is needed.
+
+#![cfg(feature = "file")]
+
+#[path = "common/mod.rs"]
+mod common;
+use common::CollectingCallback;
+
+use eventflux::core::stream::input::source::file_source::FileSource;
+use eventflux::core::stream::input::source::Source;
+use eventflux::core::stream::output::sink::file_sink::FileSink;
+use eventflux::core::stream::output::sink::Sink;
+use std::collections::HashMap;
+use std::fs;
+use std::io::Write;
+use std::path::Path;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+fn source_props(path: &Path) -> HashMap<String, String> {
+    let mut props = HashMap::new();
+    props.insert("file.path".to_string(), path.display().to_string());
+    // Fast tests: tight polling
+    props.insert("file.poll.interval.ms".to_string(), "20".to_string());
+    props
+}
+
+fn sink_props(path: &Path) -> HashMap<String, String> {
+    let mut props = HashMap::new();
+    props.insert("file.path".to_string(), path.display().to_string());
+    props
+}
+
+fn append(path: &Path, content: &str) {
+    let mut file = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .unwrap();
+    file.write_all(content.as_bytes()).unwrap();
+    file.flush().unwrap();
+}
+
+fn started_source(props: &HashMap<String, String>) -> (FileSource, CollectingCallback) {
+    let callback = CollectingCallback::new();
+    let mut source = FileSource::from_properties(props, None, "Test").unwrap();
+    source.start(Arc::new(callback.clone()));
+    (source, callback)
+}
+
+// ============================================================================
+// Source: replay-then-follow (the default contract)
+// ============================================================================
+
+#[test]
+fn test_source_delivers_existing_content_from_beginning() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("in.jsonl");
+    fs::write(&path, "{\"n\":1}\n{\"n\":2}\n").unwrap();
+
+    let (mut source, callback) = started_source(&source_props(&path));
+    let payloads = callback.wait_for(2, Duration::from_secs(10));
+    source.stop();
+
+    assert_eq!(payloads, vec![b"{\"n\":1}".to_vec(), b"{\"n\":2}".to_vec()]);
+}
+
+#[test]
+fn test_source_eof_then_external_append_is_delivered() {
+    // The review scenario: existing content is consumed, EOF is not
+    // completion — another application appends and the line must arrive
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("in.jsonl");
+    fs::write(&path, "{\"n\":1}\n").unwrap();
+
+    let (mut source, callback) = started_source(&source_props(&path));
+    assert_eq!(callback.wait_for(1, Duration::from_secs(10)).len(), 1);
+
+    // "Another application" appends after EOF was reached
+    append(&path, "{\"n\":2}\n{\"n\":3}\n");
+
+    let payloads = callback.wait_for(3, Duration::from_secs(10));
+    source.stop();
+
+    assert_eq!(
+        payloads,
+        vec![
+            b"{\"n\":1}".to_vec(),
+            b"{\"n\":2}".to_vec(),
+            b"{\"n\":3}".to_vec(),
+        ]
+    );
+}
+
+#[test]
+fn test_source_skip_lines_for_csv_header() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("in.csv");
+    fs::write(&path, "symbol,price\nAAPL,185.5\nGOOGL,142.3\n").unwrap();
+
+    let mut props = source_props(&path);
+    props.insert("file.skip.lines".to_string(), "1".to_string());
+
+    let (mut source, callback) = started_source(&props);
+    let payloads = callback.wait_for(2, Duration::from_secs(10));
+    source.stop();
+
+    assert_eq!(
+        payloads,
+        vec![b"AAPL,185.5".to_vec(), b"GOOGL,142.3".to_vec()],
+        "the header row must be skipped"
+    );
+}
+
+#[test]
+fn test_source_start_position_end_only_delivers_appends() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("in.jsonl");
+    fs::write(&path, "{\"old\":true}\n").unwrap();
+
+    let mut props = source_props(&path);
+    props.insert("file.start.position".to_string(), "end".to_string());
+
+    let (mut source, callback) = started_source(&props);
+    // Give the source time to open at the end before appending
+    std::thread::sleep(Duration::from_millis(100));
+    append(&path, "{\"new\":true}\n");
+
+    let payloads = callback.wait_for(1, Duration::from_secs(10));
+    source.stop();
+
+    assert_eq!(
+        payloads,
+        vec![b"{\"new\":true}".to_vec()],
+        "existing content must not be delivered with start.position=end"
+    );
+}
+
+#[test]
+fn test_source_holds_partial_line_until_terminated() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("in.jsonl");
+    fs::write(&path, "").unwrap();
+
+    let (mut source, callback) = started_source(&source_props(&path));
+
+    append(&path, "{\"half\":");
+    // A partial line must not be delivered
+    std::thread::sleep(Duration::from_millis(150));
+    assert!(callback.wait_for(1, Duration::from_millis(1)).is_empty());
+
+    append(&path, "1}\n");
+    let payloads = callback.wait_for(1, Duration::from_secs(10));
+    source.stop();
+
+    assert_eq!(
+        payloads,
+        vec![b"{\"half\":1}".to_vec()],
+        "the two writes must arrive as one un-split event"
+    );
+}
+
+// ============================================================================
+// Source: rotation / truncation / missing-file (tail -F contract)
+// ============================================================================
+
+#[test]
+fn test_source_reopens_after_truncation() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("in.log");
+    fs::write(&path, "before\n").unwrap();
+
+    let (mut source, callback) = started_source(&source_props(&path));
+    assert_eq!(callback.wait_for(1, Duration::from_secs(10)).len(), 1);
+
+    // Truncate-and-rewrite (logrotate copytruncate style)
+    fs::write(&path, "after\n").unwrap();
+
+    let payloads = callback.wait_for(2, Duration::from_secs(10));
+    source.stop();
+
+    assert_eq!(payloads, vec![b"before".to_vec(), b"after".to_vec()]);
+}
+
+#[test]
+fn test_source_reopens_after_rename_rotation() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("in.log");
+    fs::write(&path, "in-old-file\n").unwrap();
+
+    let (mut source, callback) = started_source(&source_props(&path));
+    assert_eq!(callback.wait_for(1, Duration::from_secs(10)).len(), 1);
+
+    // Classic rotation: rename away, create fresh at the same path
+    fs::rename(&path, dir.path().join("in.log.1")).unwrap();
+    fs::write(&path, "in-new-file\n").unwrap();
+
+    let payloads = callback.wait_for(2, Duration::from_secs(10));
+    source.stop();
+
+    assert_eq!(
+        payloads,
+        vec![b"in-old-file".to_vec(), b"in-new-file".to_vec()]
+    );
+}
+
+#[test]
+fn test_source_delivers_rotated_file_tail() {
+    // Lines appended to the old file just before rotation must be salvaged
+    // through the still-open handle (the tail -F contract), not lost
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("in.log");
+    fs::write(&path, "one\n").unwrap();
+
+    let mut props = source_props(&path);
+    // Wide poll gap so the append+rename below lands between polls
+    props.insert("file.poll.interval.ms".to_string(), "300".to_string());
+
+    let (mut source, callback) = started_source(&props);
+    assert_eq!(callback.wait_for(1, Duration::from_secs(10)).len(), 1);
+
+    // Within one poll window: tail grows, then the file is rotated away
+    append(&path, "two\n");
+    fs::rename(&path, dir.path().join("in.log.1")).unwrap();
+    fs::write(&path, "three\n").unwrap();
+
+    let payloads = callback.wait_for(3, Duration::from_secs(10));
+    source.stop();
+
+    assert_eq!(
+        payloads,
+        vec![b"one".to_vec(), b"two".to_vec(), b"three".to_vec()],
+        "the rotated-away file's tail must be delivered before switching"
+    );
+}
+
+#[test]
+fn test_source_drops_oversized_line_and_resyncs() {
+    // A delimiter-less blob past the safety cap must be dropped (no OOM)
+    // and reading must resync on the next real line
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("in.log");
+    let mut blob = vec![b'x'; 9 * 1024 * 1024]; // > 8 MiB cap, no newline
+    blob.push(b'\n');
+    blob.extend_from_slice(b"ok\n");
+    fs::write(&path, &blob).unwrap();
+
+    let (mut source, callback) = started_source(&source_props(&path));
+    let payloads = callback.wait_for(1, Duration::from_secs(10));
+    source.stop();
+
+    assert_eq!(
+        payloads,
+        vec![b"ok".to_vec()],
+        "the oversized line is dropped, the following line delivered"
+    );
+}
+
+#[test]
+fn test_source_awaits_missing_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("late.jsonl");
+
+    // File does not exist yet — the source must wait, not error
+    let (mut source, callback) = started_source(&source_props(&path));
+    std::thread::sleep(Duration::from_millis(100));
+    fs::write(&path, "{\"late\":true}\n").unwrap();
+
+    let payloads = callback.wait_for(1, Duration::from_secs(10));
+    source.stop();
+
+    assert_eq!(payloads, vec![b"{\"late\":true}".to_vec()]);
+}
+
+#[test]
+fn test_source_long_interval_stops_promptly() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("in.jsonl");
+    fs::write(&path, "{\"n\":1}\n").unwrap();
+
+    let mut props = source_props(&path);
+    // An interval far beyond the stop grace period
+    props.insert("file.poll.interval.ms".to_string(), "600000".to_string());
+
+    let (mut source, callback) = started_source(&props);
+    callback.wait_for(1, Duration::from_secs(10));
+
+    // sleep_while_running makes the interval interruptible
+    let start = Instant::now();
+    source.stop();
+    assert!(
+        start.elapsed() < Duration::from_secs(5),
+        "stop() must interrupt a long poll interval"
+    );
+}
+
+// ============================================================================
+// Sink
+// ============================================================================
+
+#[test]
+fn test_sink_one_line_per_event_append_and_truncate() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("out.jsonl");
+    fs::write(&path, "{\"pre\":true}\n").unwrap();
+
+    // Append (default) keeps existing content
+    let sink = FileSink::from_properties(&sink_props(&path)).unwrap();
+    sink.start();
+    sink.publish(b"{\"n\":1}").unwrap();
+    sink.publish(b"{\"n\":2}").unwrap();
+    sink.stop();
+    assert_eq!(
+        fs::read_to_string(&path).unwrap(),
+        "{\"pre\":true}\n{\"n\":1}\n{\"n\":2}\n"
+    );
+
+    // Truncate discards it
+    let mut props = sink_props(&path);
+    props.insert("file.append".to_string(), "false".to_string());
+    let sink = FileSink::from_properties(&props).unwrap();
+    sink.start();
+    sink.publish(b"{\"n\":3}").unwrap();
+    sink.stop();
+    assert_eq!(fs::read_to_string(&path).unwrap(), "{\"n\":3}\n");
+}
+
+#[test]
+fn test_sink_flush_per_event_is_immediately_readable() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("out.jsonl");
+
+    let sink = FileSink::from_properties(&sink_props(&path)).unwrap();
+    sink.start();
+    sink.publish(b"{\"n\":1}").unwrap();
+
+    // Default policy flushes every event — visible before stop()
+    assert_eq!(fs::read_to_string(&path).unwrap(), "{\"n\":1}\n");
+    sink.stop();
+}
+
+#[test]
+fn test_sink_size_rotation_rolls_and_continues() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("out.log");
+
+    let mut props = sink_props(&path);
+    props.insert("file.rotate.size.bytes".to_string(), "10".to_string());
+    let sink = FileSink::from_properties(&props).unwrap();
+    sink.start();
+
+    sink.publish(b"0123456789").unwrap(); // 11 bytes with \n → rolls
+    sink.publish(b"next").unwrap(); // lands in the fresh file
+    sink.stop();
+
+    let rolled: Vec<_> = fs::read_dir(dir.path())
+        .unwrap()
+        .map(|e| e.unwrap().path())
+        .filter(|p| p != &path)
+        .collect();
+    assert_eq!(rolled.len(), 1, "exactly one rolled file: {rolled:?}");
+    assert!(
+        rolled[0]
+            .file_name()
+            .unwrap()
+            .to_string_lossy()
+            .starts_with("out.log."),
+        "rolled name keeps the original as prefix: {rolled:?}"
+    );
+    assert_eq!(fs::read_to_string(&rolled[0]).unwrap(), "0123456789\n");
+    assert_eq!(fs::read_to_string(&path).unwrap(), "next\n");
+}
+
+#[test]
+fn test_sink_time_rotation() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("out.log");
+
+    let mut props = sink_props(&path);
+    props.insert("file.rotate.interval.ms".to_string(), "50".to_string());
+    let sink = FileSink::from_properties(&props).unwrap();
+    sink.start();
+
+    sink.publish(b"first").unwrap();
+    std::thread::sleep(Duration::from_millis(80));
+    sink.publish(b"second").unwrap(); // age trigger fires after this write
+    sink.publish(b"third").unwrap();
+    sink.stop();
+
+    let rolled_count = fs::read_dir(dir.path())
+        .unwrap()
+        .map(|e| e.unwrap().path())
+        .filter(|p| p != &path)
+        .count();
+    assert!(rolled_count >= 1, "age-based rotation must have rolled");
+    assert!(fs::read_to_string(&path).unwrap().contains("third"));
+}
+
+#[test]
+fn test_sink_same_second_zstd_rolls_do_not_overwrite() {
+    // Two rolls inside one second resolve to the same timestamp; the
+    // collision check must see the compressed name of the first roll, or
+    // the second roll silently destroys it
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("out.log");
+
+    let mut props = sink_props(&path);
+    props.insert("file.rotate.size.bytes".to_string(), "5".to_string());
+    props.insert("file.rotate.compression".to_string(), "zstd".to_string());
+    let sink = FileSink::from_properties(&props).unwrap();
+    sink.start();
+
+    sink.publish(b"first-roll").unwrap(); // rolls + compresses
+    sink.publish(b"second-roll").unwrap(); // rolls again, same second
+    sink.stop();
+
+    let mut rolled: Vec<_> = fs::read_dir(dir.path())
+        .unwrap()
+        .map(|e| e.unwrap().path())
+        .filter(|p| p != &path)
+        .collect();
+    rolled.sort();
+    assert_eq!(rolled.len(), 2, "both rolls must survive: {rolled:?}");
+    let decoded: Vec<Vec<u8>> = rolled
+        .iter()
+        .map(|p| zstd::stream::decode_all(fs::File::open(p).unwrap()).unwrap())
+        .collect();
+    assert!(decoded.contains(&b"first-roll\n".to_vec()), "{decoded:?}");
+    assert!(decoded.contains(&b"second-roll\n".to_vec()), "{decoded:?}");
+}
+
+#[test]
+fn test_sink_truncate_mode_reopen_does_not_wipe() {
+    // file.append=false truncates ONLY at start(); a recovery/late reopen
+    // (publish after stop) must append, not wipe the data already written
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("out.jsonl");
+
+    let mut props = sink_props(&path);
+    props.insert("file.append".to_string(), "false".to_string());
+    let sink = FileSink::from_properties(&props).unwrap();
+    sink.start();
+    sink.publish(b"before-stop").unwrap();
+    sink.stop();
+
+    sink.publish(b"after-stop").unwrap();
+    assert_eq!(
+        fs::read_to_string(&path).unwrap(),
+        "before-stop\nafter-stop\n",
+        "the reopen must not reapply startup truncation"
+    );
+
+    // A real (re)start DOES apply the startup contract — deterministically,
+    // even though the stray publish above already reopened the file
+    sink.start();
+    sink.publish(b"after-restart").unwrap();
+    sink.stop();
+    assert_eq!(
+        fs::read_to_string(&path).unwrap(),
+        "after-restart\n",
+        "start() must truncate deterministically with file.append = false"
+    );
+}
+
+#[test]
+fn test_sink_zstd_compressed_roll_decodes_to_content() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("out.log");
+
+    let mut props = sink_props(&path);
+    props.insert("file.rotate.size.bytes".to_string(), "10".to_string());
+    props.insert("file.rotate.compression".to_string(), "zstd".to_string());
+    let sink = FileSink::from_properties(&props).unwrap();
+    sink.start();
+
+    sink.publish(b"0123456789").unwrap(); // rolls + compresses
+    sink.publish(b"next").unwrap();
+    sink.stop();
+
+    let rolled: Vec<_> = fs::read_dir(dir.path())
+        .unwrap()
+        .map(|e| e.unwrap().path())
+        .filter(|p| p != &path)
+        .collect();
+    assert_eq!(rolled.len(), 1, "one compressed rolled file: {rolled:?}");
+    assert!(
+        rolled[0].extension().unwrap() == "zst",
+        "rolled file is .zst: {rolled:?}"
+    );
+    let decoded = zstd::stream::decode_all(fs::File::open(&rolled[0]).unwrap()).unwrap();
+    assert_eq!(decoded, b"0123456789\n");
+    assert_eq!(fs::read_to_string(&path).unwrap(), "next\n");
+}
+
+// ============================================================================
+// Round trip: file sink → file source (self-hosting analogue of HTTP's)
+// ============================================================================
+
+#[test]
+fn test_sink_to_source_round_trip() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("pipe.jsonl");
+
+    let (mut source, callback) = started_source(&source_props(&path));
+
+    let sink = FileSink::from_properties(&sink_props(&path)).unwrap();
+    sink.start();
+    sink.publish(b"{\"n\":1}").unwrap();
+    sink.publish(b"{\"n\":2}").unwrap();
+    sink.publish(b"{\"n\":3}").unwrap();
+    sink.stop();
+
+    let payloads = callback.wait_for(3, Duration::from_secs(10));
+    source.stop();
+
+    assert_eq!(
+        payloads,
+        vec![
+            b"{\"n\":1}".to_vec(),
+            b"{\"n\":2}".to_vec(),
+            b"{\"n\":3}".to_vec(),
+        ]
+    );
+}
+
+// ============================================================================
+// E2E: SQL app — replay a JSONL file, filter, write JSONL out
+// ============================================================================
+
+#[tokio::test]
+async fn test_e2e_sql_file_to_file() {
+    use eventflux::core::eventflux_manager::EventFluxManager;
+
+    let dir = tempfile::tempdir().unwrap();
+    let input = dir.path().join("trades.jsonl");
+    let output = dir.path().join("alerts.jsonl");
+    fs::write(
+        &input,
+        concat!(
+            "{\"symbol\":\"AAPL\",\"volume\":5000}\n",
+            "{\"symbol\":\"GOOGL\",\"volume\":800}\n",
+            "{\"symbol\":\"MSFT\",\"volume\":1500}\n",
+        ),
+    )
+    .unwrap();
+
+    let sql = format!(
+        r#"
+        CREATE STREAM Trades (symbol STRING, volume INT) WITH (
+            type = 'source', extension = 'file', format = 'json',
+            "file.path" = '{input}',
+            "file.poll.interval.ms" = '20'
+        );
+        CREATE STREAM HighVolume (symbol STRING, volume INT) WITH (
+            type = 'sink', extension = 'file', format = 'json',
+            "file.path" = '{output}'
+        );
+        INSERT INTO HighVolume SELECT symbol, volume FROM Trades WHERE volume > 1000;
+    "#,
+        input = input.display(),
+        output = output.display(),
+    );
+
+    let manager = EventFluxManager::new();
+    let runtime = manager
+        .create_eventflux_app_runtime_from_string(&sql)
+        .await
+        .expect("runtime");
+    runtime.start().expect("start");
+
+    // Wait until both passing events are durably in the output file
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let content = fs::read_to_string(&output).unwrap_or_default();
+        if content.lines().count() >= 2 || Instant::now() >= deadline {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    runtime.shutdown();
+
+    let lines: Vec<serde_json::Value> = fs::read_to_string(&output)
+        .unwrap()
+        .lines()
+        .map(|l| serde_json::from_str(l).unwrap())
+        .collect();
+    assert_eq!(lines.len(), 2, "GOOGL (volume 800) must be filtered out");
+    assert_eq!(lines[0]["symbol"], "AAPL");
+    assert_eq!(lines[0]["volume"], 5000);
+    assert_eq!(lines[1]["symbol"], "MSFT");
+    assert_eq!(lines[1]["volume"], 1500);
+}

--- a/website/docs/connectors/file.md
+++ b/website/docs/connectors/file.md
@@ -1,0 +1,102 @@
+---
+sidebar_position: 2
+title: File Connector
+description: Replay and follow files, write line-delimited output with rotation
+---
+
+# File Connector
+
+The File connector ingests events from a local file and writes processed events to local files. The source **never finishes**: after consuming existing content it keeps observing the file and delivers whatever any other application appends — everything is long-running and realtime. It supports JSON, CSV, and bytes formats.
+
+Everything is line-delimited: **one line = one event** (a JSONL line, a CSV row, or arbitrary bytes per line).
+
+## Prerequisites
+
+The File connector is feature-gated but adds **no new dependencies** (rolled-file compression and timestamps use zstd and chrono, which are already core dependencies):
+
+```bash
+cargo build --release --features file
+# or: cargo build --release --features connectors-all
+```
+
+## File Source
+
+Observes one file, delivering each complete line as one payload.
+
+```sql
+CREATE STREAM Trades (symbol STRING, price DOUBLE, volume INT) WITH (
+    type = 'source',
+    extension = 'file',
+    format = 'json',
+    "file.path" = '/var/data/trades.jsonl',
+    "file.poll.interval.ms" = '200'
+);
+```
+
+| Option | Required | Default | Description |
+|--------|----------|---------|-------------|
+| `file.path` | Yes | - | Path of the file to observe |
+| `file.start.position` | No | `beginning` | `beginning` = deliver existing content first, then follow appends; `end` = only lines appended after startup |
+| `file.poll.interval.ms` | No | `500` | How often to check for new data / rotation (interruptible — long intervals never delay shutdown) |
+| `file.skip.lines` | No | `0` | Skip the first N lines (e.g. a CSV header row); re-applied whenever reading restarts from the top (rotation) |
+| `file.require.exists` | No | `false` | `false` = a missing file is awaited (`tail -F` semantics); `true` = fail fast at startup if absent |
+| `error.*` | No | - | Error strategies (`drop`/`retry`/`dlq`/`fail`) — same options as [Kafka](/docs/connectors/kafka#error-handling) |
+
+Behavior:
+
+- **Rotation and truncation** follow the `tail -F` contract: if the path points at a new file (rename-over / recreate), the renamed-away file's remaining lines are first drained through the still-open handle, then reading switches to the new file from the top. Only lines a writer appends to the old file *after* that final drain are missed — keep poll intervals short if writers keep old files open long after rotation. A truncated file (same file object, size shrank) reopens from the top; its overwritten content is gone by definition.
+- A **partial final line** (no terminator yet) is held until completed — writers that flush mid-line never produce split events.
+- Empty lines are skipped; payload bytes are the raw line without the terminator (`\n` and `\r\n` both accepted).
+- I/O errors are routed through the `error.*` strategy as connection errors; after a transient read error, reading resumes where it stopped instead of replaying the file. Unterminated lines beyond an 8 MiB safety cap are dropped, with reading resyncing at the next terminator.
+
+**Restarts:** no read offset is persisted. After an app restart, `file.start.position` governs: `end` skips lines written while down; `beginning` re-reads the file (duplicates downstream). Checkpointed offsets are planned as a follow-up.
+
+## File Sink
+
+Appends each event as one line. Rotation and compressed rolls are built in.
+
+```sql
+CREATE STREAM HighVolume (symbol STRING, volume INT) WITH (
+    type = 'sink',
+    extension = 'file',
+    format = 'json',
+    "file.path" = '/var/data/high_volume.jsonl',
+    "file.rotate.size.bytes" = '104857600',
+    "file.rotate.compression" = 'zstd'
+);
+```
+
+| Option | Required | Default | Description |
+|--------|----------|---------|-------------|
+| `file.path` | Yes | - | Output file path (parent directory must exist) |
+| `file.append` | No | `true` | `true` = append to an existing file, `false` = truncate at startup |
+| `file.flush.interval.ms` | No | `0` | `0` = flush after every event (durable, default); N > 0 = flush at most once every N ms, checked per publish. The crash-loss window is bounded in bytes (the write buffer), not in wall time — a trickle stream can hold buffered events until its next publish or `stop()` |
+| `file.rotate.size.bytes` | No | `0` (off) | Roll the file when it reaches this size |
+| `file.rotate.interval.ms` | No | `0` (off) | Roll the file at this age, counted from file open |
+| `file.rotate.compression` | No | `none` | `none` or `zstd` — compress the rolled file to `<name>.zst` |
+
+Behavior:
+
+- One event = one line: the mapper's payload plus `\n`. Rotation checks run after the write, so a line never splits across files.
+- Rolled files are renamed to `<path>.<UTC timestamp>` (e.g. `out.jsonl.20260722T101530Z`), then a fresh file continues at `file.path`. Both rotation triggers may be set; whichever fires first rolls.
+- Under the default flush policy an event is durably in the file (through the OS) before the publish returns; compression runs in the publishing thread — backpressure by design.
+- Setting `file.rotate.compression` without a rotation trigger is rejected at startup.
+
+## Connection Validation
+
+At startup (fail-fast):
+
+- **Source**: the parent directory must exist and `file.path` must not be a directory; the file itself must exist only when `file.require.exists = true`.
+- **Sink**: the file is opened in append mode and closed (creating it if absent, matching append semantics) — missing or unwritable directories fail immediately.
+
+## Complete End-to-End Example
+
+See [`examples/file.eventflux`](https://github.com/eventflux-io/eventflux/blob/main/examples/file.eventflux) — replay a JSONL file, filter, append matches to an output file; testable with `printf`, `echo >>`, and `tail -f` alone.
+
+## Not Yet Supported
+
+- Directory spool mode (processing files appearing in a directory, with move/delete after processing) — v1 deliberately observes one given file
+- Offset checkpointing across restarts — see **Restarts** above
+- Native filesystem watching (inotify/FSEvents) — polling is the v1 backend; the config is forward-compatible
+- gzip-compressed rolls — `zstd` only until interop with gzip-only tooling (stock `zcat`, logrotate ecosystems, `.gz`-detecting shippers) is needed
+- Custom delimiters / multi-line records — line-delimited only

--- a/website/docs/connectors/http.md
+++ b/website/docs/connectors/http.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 3
 title: HTTP Connector
 description: REST polling, webhook ingestion, and webhook delivery
 ---

--- a/website/docs/connectors/kafka.md
+++ b/website/docs/connectors/kafka.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 4
 title: Kafka Connector
 description: Consume from and produce to Apache Kafka topics
 ---
@@ -148,10 +148,12 @@ clause options on the source stream):
 |--------|---------|-------------|
 | `error.strategy` | `drop` | What to do when the pipeline rejects a record: `drop`, `retry`, `dlq`, `fail` |
 | `error.retry.max-attempts` | `3` | Max retries before falling back to drop |
-| `error.retry.initial-delay-ms` | `100` | First retry delay |
-| `error.retry.max-delay-ms` | `10000` | Retry delay ceiling |
-| `error.retry.backoff-multiplier` | `2.0` | Exponential backoff factor |
+| `error.retry.backoff` | `exponential` | Backoff strategy: `exponential`, `linear`, or `fixed` |
+| `error.retry.initial-delay` | `100ms` | First retry delay (duration string) |
+| `error.retry.max-delay` | `30s` | Retry delay ceiling (duration string) |
+| `error.log-level` | `warn` | Log level for handled errors |
 | `error.dlq.stream` | - | Dead-letter stream name (required when strategy is `dlq`) |
+| `error.dlq.fallback-strategy` | `log` | What to do when DLQ delivery itself fails |
 
 Strategy semantics and their offset interaction:
 
@@ -176,9 +178,9 @@ CREATE STREAM Orders (order_id STRING, amount DOUBLE) WITH (
     "kafka.enable.auto.commit" = 'false',      -- at-least-once
     "error.strategy" = 'retry',
     "error.retry.max-attempts" = '5',
-    "error.retry.initial-delay-ms" = '200',
-    "error.retry.max-delay-ms" = '5000',
-    "error.retry.backoff-multiplier" = '2.0'
+    "error.retry.initial-delay" = '200ms',
+    "error.retry.max-delay" = '5s',
+    "error.retry.backoff" = 'exponential'
 );
 ```
 

--- a/website/docs/connectors/mappers.md
+++ b/website/docs/connectors/mappers.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 7
 title: Mappers Reference
 description: JSON, CSV, and Bytes format handling for EventFlux connectors
 ---

--- a/website/docs/connectors/overview.md
+++ b/website/docs/connectors/overview.md
@@ -101,6 +101,7 @@ extension name. The default build is fully minimal (core engine plus the
 built-in `timer` source and `log` sink):
 
 ```bash
+cargo build --release --features file              # just File
 cargo build --release --features http              # just HTTP
 cargo build --release --features kafka             # just Kafka
 cargo build --release --features rabbitmq          # just RabbitMQ
@@ -124,11 +125,11 @@ build. Rebuild with `--features rabbitmq` (or `--features connectors-all`).
 |-----------|--------|------|--------------|--------|-------------|
 | **Timer** | Yes | — | (always built) | Production Ready | Periodic tick source |
 | **Log** | — | Yes | (always built) | Production Ready | Logging sink for debugging |
+| **File** | Yes | Yes | `file` | Production Ready | Replay/follow files, rotating output |
 | **HTTP** | Yes | Yes | `http` | Production Ready | REST polling, webhooks in/out |
 | **Kafka** | Yes | Yes | `kafka` | Production Ready | Apache Kafka streaming |
 | **RabbitMQ** | Yes | Yes | `rabbitmq` | Production Ready | AMQP 0-9-1 message broker |
 | **WebSocket** | Yes | Yes | `websocket` | Production Ready | Real-time bidirectional streaming |
-| **File** | Planned | Planned | — | Roadmap | File-based input/output |
 
 ## Available Mappers
 
@@ -219,6 +220,7 @@ manager.context().add_sink_factory(
 
 ## Next Steps
 
+- **[File Connector](/docs/connectors/file)** - Replay and follow files, rotating line-delimited output
 - **[HTTP Connector](/docs/connectors/http)** - REST polling, webhook ingestion and delivery
 - **[Kafka Connector](/docs/connectors/kafka)** - Consume from and produce to Apache Kafka topics
 - **[RabbitMQ Connector](/docs/connectors/rabbitmq)** - Connect to RabbitMQ message broker

--- a/website/docs/connectors/rabbitmq.md
+++ b/website/docs/connectors/rabbitmq.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 5
 title: RabbitMQ Connector
 description: Connect EventFlux to RabbitMQ message broker for real-time event streaming
 ---

--- a/website/docs/connectors/websocket.md
+++ b/website/docs/connectors/websocket.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 6
 title: WebSocket Connector
 description: Connect EventFlux to WebSocket endpoints for real-time bidirectional streaming
 ---

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -41,6 +41,7 @@ a cargo feature named exactly after its SQL extension name:
 
 | Feature | Connector | In default build? |
 |---------|-----------|-------------------|
+| `file` | File source (replay + follow) + sink (rotation) | No |
 | `http` | HTTP source (polling + webhook) + sink | No |
 | `kafka` | Kafka source + sink (needs cmake to build) | No |
 | `rabbitmq` | RabbitMQ source + sink | No |
@@ -147,7 +148,7 @@ Beyond connectors, EventFlux exposes additional opt-in cargo features:
 
 | Feature | Purpose |
 |---------|---------|
-| `rabbitmq`, `websocket`, `connectors-all` | External connectors (see table above) |
+| `file`, `http`, `kafka`, `rabbitmq`, `websocket`, `connectors-all` | External connectors (see table above) |
 | `kubernetes`, `consul`, `etcd`, `vault`, `cloud-native` | Cloud-native integrations for distributed deployments |
 | `perf-tests` | Performance test suite |
 

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -51,6 +51,7 @@ const sidebars = {
       collapsed: false,
       items: [
         'connectors/overview',
+        'connectors/file',
         'connectors/http',
         'connectors/kafka',
         'connectors/rabbitmq',


### PR DESCRIPTION
Implements the File connector (Priority 3) per the spec in `feat/file/README.md`. The first connector with **zero new dependencies** — pure `std`, with rolled-file compression via the already-present zstd.

## Source (`extension = 'file'`)

Observes one file, one line = one event (JSONL line, CSV row, or raw bytes). The source never finishes: EOF just means "nothing new yet" — existing content is replayed per `file.start.position` (`beginning` default / `end`), then appends from any other application are delivered as they land. Everything follows the `tail -F` contract:

- Rotation (rename-over/recreate, detected via device+inode or creation time): the renamed-away file's remaining lines are **drained through the still-open handle** before switching to the new file; truncation reopens from the top
- Missing files are awaited (`file.require.exists = true` opts into fail-fast); a partial final line is held until terminated, so mid-line flushes never split events
- Transient read errors **resume at the last consumed offset** (skip budget preserved) instead of replaying the file; real stat errors route through the standard `error.*` strategies
- `file.skip.lines` for CSV headers (re-applied on every from-zero reopen); an 8 MiB safety cap drops delimiter-less blobs and resyncs at the next terminator (no OOM)
- Hot path is zero-copy: complete lines are delivered as slices of a reused 64 KB buffer; only chunk-spanning fragments touch the held buffer; idle polls are syscall-free after the metadata check

## Sink

Appends payload + `\n` per event with a flush policy (per-event default; optional interval), size- and/or age-based rotation to timestamped rolls, and optional zstd compression of rolled files. Rotation runs after the write so lines never split across files; rolls that collide within one second get numeric suffixes (compressed names included); `file.append = false` truncates deterministically at every `start()` — and only there. All failure paths (flush/rename/compress/reopen) recover on the next publish without data loss, with truthful written/failed/rolled counters.

## Shared infrastructure

- `connector_util::parse_required` — mandatory-key parsing, reusable by all connectors
- `SOURCE_ERROR_PARAMETERS` in `source_support` — the `error.*` key surface defined once and adopted by all five source factories; the previous per-connector copies advertised three key names the code never read (`-ms` variants, `backoff-multiplier`), now corrected here plus in the Kafka docs (which also had a wrong default) and a vacuously-passing RabbitMQ test

## Gating, tests, docs

- Feature `file = []` (uniform gating convention), in `connectors-all`; `GATED_OUT_EXTENSIONS`, CI/justfile/CONTRIBUTING per-connector checks
- 20 fully self-hosting integration tests (temp files, nothing ignored): replay/follow, EOF-then-append, both rotation styles with tail salvage, oversized-line resync, same-second compressed-roll collision, truncate-restart determinism, sink→source round trip, SQL e2e
- Website connector page, `examples/file.eventflux` (verified live: replay → filter → output, then an external append delivered while running), README/ROADMAP/writing_extensions updated

Deferred with forward paths in the spec: directory spool mode, offset checkpointing (StateHolder follow-up), native FS watching, gzip rolls, configurable `file.max.line.bytes`.