### PR TITLE
fix: redact credentials in connector config Debug output

### DIFF
--- a/src/core/stream/connector_util.rs
+++ b/src/core/stream/connector_util.rs
@@ -21,6 +21,49 @@ use std::collections::HashMap;
 use std::fmt::Display;
 use std::str::FromStr;
 
+/// A secret configuration value (password, token, credential-bearing header)
+/// whose `Debug`/`Display` output is always `***`. The raw value must be
+/// requested explicitly via [`Redacted::expose`], so a `{:?}` of a connector
+/// config can never leak credentials into logs (#143).
+#[derive(Clone, PartialEq, Eq, Default)]
+pub struct Redacted(String);
+
+impl Redacted {
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    /// The actual secret — call only at the point of use (connection
+    /// building, header injection), never in log/format paths.
+    pub fn expose(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<String> for Redacted {
+    fn from(value: String) -> Self {
+        Self(value)
+    }
+}
+
+impl From<&str> for Redacted {
+    fn from(value: &str) -> Self {
+        Self(value.to_string())
+    }
+}
+
+impl std::fmt::Debug for Redacted {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("***")
+    }
+}
+
+impl Display for Redacted {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("***")
+    }
+}
+
 /// Key injected by `stream_initializer` into the properties map passed to
 /// source/sink factories, carrying the stream's `format` (e.g. "json").
 /// The leading underscore marks it as reserved/injected — factories must not
@@ -86,6 +129,15 @@ mod tests {
         assert!(parse_or(&props, "k", 5u64)
             .unwrap_err()
             .contains("Invalid k"));
+    }
+
+    #[test]
+    fn test_redacted_never_prints_the_secret() {
+        let secret = Redacted::new("hunter2");
+        assert_eq!(format!("{secret}"), "***");
+        assert_eq!(format!("{secret:?}"), "***");
+        assert_eq!(format!("{:?}", Some(&secret)), "Some(***)");
+        assert_eq!(secret.expose(), "hunter2");
     }
 
     #[test]

--- a/src/core/stream/http_common.rs
+++ b/src/core/stream/http_common.rs
@@ -18,16 +18,21 @@
 //! Configuration and client helpers shared by the HTTP source and sink.
 
 use crate::core::exception::EventFluxError;
-use crate::core::stream::connector_util::{parse_or, parse_prefixed};
+use crate::core::stream::connector_util::{parse_or, parse_prefixed, Redacted};
 use std::collections::HashMap;
 use std::time::Duration;
 
 /// Request headers from `http.headers.<Name>` properties.
 ///
+/// Values are wrapped in [`Redacted`] — headers routinely carry credentials
+/// (`Authorization`, API keys), so a Debug of a config prints names only.
 /// Secrets belong in environment variables:
 /// `"http.headers.Authorization" = 'Bearer ${TOKEN}'`.
-pub fn parse_headers(properties: &HashMap<String, String>) -> Vec<(String, String)> {
+pub fn parse_headers(properties: &HashMap<String, String>) -> Vec<(String, Redacted)> {
     parse_prefixed(properties, "http.headers.")
+        .into_iter()
+        .map(|(name, value)| (name, Redacted::new(value)))
+        .collect()
 }
 
 /// Validate an `http://` or `https://` URL property.
@@ -109,12 +114,12 @@ pub fn parse_method(
 pub fn build_request(
     method: &str,
     url: &str,
-    headers: &[(String, String)],
+    headers: &[(String, Redacted)],
 ) -> ureq::http::request::Builder {
     // ureq re-exports the exact `http` crate version its API expects
     let mut request = ureq::http::Request::builder().method(method).uri(url);
     for (name, value) in headers {
-        request = request.header(name, value);
+        request = request.header(name, value.expose());
     }
     request
 }
@@ -162,7 +167,7 @@ pub fn probe_reachability(
     agent: &ureq::Agent,
     method: &str,
     url: &str,
-    headers: &[(String, String)],
+    headers: &[(String, Redacted)],
 ) -> Result<(), EventFluxError> {
     let request = build_request(method, url, headers).body(()).map_err(|e| {
         EventFluxError::configuration(format!("Failed to build probe request for '{url}': {e}"))

--- a/src/core/stream/input/source/http_source.rs
+++ b/src/core/stream/input/source/http_source.rs
@@ -42,7 +42,7 @@ use crate::core::error::source_support::{
 };
 use crate::core::exception::EventFluxError;
 use crate::core::extension::SourceFactory;
-use crate::core::stream::connector_util::parse_or;
+use crate::core::stream::connector_util::{parse_or, Redacted};
 use crate::core::stream::http_common::{
     build_agent, build_request, constant_time_eq, parse_headers, parse_method, parse_url,
     probe_reachability,
@@ -67,8 +67,8 @@ pub struct HttpPollConfig {
     pub interval_ms: u64,
     /// `GET` (default) or `POST` (some APIs poll via POST)
     pub method: String,
-    /// Request headers from `http.headers.<Name>`
-    pub headers: Vec<(String, String)>,
+    /// Request headers from `http.headers.<Name>` (values redacted in Debug)
+    pub headers: Vec<(String, Redacted)>,
     /// Per-request timeout (default 30000)
     pub timeout_ms: u64,
 }
@@ -82,8 +82,9 @@ pub struct HttpWebhookConfig {
     pub port: u16,
     /// Request path to accept (default "/")
     pub path: String,
-    /// Optional inbound auth: required header name + exact value
-    pub auth: Option<(String, String)>,
+    /// Optional inbound auth: required header name + exact value (the
+    /// token is redacted in Debug output)
+    pub auth: Option<(String, Redacted)>,
     /// Concurrency cap (default 256)
     pub max_concurrent: usize,
     /// Payload size cap in bytes (default 1 MiB); oversized → 413
@@ -150,7 +151,7 @@ impl HttpSourceMode {
                                 "Invalid http.auth.header '{header}': not a valid HTTP header name"
                             ));
                         }
-                        Some((header.clone(), token.clone()))
+                        Some((header.clone(), Redacted::new(token.clone())))
                     }
                     (None, None) => None,
                     _ => {
@@ -205,7 +206,7 @@ type DeliveryJob = (
 
 /// Shared state for concurrent webhook handlers
 struct WebhookState {
-    auth: Option<(String, String)>,
+    auth: Option<(String, Redacted)>,
     /// Payload size cap — enforced while reading the body, after auth
     max_body_bytes: usize,
     /// Bounded queue to the single delivery thread — `send().await`
@@ -232,7 +233,7 @@ async fn webhook_handler(State(state): State<Arc<WebhookState>>, request: Reques
             .headers()
             .get(name.as_str())
             .and_then(|v| v.to_str().ok())
-            .is_some_and(|v| constant_time_eq(v.as_bytes(), token.as_bytes()));
+            .is_some_and(|v| constant_time_eq(v.as_bytes(), token.expose().as_bytes()));
         if !authorized {
             return StatusCode::UNAUTHORIZED;
         }
@@ -696,7 +697,7 @@ mod tests {
         assert_eq!(config.timeout_ms, 2000);
         assert_eq!(
             config.headers,
-            vec![("X-Api-Key".to_string(), "k".to_string())]
+            vec![("X-Api-Key".to_string(), Redacted::new("k"))]
         );
     }
 
@@ -731,10 +732,11 @@ mod tests {
         };
         assert_eq!(config.host, "127.0.0.1");
         assert_eq!(config.path, "/hooks/alerts");
-        assert_eq!(
-            config.auth,
-            Some(("X-Token".to_string(), "secret".to_string()))
-        );
+        let debug = format!("{config:?}");
+        assert!(!debug.contains("secret"), "leaked: {debug}");
+        let (auth_header, auth_token) = config.auth.expect("auth configured");
+        assert_eq!(auth_header, "X-Token");
+        assert_eq!(auth_token.expose(), "secret");
         assert_eq!(config.max_concurrent, 16);
         assert_eq!(config.max_body_bytes, 1024);
     }

--- a/src/core/stream/input/source/rabbitmq_source.rs
+++ b/src/core/stream/input/source/rabbitmq_source.rs
@@ -64,8 +64,9 @@ pub struct RabbitMQSourceConfig {
     pub queue: String,
     /// Username for authentication (default: "guest")
     pub username: String,
-    /// Password for authentication (default: "guest")
-    pub password: String,
+    /// Password for authentication (default: "guest"); redacted in Debug
+    /// output — call `.expose()` at the point of use
+    pub password: crate::core::stream::connector_util::Redacted,
     /// Prefetch count for consumer (default: 10)
     pub prefetch_count: u16,
     /// Consumer tag (auto-generated if not specified)
@@ -86,7 +87,7 @@ impl Default for RabbitMQSourceConfig {
             vhost: "/".to_string(),
             queue: String::new(),
             username: "guest".to_string(),
-            password: "guest".to_string(),
+            password: "guest".into(),
             prefetch_count: 10,
             consumer_tag: None,
             auto_ack: true,
@@ -102,7 +103,11 @@ impl RabbitMQSourceConfig {
         let encoded_vhost = urlencoding::encode(&self.vhost);
         format!(
             "amqp://{}:{}@{}:{}/{}",
-            self.username, self.password, self.host, self.port, encoded_vhost
+            self.username,
+            self.password.expose(),
+            self.host,
+            self.port,
+            encoded_vhost
         )
     }
 
@@ -139,7 +144,7 @@ impl RabbitMQSourceConfig {
         }
 
         if let Some(password) = properties.get("rabbitmq.password") {
-            config.password = password.clone();
+            config.password = password.clone().into();
         }
 
         if let Some(prefetch) = properties.get("rabbitmq.prefetch") {
@@ -947,7 +952,7 @@ mod tests {
         assert_eq!(config.port, 5672);
         assert_eq!(config.vhost, "/");
         assert_eq!(config.username, "guest");
-        assert_eq!(config.password, "guest");
+        assert_eq!(config.password.expose(), "guest");
         assert_eq!(config.prefetch_count, 10);
     }
 
@@ -976,7 +981,10 @@ mod tests {
         assert_eq!(config.port, 5673);
         assert_eq!(config.vhost, "production");
         assert_eq!(config.username, "admin");
-        assert_eq!(config.password, "secret");
+        assert_eq!(config.password.expose(), "secret");
+        let debug = format!("{config:?}");
+        assert!(!debug.contains("secret"), "leaked: {debug}");
+        assert!(debug.contains("***"));
         assert_eq!(config.prefetch_count, 50);
         assert_eq!(config.consumer_tag, Some("my-consumer".to_string()));
         assert!(!config.auto_ack);
@@ -1010,7 +1018,7 @@ mod tests {
             vhost: "/".to_string(),
             queue: "test".to_string(),
             username: "guest".to_string(),
-            password: "guest".to_string(),
+            password: "guest".into(),
             ..Default::default()
         };
 
@@ -1026,7 +1034,7 @@ mod tests {
             vhost: "my-vhost".to_string(),
             queue: "test".to_string(),
             username: "admin".to_string(),
-            password: "secret".to_string(),
+            password: "secret".into(),
             ..Default::default()
         };
 

--- a/src/core/stream/input/source/websocket_source.rs
+++ b/src/core/stream/input/source/websocket_source.rs
@@ -74,7 +74,9 @@ pub struct WebSocketSourceConfig {
     /// Maximum reconnect attempts (-1 = unlimited, default: -1)
     pub reconnect_max_attempts: i32,
     /// Custom headers for connection (e.g., Authorization)
-    pub headers: HashMap<String, String>,
+    /// Custom handshake headers (values redacted in Debug — they may
+    /// carry Authorization tokens)
+    pub headers: HashMap<String, crate::core::stream::connector_util::Redacted>,
     /// WebSocket subprotocol for negotiation
     pub subprotocol: Option<String>,
 }
@@ -147,6 +149,7 @@ impl WebSocketSourceConfig {
         config.headers =
             crate::core::stream::connector_util::parse_prefixed(properties, "websocket.headers.")
                 .into_iter()
+                .map(|(name, value)| (name, value.into()))
                 .collect();
 
         Ok(config)
@@ -190,7 +193,7 @@ impl WebSocketSource {
 
         // Add custom headers
         for (name, value) in &config.headers {
-            request = request.header(name.as_str(), value.as_str());
+            request = request.header(name.as_str(), value.expose());
         }
 
         // Add subprotocol header if configured
@@ -754,12 +757,12 @@ mod tests {
         assert_eq!(config.subprotocol, Some("graphql-ws".to_string()));
         assert_eq!(
             config.headers.get("Authorization"),
-            Some(&"Bearer token123".to_string())
+            Some(&"Bearer token123".into())
         );
-        assert_eq!(
-            config.headers.get("X-Custom"),
-            Some(&"custom-value".to_string())
-        );
+        let debug = format!("{config:?}");
+        assert!(!debug.contains("token123"), "leaked: {debug}");
+        assert!(debug.contains("Authorization"), "names stay visible");
+        assert_eq!(config.headers.get("X-Custom"), Some(&"custom-value".into()));
     }
 
     #[test]

--- a/src/core/stream/kafka_common.rs
+++ b/src/core/stream/kafka_common.rs
@@ -37,7 +37,8 @@ pub struct KafkaConnectionConfig {
     /// `PLAIN`, `SCRAM-SHA-256`, `SCRAM-SHA-512`
     pub sasl_mechanism: Option<String>,
     pub sasl_username: Option<String>,
-    pub sasl_password: Option<String>,
+    /// Redacted in Debug output — call `.expose()` at the point of use
+    pub sasl_password: Option<crate::core::stream::connector_util::Redacted>,
     /// CA certificate path
     pub ssl_ca_location: Option<String>,
     /// Verbatim librdkafka overrides from `kafka.rdkafka.<prop>`
@@ -65,7 +66,9 @@ impl KafkaConnectionConfig {
         let security_protocol = properties.get("kafka.security.protocol").cloned();
         let sasl_mechanism = properties.get("kafka.sasl.mechanism").cloned();
         let sasl_username = properties.get("kafka.sasl.username").cloned();
-        let sasl_password = properties.get("kafka.sasl.password").cloned();
+        let sasl_password = properties
+            .get("kafka.sasl.password")
+            .map(|v| crate::core::stream::connector_util::Redacted::new(v.clone()));
         let ssl_ca_location = properties.get("kafka.ssl.ca.location").cloned();
 
         // SASL credentials only make sense with a SASL security protocol.
@@ -120,7 +123,7 @@ impl KafkaConnectionConfig {
             config.set("sasl.username", v);
         }
         if let Some(v) = &self.sasl_password {
-            config.set("sasl.password", v);
+            config.set("sasl.password", v.expose());
         }
         if let Some(v) = &self.ssl_ca_location {
             config.set("ssl.ca.location", v);
@@ -230,6 +233,22 @@ mod tests {
         props.insert("kafka.sasl.username".to_string(), "user".to_string());
 
         assert!(KafkaConnectionConfig::from_properties(&props, &[]).is_ok());
+    }
+
+    #[test]
+    fn test_debug_never_leaks_the_sasl_password() {
+        let mut props = base_props();
+        props.insert(
+            "kafka.security.protocol".to_string(),
+            "sasl_ssl".to_string(),
+        );
+        props.insert("kafka.sasl.password".to_string(), "hunter2".to_string());
+
+        let config = KafkaConnectionConfig::from_properties(&props, &[]).unwrap();
+        let debug = format!("{config:?}");
+        assert!(!debug.contains("hunter2"), "leaked: {debug}");
+        assert!(debug.contains("***"));
+        assert_eq!(config.sasl_password.unwrap().expose(), "hunter2");
     }
 
     #[test]

--- a/src/core/stream/output/sink/http_sink.rs
+++ b/src/core/stream/output/sink/http_sink.rs
@@ -33,7 +33,7 @@
 use super::sink_trait::Sink;
 use crate::core::exception::EventFluxError;
 use crate::core::extension::SinkFactory;
-use crate::core::stream::connector_util::{parse_or, INJECTED_FORMAT_KEY};
+use crate::core::stream::connector_util::{parse_or, Redacted, INJECTED_FORMAT_KEY};
 use crate::core::stream::http_common::{
     build_agent, build_request, is_retryable_status, parse_headers, parse_method, parse_url,
     probe_reachability, HttpRetryConfig,
@@ -50,8 +50,8 @@ pub struct HttpSinkConfig {
     pub url: String,
     /// `POST` (default), `PUT`, or `PATCH`
     pub method: String,
-    /// Request headers from `http.headers.<Name>`
-    pub headers: Vec<(String, String)>,
+    /// Request headers from `http.headers.<Name>` (values redacted in Debug)
+    pub headers: Vec<(String, Redacted)>,
     /// Content-Type: explicit `http.content.type`, else derived from the
     /// stream format (json/csv/bytes); `None` when a
     /// `http.headers.Content-Type` entry supplies it verbatim instead
@@ -372,8 +372,11 @@ mod tests {
         assert_eq!(config.validation_method, "NONE");
         assert_eq!(
             config.headers,
-            vec![("Authorization".to_string(), "Bearer tok".to_string())]
+            vec![("Authorization".to_string(), Redacted::new("Bearer tok"))]
         );
+        let debug = format!("{config:?}");
+        assert!(!debug.contains("Bearer tok"), "leaked: {debug}");
+        assert!(debug.contains("Authorization"), "names stay visible");
     }
 
     #[test]
@@ -415,7 +418,7 @@ mod tests {
         assert_eq!(config.content_type, None);
         assert_eq!(
             config.headers,
-            vec![("Content-Type".to_string(), "application/xml".to_string())]
+            vec![("Content-Type".to_string(), Redacted::new("application/xml"))]
         );
 
         // Both mechanisms at once is ambiguous — rejected

--- a/src/core/stream/output/sink/rabbitmq_sink.rs
+++ b/src/core/stream/output/sink/rabbitmq_sink.rs
@@ -62,8 +62,9 @@ pub struct RabbitMQSinkConfig {
     pub routing_key: String,
     /// Username for authentication (default: "guest")
     pub username: String,
-    /// Password for authentication (default: "guest")
-    pub password: String,
+    /// Password for authentication (default: "guest"); redacted in Debug
+    /// output — call `.expose()` at the point of use
+    pub password: crate::core::stream::connector_util::Redacted,
     /// Whether messages should be persistent (default: true)
     pub persistent: bool,
     /// Content type header for messages (default: "application/octet-stream")
@@ -86,7 +87,7 @@ impl Default for RabbitMQSinkConfig {
             exchange: String::new(),
             routing_key: String::new(),
             username: "guest".to_string(),
-            password: "guest".to_string(),
+            password: "guest".into(),
             persistent: true,
             content_type: None,
             declare_exchange: false,
@@ -103,7 +104,11 @@ impl RabbitMQSinkConfig {
         let encoded_vhost = urlencoding::encode(&self.vhost);
         format!(
             "amqp://{}:{}@{}:{}/{}",
-            self.username, self.password, self.host, self.port, encoded_vhost
+            self.username,
+            self.password.expose(),
+            self.host,
+            self.port,
+            encoded_vhost
         )
     }
 
@@ -140,7 +145,7 @@ impl RabbitMQSinkConfig {
         }
 
         if let Some(password) = properties.get("rabbitmq.password") {
-            config.password = password.clone();
+            config.password = password.clone().into();
         }
 
         if let Some(routing_key) = properties.get("rabbitmq.routing.key") {
@@ -743,7 +748,7 @@ mod tests {
         assert_eq!(config.port, 5673);
         assert_eq!(config.vhost, "production");
         assert_eq!(config.username, "admin");
-        assert_eq!(config.password, "secret");
+        assert_eq!(config.password.expose(), "secret");
         assert_eq!(config.routing_key, "mykey");
         assert!(!config.persistent);
         assert_eq!(config.content_type, Some("application/json".to_string()));
@@ -779,7 +784,7 @@ mod tests {
             vhost: "/".to_string(),
             exchange: "test".to_string(),
             username: "guest".to_string(),
-            password: "guest".to_string(),
+            password: "guest".into(),
             ..Default::default()
         };
 
@@ -795,7 +800,7 @@ mod tests {
             vhost: "my-vhost".to_string(),
             exchange: "test".to_string(),
             username: "admin".to_string(),
-            password: "secret".to_string(),
+            password: "secret".into(),
             ..Default::default()
         };
 

--- a/src/core/stream/output/sink/websocket_sink.rs
+++ b/src/core/stream/output/sink/websocket_sink.rs
@@ -97,7 +97,9 @@ pub struct WebSocketSinkConfig {
     /// Message type: text or binary (default: text)
     pub message_type: MessageType,
     /// Custom headers for connection (e.g., Authorization)
-    pub headers: HashMap<String, String>,
+    /// Custom handshake headers (values redacted in Debug — they may
+    /// carry Authorization tokens)
+    pub headers: HashMap<String, crate::core::stream::connector_util::Redacted>,
     /// WebSocket subprotocol for negotiation
     pub subprotocol: Option<String>,
 }
@@ -175,6 +177,7 @@ impl WebSocketSinkConfig {
         config.headers =
             crate::core::stream::connector_util::parse_prefixed(properties, "websocket.headers.")
                 .into_iter()
+                .map(|(name, value)| (name, value.into()))
                 .collect();
 
         Ok(config)
@@ -232,7 +235,7 @@ impl WebSocketSink {
 
         // Add custom headers
         for (name, value) in &config.headers {
-            request = request.header(name.as_str(), value.as_str());
+            request = request.header(name.as_str(), value.expose());
         }
 
         // Add subprotocol header if configured
@@ -706,7 +709,7 @@ mod tests {
         assert_eq!(config.subprotocol, Some("graphql-ws".to_string()));
         assert_eq!(
             config.headers.get("Authorization"),
-            Some(&"Bearer token".to_string())
+            Some(&"Bearer token".into())
         );
     }
 


### PR DESCRIPTION
Closes #143.

Connector config structs derived `Debug` over raw secrets, so any `{:?}` — a future log line, an error context, a debugger dump — would print SASL passwords, AMQP passwords, webhook tokens, and `Authorization` headers in plaintext. No current log site printed them (verified during the audit that filed #143), so the exposure was latent; this closes it structurally rather than by auditing log sites forever.

## Mechanism

New `connector_util::Redacted` newtype: `Debug`/`Display` always print `***`; the raw value must be requested explicitly via `.expose()` at the point of use (connection building, header injection). Leaking now requires writing `.expose()` into a format string — visible in review — instead of being the silent default.

## Adopted by

| Secret | Field |
|--------|-------|
| Kafka SASL password | `KafkaConnectionConfig.sasl_password` |
| RabbitMQ password | source + sink `password` (the AMQP URI builder calls `.expose()`; verified the URI never reaches a log line) |
| HTTP webhook token | `HttpWebhookConfig.auth` (+ `WebhookState`) |
| HTTP header values | poll/sink `headers` — headers routinely carry `Authorization`/API keys, so values redact wholesale; names stay visible |
| WebSocket header values | source + sink handshake `headers` |

File connector has no secrets; nothing to adopt.

## Tests

Leak-guard tests per adopting config assert `format!("{:?}", config)` contains `***` and not the secret (and that header *names* stay visible for diagnosability), plus unit tests on `Redacted` itself. Full suite green: 3179 (`connectors-all`) / 2983 (minimal), clippy `-D warnings` clean on both configs.